### PR TITLE
Added Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+.cache
+Dockerfile
+README.md
+Vagrantfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .github
 .cache
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex \
     && apk add --no-cache --virtual .build-deps \
         bash \
         rsync \
+        git \
     && bash build.sh -b \
     && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator -maxdepth 2)/ / \
     && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator-cli -maxdepth 2)/ / \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.6-alpine
+
+EXPOSE  3000
+
+ADD . /go/src/github.com/github/orchestrator
+WORKDIR /go/src/github.com/github/orchestrator
+
+RUN set -ex \
+    && apk add --no-cache --virtual .build-deps \
+        bash \
+        rsync \
+    && bash build.sh -b \
+    && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator -maxdepth 2)/ / \
+    && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator-cli -maxdepth 2)/ / \
+    && apk del .build-deps \
+    && rm -rf /tmp/orchestrator-release \
+    && cp ./docker/entrypoint.sh /entrypoint.sh
+
+CMD /entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,7 @@ if [ ! -e /etc/orchestrator.conf.json ] ; then
 cat <<EOF > /etc/orchestrator.conf.json
 {
   "Debug": true,
-  "ListenAddress": "${ORC_ADDRESS:-:3000}",
+  "ListenAddress": ":3000",
   "MySQLTopologyUser": "${ORC_TOPOLOGY_USER:-:orchestrator}",
   "MySQLTopologyPassword": "${ORC_TOPOLOGY_PASSOWRD:-:orchestrator}",
   "MySQLOrchestratorHost": "${ORC_DB_HOST:-db}",

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+if [ ! -e /etc/orchestrator.conf.json ] ; then
+cat <<EOF > /etc/orchestrator.conf.json
+{
+  "Debug": true,
+  "ListenAddress": "${ORC_ADDRESS:-:3000}",
+  "MySQLTopologyUser": "${ORC_TOPOLOGY_USER:-:orchestrator}",
+  "MySQLTopologyPassword": "${ORC_TOPOLOGY_PASSOWRD:-:orchestrator}",
+  "MySQLOrchestratorHost": "${ORC_DB_HOST:-db}",
+  "MySQLOrchestratorPort": ${ORC_DB_PORT:-3306},
+  "MySQLOrchestratorDatabase": "${ORC_DB_NAME:-orchestrator}",
+  "MySQLOrchestratorUser": "${ORC_USER:-orc_server_user}",
+  "MySQLOrchestratorPassword": "${ORC_PASSWORD:-orc_server_password}"
+}
+EOF
+fi
+
+exec /usr/local/orchestrator/orchestrator http

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,25 @@
+# Docker
+
+## Building the docker image
+```
+docker build -t orchestrator:latest .
+```
+
+## Running the docker image
+The docker images exposes orcestrator on port 3000.
+
+```
+docker run -p 3000:3000 orchestrator
+```
+
+The folowing environment variables are available and take effect if no config
+file si bind mounted into container at `/etc/orchestrator.conf.json`
+
+* `ORC_ADDRESS`: set the `ListenAddress`, defaults to `:3000`
+* `ORC_TOPOLOGY_USER`: defaults to `orcestrator`
+* `ORC_TOPOLOGY_PASSOWRD`: defaults to `orchestrator`
+* `ORC_DB_HOST`: defaults to `db`
+* `ORC_DB_PORT`: defaults to `3306`
+* `ORC_DB_NAME`: defaults to `orchestrator`
+* `ORC_USER`: defaulsts to `orc_server_user`
+* `ORC_PASSWORD`: defaults to `orc_server_password`

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -15,7 +15,6 @@ docker run -p 3000:3000 orchestrator
 The folowing environment variables are available and take effect if no config
 file si bind mounted into container at `/etc/orchestrator.conf.json`
 
-* `ORC_ADDRESS`: set the `ListenAddress`, defaults to `:3000`
 * `ORC_TOPOLOGY_USER`: defaults to `orcestrator`
 * `ORC_TOPOLOGY_PASSOWRD`: defaults to `orchestrator`
 * `ORC_DB_HOST`: defaults to `db`


### PR DESCRIPTION
This PR adds docker support for orchestrator. It builds and installs
orchestrator in `/usr/local/orchestrator` and `orchestrator-cli` in
`/usr/bin/orchestrator`.

The images executes by default the orchestrator server.

It also exposes port 3000.