### PR TITLE
supporting show-resolve-hosts, show-unresolve-hosts

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1363,6 +1363,26 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			jsonString := config.Config.ToJSONString()
 			fmt.Println(jsonString)
 		}
+	case registerCliCommand("show-resolve-hosts", "Meta", `Show the content of the hostname_resolve table. Generally used for debugging`):
+		{
+			resolves, err := inst.ReadAllHostnameResolves()
+			if err != nil {
+				log.Fatale(err)
+			}
+			for _, r := range resolves {
+				fmt.Println(fmt.Sprintf("%+v", r))
+			}
+		}
+	case registerCliCommand("show-unresolve-hosts", "Meta", `Show the content of the hostname_unresolve table. Generally used for debugging`):
+		{
+			unresolves, err := inst.ReadAllHostnameUnresolves()
+			if err != nil {
+				log.Fatale(err)
+			}
+			for _, r := range unresolves {
+				fmt.Println(fmt.Sprintf("%+v", r))
+			}
+		}
 	case registerCliCommand("redeploy-internal-db", "Meta, internal", `Force internal schema migration to current backend structure`):
 		{
 			config.RuntimeCLIFlags.ConfiguredVersion = ""

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1370,7 +1370,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			}
 			for _, r := range resolves {
-				fmt.Println(fmt.Sprintf("%v", r))
+				fmt.Println(r)
 			}
 		}
 	case registerCliCommand("show-unresolve-hosts", "Meta", `Show the content of the hostname_unresolve table. Generally used for debugging`):
@@ -1380,7 +1380,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			}
 			for _, r := range unresolves {
-				fmt.Println(fmt.Sprintf("%v", r))
+				fmt.Println(r)
 			}
 		}
 	case registerCliCommand("redeploy-internal-db", "Meta, internal", `Force internal schema migration to current backend structure`):

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1370,7 +1370,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			}
 			for _, r := range resolves {
-				fmt.Println(fmt.Sprintf("%+v", r))
+				fmt.Println(fmt.Sprintf("%v", r))
 			}
 		}
 	case registerCliCommand("show-unresolve-hosts", "Meta", `Show the content of the hostname_unresolve table. Generally used for debugging`):
@@ -1380,7 +1380,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			}
 			for _, r := range unresolves {
-				fmt.Println(fmt.Sprintf("%+v", r))
+				fmt.Println(fmt.Sprintf("%v", r))
 			}
 		}
 	case registerCliCommand("redeploy-internal-db", "Meta, internal", `Force internal schema migration to current backend structure`):

--- a/go/inst/resolve.go
+++ b/go/inst/resolve.go
@@ -33,7 +33,7 @@ type HostnameResolve struct {
 	resolvedHostname string
 }
 
-func (this *HostnameResolve) String() string {
+func (this HostnameResolve) String() string {
 	return fmt.Sprintf("%s %s", this.hostname, this.resolvedHostname)
 }
 
@@ -42,7 +42,7 @@ type HostnameUnresolve struct {
 	unresolvedHostname string
 }
 
-func (this *HostnameUnresolve) String() string {
+func (this HostnameUnresolve) String() string {
 	return fmt.Sprintf("%s %s", this.hostname, this.unresolvedHostname)
 }
 

--- a/go/inst/resolve.go
+++ b/go/inst/resolve.go
@@ -33,6 +33,19 @@ type HostnameResolve struct {
 	resolvedHostname string
 }
 
+func (this *HostnameResolve) String() string {
+	return fmt.Sprintf("%s %s", this.hostname, this.resolvedHostname)
+}
+
+type HostnameUnresolve struct {
+	hostname           string
+	unresolvedHostname string
+}
+
+func (this *HostnameUnresolve) String() string {
+	return fmt.Sprintf("%s %s", this.hostname, this.unresolvedHostname)
+}
+
 func init() {
 	if config.Config.ExpiryHostnameResolvesMinutes < 1 {
 		config.Config.ExpiryHostnameResolvesMinutes = 1
@@ -150,7 +163,7 @@ func LoadHostnameResolveCache() error {
 }
 
 func loadHostnameResolveCacheFromDatabase() error {
-	allHostnamesResolves, err := readAllHostnameResolves()
+	allHostnamesResolves, err := ReadAllHostnameResolves()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resubmission of https://github.com/outbrain/orchestrator/pull/301 by @sjmudd

`-c show-resolve-hosts`, `-c show-unresolve-hosts` are Meta commands to list down known hostname resolves/unresolves