### PR TITLE
Show the count and not the list of server if the number being polled …

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -345,7 +345,7 @@ func newConfiguration() *Configuration {
 		GraphiteConvertHostnameDotsToUnderscores:     true,
 		GraphitePollSeconds:                          60,
 		URLPrefix:                                    "",
-		MaxOutdatedKeysToShow:                        10,
+		MaxOutdatedKeysToShow:                        64,
 	}
 }
 

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -191,6 +191,7 @@ type Configuration struct {
 	GraphiteConvertHostnameDotsToUnderscores     bool              // If true, then hostname's dots are converted to underscores before being used in graphite path
 	GraphitePollSeconds                          int               // Graphite writes interval. 0 disables.
 	URLPrefix                                    string            // URL prefix to run orchestrator on non-root web path, e.g. /orchestrator to put it behind nginx.
+	MaxOutdatedKeysToShow                        int               // Maximum number of keys to show in ContinousDiscovery. If the number of polled hosts grows too far then showing the complete list is not ideal.
 }
 
 // ToJSONString will marshal this configuration as JSON
@@ -344,6 +345,7 @@ func newConfiguration() *Configuration {
 		GraphiteConvertHostnameDotsToUnderscores:     true,
 		GraphitePollSeconds:                          60,
 		URLPrefix:                                    "",
+		MaxOutdatedKeysToShow:                        10,
 	}
 }
 

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -222,7 +222,11 @@ func ContinuousDiscovery() {
 						log.Errore(err)
 					}
 
-					log.Debugf("outdated keys: %+v", instanceKeys)
+					if len(instanceKeys) > config.Config.MaxOutdatedKeysToShow {
+						log.Debugf("polling %d outdated keys", len(instanceKeys))
+					} else {
+						log.Debugf("outdated keys: %+v", instanceKeys)
+					}
 					for _, instanceKey := range instanceKeys {
 						instanceKey := instanceKey
 


### PR DESCRIPTION
…is over MaxOutdatedKeysToShow (default: 10)

### Issue

This change is to prevent the logging of all the outdated keys (better term would be _polled hosts_ or _polled instances_) when the number grows over a certain threshold. When a large number of servers are being polled this list just gets to big and intrusive.

I have been using a variation of this code on my own patched code for some time. It was not configurable in my case. This allows for the current behaviour by default for small environments, and changes to use my preferred output if the number of monitored servers goes over the configured limit.

### Description

Add a new config setting: MaxOutdatedKeysToShow, default 10, which if exceeded will adjust the logging to just show: `polling NNN outdated keys` rather than `outdated keys: [ host1:12345, host2:12345, ... hostn:12345 ]`

