### PR TITLE
Add orchestrator version and git commit to startup message (if available)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@
 #
 set -e
 
+GIT_COMMIT=$(git rev-parse HEAD)
 RELEASE_VERSION=
 RELEASE_SUBVERSION=
 TOPDIR=/tmp/orchestrator-release
@@ -96,7 +97,7 @@ function package() {
 
   cd $TOPDIR
 
-  echo "Release version is ${RELEASE_VERSION}"
+  echo "Release version is ${RELEASE_VERSION} ( ${GIT_COMMIT} )"
 
   case $target in
     'linux')
@@ -131,7 +132,7 @@ function build() {
   arch="$2"
   builddir="$3"
   prefix="$4"
-  ldflags="-X main.AppVersion=${RELEASE_VERSION}"
+  ldflags="-X main.AppVersion=${RELEASE_VERSION} -X main.GitCommit=${GIT_COMMIT}"
   echo "Building via $(go version)"
   gobuild="go build ${opt_race} -ldflags \"$ldflags\" -o $builddir/orchestrator${prefix}/orchestrator/orchestrator go/cmd/orchestrator/main.go"
 

--- a/go/cmd/orchestrator/main.go
+++ b/go/cmd/orchestrator/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/outbrain/golib/math"
 )
 
-var AppVersion string
+var AppVersion, GitCommit string
 
 // main is the application's entry point. It will either spawn a CLI or HTTP itnerfaces.
 func main() {
@@ -89,12 +89,20 @@ func main() {
 	if *stack {
 		log.SetPrintStackTrace(*stack)
 	}
-	log.Info("starting orchestrator") // FIXME and add the version which is currently in build.sh
-
 	if *config.RuntimeCLIFlags.Version {
 		fmt.Println(AppVersion)
+		fmt.Println(GitCommit)
 		return
 	}
+
+	startText := "starting orchestrator"
+	if AppVersion != "" {
+		startText += ", version: " + AppVersion
+	}
+	if GitCommit != "" {
+		startText += ", git commit: " + GitCommit
+	}
+	log.Info(startText)
 
 	runtime.GOMAXPROCS(math.MinInt(4, runtime.NumCPU()))
 


### PR DESCRIPTION
On startup orchestrator does not tell you it's version in the logging. That's not good if you frequently upgrade the server as you may not be sure which version of the binaries you are running.

This patch shows the "release version" but also "git commit" if that information is provided. The build.sh script adds it automatically.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
