### PR TITLE
clusters-menu links prefer using cluster alias

### DIFF
--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -893,10 +893,10 @@ $(document).ready(function() {
   $.get(appUrl("/api/clusters-info"), function(clusters) {
     clusters.forEach(function(cluster) {
       var url = appUrl('/web/cluster/' + cluster.ClusterName)
-      var title = '<span class="small">' + cluster.ClusterName + '</span>';
+      var title = cluster.ClusterName;
       if ((cluster.ClusterAlias != "") && (cluster.ClusterAlias != cluster.ClusterName)) {
         url = appUrl('/web/cluster/alias/' + encodeURIComponent(cluster.ClusterAlias));
-        title = '<strong>' + cluster.ClusterAlias + '</strong>, ' + title;
+        title = '<strong>' + cluster.ClusterAlias + '</strong>, <span class="small">' + title + '</span>';;
       }
       $("#dropdown-clusters").append('<li><a href="' + url + '">' + title + '</a></li>');
     });

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -892,9 +892,13 @@ $(document).ready(function() {
 
   $.get(appUrl("/api/clusters-info"), function(clusters) {
     clusters.forEach(function(cluster) {
+      var url = appUrl('/web/cluster/' + cluster.ClusterName)
       var title = '<span class="small">' + cluster.ClusterName + '</span>';
-      title = ((cluster.ClusterAlias != "") ? '<strong>' + cluster.ClusterAlias + '</strong>, ' + title : title);
-      $("#dropdown-clusters").append('<li><a href="' + appUrl('/web/cluster/' + cluster.ClusterName) + '">' + title + '</a></li>');
+      if ((cluster.ClusterAlias != "") && (cluster.ClusterName != "")) {
+        url = appUrl('/web/cluster/alias/' + encodeURIComponent(cluster.ClusterAlias));
+        title = '<strong>' + cluster.ClusterAlias + '</strong>, ' + title;
+      }
+      $("#dropdown-clusters").append('<li><a href="' + url + '">' + title + '</a></li>');
     });
     onClustersListeners.forEach(function(func) {
       func(clusters);

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -894,7 +894,7 @@ $(document).ready(function() {
     clusters.forEach(function(cluster) {
       var url = appUrl('/web/cluster/' + cluster.ClusterName)
       var title = '<span class="small">' + cluster.ClusterName + '</span>';
-      if ((cluster.ClusterAlias != "") && (cluster.ClusterName != "")) {
+      if ((cluster.ClusterAlias != "") && (cluster.ClusterAlias != cluster.ClusterName)) {
         url = appUrl('/web/cluster/alias/' + encodeURIComponent(cluster.ClusterAlias));
         title = '<strong>' + cluster.ClusterAlias + '</strong>, ' + title;
       }


### PR DESCRIPTION
Also, avoiding having both alias and cluster name when no alias exists (i.e alias _is_ the cluster name)

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`

