### PR TITLE
cluster_alias_override: manual setting of alias, persisting

### DIFF
--- a/go/db/db.go
+++ b/go/db/db.go
@@ -504,6 +504,13 @@ var generateSQLBase = []string{
 		  PRIMARY KEY (disable_recovery)
 		) ENGINE=InnoDB DEFAULT CHARSET=ascii
 	`,
+	`
+		CREATE TABLE IF NOT EXISTS cluster_alias_override (
+		  cluster_name varchar(128) CHARACTER SET ascii NOT NULL,
+		  alias varchar(128) NOT NULL,
+		  PRIMARY KEY (cluster_name)
+		) ENGINE=InnoDB DEFAULT CHARSET=ascii
+	`,
 }
 
 // generateSQLPatches contains DDLs for patching schema to the latest version.

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1288,7 +1288,7 @@ func (this *HttpAPI) ClusterOSCReplicas(params martini.Params, r render.Render, 
 }
 
 // SetClusterAlias will change an alias for a given clustername
-func (this *HttpAPI) SetClusterAlias(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+func (this *HttpAPI) SetClusterAliasManualOverride(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
@@ -1296,7 +1296,7 @@ func (this *HttpAPI) SetClusterAlias(params martini.Params, r render.Render, req
 	clusterName := params["clusterName"]
 	alias := req.URL.Query().Get("alias")
 
-	err := inst.SetClusterAlias(clusterName, alias)
+	err := inst.SetClusterAliasManualOverride(clusterName, alias)
 	if err != nil {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return
@@ -2400,7 +2400,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerRequest(m, "cluster-info/:clusterName", this.ClusterInfo)
 	this.registerRequest(m, "cluster-info/alias/:clusterAlias", this.ClusterInfoByAlias)
 	this.registerRequest(m, "cluster-osc-slaves/:clusterName", this.ClusterOSCReplicas)
-	this.registerRequest(m, "set-cluster-alias/:clusterName", this.SetClusterAlias)
+	this.registerRequest(m, "set-cluster-alias/:clusterName", this.SetClusterAliasManualOverride)
 	this.registerRequest(m, "clusters", this.Clusters)
 	this.registerRequest(m, "clusters-info", this.ClustersInfo)
 

--- a/go/inst/cluster_alias.go
+++ b/go/inst/cluster_alias.go
@@ -21,6 +21,11 @@ func SetClusterAlias(clusterName string, alias string) error {
 	return WriteClusterAlias(clusterName, alias)
 }
 
+// SetClusterAliasManualOverride will write (and override) a single cluster name mapping
+func SetClusterAliasManualOverride(clusterName string, alias string) error {
+	return WriteClusterAliasManualOverride(clusterName, alias)
+}
+
 // GetClusterByAlias returns the cluster name associated with given alias.
 // The function returns with error when:
 // - No cluster is associated with the alias


### PR DESCRIPTION
Storyline: https://github.com/github/orchestrator/issues/23

This supports a manual override for cluster-alias, from web or from elsewhere. Such override (per cluster) is stronger than `ClusterAliasQuery`.

The web interface for setting cluster-alias benefits from this PR.

The change persists in a new, `cluster_alias_override` table, which is checked when reading a topology instance.