### PR TITLE
Update license doc to say Apache License 2.0

### DIFF
--- a/docs/contributions.md
+++ b/docs/contributions.md
@@ -1,4 +1,4 @@
 # Contributions
 
 Yes, please. All contributions must be licensed under the
-[MIT license](license.md) or compatible.
+[Apache License 2.0](license.md) or compatible.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -69,7 +69,7 @@ No.
 
 ### Is orchestrator open source?
 
-Yes. `Orchestrator` is released as open source under the MIT license and is available at: https://github.com/github/orchestrator
+Yes. `Orchestrator` is released as open source under the Apache License 2.0 and is available at: https://github.com/github/orchestrator
 
 ### Who develops orchestrator and why?
 


### PR DESCRIPTION
Minor documentation updates to have documentation match [LICENSE](https://github.com/github/orchestrator/blob/master/LICENSE)