### PR TITLE
Fix build.sh which would not run correctly if run from a different directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@
 #
 set -e
 
+mydir=$(dirname $0)
 RELEASE_VERSION=
 RELEASE_SUBVERSION=
 TOPDIR=/tmp/orchestrator-release
@@ -80,7 +81,7 @@ function oinstall() {
   builddir="$1"
   prefix="$2"
 
-  cd  $(dirname $0)
+  cd  $mydir
   gofmt -s -w  go/
   rsync -qa ./resources $builddir/orchestrator${prefix}/orchestrator/
   rsync -qa ./conf/orchestrator-sample.* $builddir/orchestrator${prefix}/orchestrator/
@@ -155,7 +156,7 @@ function main() {
   build_only=$4
 
   if [ -z "${RELEASE_VERSION}" ] ; then
-    RELEASE_VERSION=$(cat RELEASE_VERSION)
+    RELEASE_VERSION=$(cat $mydir/RELEASE_VERSION)
   fi
   RELEASE_VERSION="${RELEASE_VERSION}${RELEASE_SUBVERSION}"
 


### PR DESCRIPTION
If you run `build.sh` from a different directory it may not work correctly.

e.g. `cd go/discovery && ../../build.sh -b` gave an error due to `RELEASE_VERSION` not being found.

Now this works:

```
[myuser@myhost ~/src/orchestrator/src/github.com/github/orchestrator/go/discovery]$ export GOPATH=~/src/orchestrator
[myuser@myhost ~/src/orchestrator/src/github.com/github/orchestrator/go/discovery]$ ../../build.sh -b
Build only; no packaging
Building via go version go1.7 darwin/amd64
orchestrator binary created
binary copied to orchestrator-cli
orchestrator build done; exit status is 0
[myuser@myhost ~/src/orchestrator/src/github.com/github/orchestrator/go/discovery]$ 
```
