### PR TITLE
-c clusters-alias to show cluster name & alias

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -940,8 +940,17 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			clusters, err := inst.ReadClusters()
 			if err != nil {
 				log.Fatale(err)
-			} else {
-				fmt.Println(strings.Join(clusters, "\n"))
+			}
+			fmt.Println(strings.Join(clusters, "\n"))
+		}
+	case registerCliCommand("clusters-alias", "Information", `List all clusters known to orchestrator`):
+		{
+			clusters, err := inst.ReadClustersInfo("")
+			if err != nil {
+				log.Fatale(err)
+			}
+			for _, cluster := range clusters {
+				fmt.Println(fmt.Sprintf("%s\t%s", cluster.ClusterName, cluster.ClusterAlias))
 			}
 		}
 	case registerCliCommand("all-clusters-masters", "Information", `List of writeable masters, one per cluster`):

--- a/tests/integration/clusters-alias/expect_output
+++ b/tests/integration/clusters-alias/expect_output
@@ -1,0 +1,1 @@
+testhost:22293  testhost:22293

--- a/tests/integration/clusters-alias/extra_args
+++ b/tests/integration/clusters-alias/extra_args
@@ -1,0 +1,1 @@
+-c clusters-alias

--- a/tests/integration/test.sh
+++ b/tests/integration/test.sh
@@ -95,7 +95,7 @@ test_single() {
   fi
 
   if [ -f $tests_path/$test_name/expect_output ] ; then
-    diff $tests_path/$test_name/expect_output $test_outfile > $test_diff_file
+    diff -b $tests_path/$test_name/expect_output $test_outfile > $test_diff_file
     diff_result=$?
     if [ $diff_result -ne 0 ] ; then
       echo


### PR DESCRIPTION
Storyline: https://github.com/github/orchestrator/issues/18

The new CLI command `clusters-alias` presents cluster name & info, tab separated: 

```shell
$ orchestrator -c clusters-alias 
some.cluster1.master.com	mycluster1
some.cluster2.master.com	mycluster2
```

compare to `-c clusters` which only shows the first column (cluster name)

cc @tomkrouper 