### PR TITLE
correlating relay logs

### DIFF
--- a/go/agent/agent_dao.go
+++ b/go/agent/agent_dao.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/github/orchestrator/go/config"
@@ -39,6 +40,7 @@ type httpMethodFunc func(uri string) (resp *http.Response, err error)
 var SeededAgents chan *Agent = make(chan *Agent)
 
 var httpClient *http.Client
+var httpClientMutex = &sync.Mutex{}
 
 // InitHttpClient gets called once, and initializes httpClient according to config.Config
 func InitHttpClient() {

--- a/go/agent/agent_dao.go
+++ b/go/agent/agent_dao.go
@@ -34,6 +34,8 @@ import (
 	"github.com/outbrain/golib/sqlutils"
 )
 
+type httpMethodFunc func(uri string) (resp *http.Response, err error)
+
 var SeededAgents chan *Agent = make(chan *Agent)
 
 var httpClient *http.Client
@@ -59,6 +61,11 @@ func InitHttpClient() {
 // httpGet is a convenience method for getting http response from URL, optionaly skipping SSL cert verification
 func httpGet(url string) (resp *http.Response, err error) {
 	return httpClient.Get(url)
+}
+
+// httpPost is a convenience method for posting text data
+func httpPost(url string, bodyType string, content string) (resp *http.Response, err error) {
+	return httpClient.Post(url, bodyType, strings.NewReader(content))
 }
 
 // AuditAgentOperation creates and writes a new audit entry by given agent
@@ -393,8 +400,9 @@ func GetAgent(hostname string) (Agent, error) {
 	return agent, err
 }
 
-// executeAgentCommand requests an agent to execute a command via HTTP api
-func executeAgentCommand(hostname string, command string, onResponse *func([]byte)) (Agent, error) {
+// executeAgentCommandWithMethodFunc requests an agent to execute a command via HTTP api, either GET or POST,
+// with specific http method implementation by the caller
+func executeAgentCommandWithMethodFunc(hostname string, command string, methodFunc httpMethodFunc, onResponse *func([]byte)) (Agent, error) {
 	agent, token, err := readAgentBasicInfo(hostname)
 	if err != nil {
 		return agent, err
@@ -412,7 +420,7 @@ func executeAgentCommand(hostname string, command string, onResponse *func([]byt
 	log.Debugf("orchestrator-agent command: %s", fullCommand)
 	agentCommandUri := fmt.Sprintf("%s/%s", uri, fullCommand)
 
-	body, err := readResponse(httpGet(agentCommandUri))
+	body, err := readResponse(methodFunc(agentCommandUri))
 	if err != nil {
 		return agent, log.Errore(err)
 	}
@@ -422,6 +430,22 @@ func executeAgentCommand(hostname string, command string, onResponse *func([]byt
 	auditAgentOperation("agent-command", &agent, command)
 
 	return agent, err
+}
+
+// executeAgentCommand requests an agent to execute a command via HTTP api
+func executeAgentCommand(hostname string, command string, onResponse *func([]byte)) (Agent, error) {
+	httpFunc := func(uri string) (resp *http.Response, err error) {
+		return httpGet(uri)
+	}
+	return executeAgentCommandWithMethodFunc(hostname, command, httpFunc, onResponse)
+}
+
+// executeAgentPostCommand requests an agent to execute a command via HTTP POST
+func executeAgentPostCommand(hostname string, command string, content string, onResponse *func([]byte)) (Agent, error) {
+	httpFunc := func(uri string) (resp *http.Response, err error) {
+		return httpPost(uri, "text/plain", content)
+	}
+	return executeAgentCommandWithMethodFunc(hostname, command, httpFunc, onResponse)
 }
 
 // Unmount unmounts the designated snapshot mount point
@@ -902,4 +926,12 @@ func ReadSeedStates(seedId int64) ([]SeedOperationState, error) {
 		log.Errore(err)
 	}
 	return res, err
+}
+
+func RelaylogContentsTail(hostname string, startCoordinates *inst.BinlogCoordinates, onResponse *func([]byte)) (Agent, error) {
+	return executeAgentCommand(hostname, fmt.Sprintf("mysql-relaylog-contents-tail/%s/%d", startCoordinates.LogFile, startCoordinates.LogPos), onResponse)
+}
+
+func ApplyRelaylogContents(hostname string, content string) (Agent, error) {
+	return executeAgentPostCommand(hostname, "apply-relaylog-contents", content, nil)
 }

--- a/go/agent/agent_dao.go
+++ b/go/agent/agent_dao.go
@@ -44,6 +44,9 @@ var httpClientMutex = &sync.Mutex{}
 
 // InitHttpClient gets called once, and initializes httpClient according to config.Config
 func InitHttpClient() {
+	httpClientMutex.Lock()
+	defer httpClientMutex.Unlock()
+
 	if httpClient != nil {
 		return
 	}

--- a/go/agent/instance_topology_agent.go
+++ b/go/agent/instance_topology_agent.go
@@ -62,6 +62,11 @@ func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.
 	}
 	log.Debugf("AlignViaRelaylogCorrelation: applied content (%d bytes)", len(content))
 
+	instance, err = inst.ChangeMasterTo(&instance.Key, &otherInstance.MasterKey, &otherInstance.ExecBinlogCoordinates, false, inst.GTIDHintNeutral)
+	if err != nil {
+		goto Cleanup
+	}
+
 Cleanup:
 	if err != nil {
 		return instance, log.Errore(err)

--- a/go/agent/instance_topology_agent.go
+++ b/go/agent/instance_topology_agent.go
@@ -17,6 +17,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/github/orchestrator/go/inst"
@@ -29,7 +30,7 @@ func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.
 	var nextCoordinates *inst.BinlogCoordinates
 	var content string
 	onResponse := func(contentBytes []byte) {
-		content = string(contentBytes)
+		json.Unmarshal(contentBytes, &content)
 	}
 	log.Debugf("AlignViaRelaylogCorrelation: stopping replication")
 

--- a/go/agent/instance_topology_agent.go
+++ b/go/agent/instance_topology_agent.go
@@ -50,6 +50,7 @@ func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.
 	}
 	log.Debugf("AlignViaRelaylogCorrelation: correlated next-coordinates are %+v", *nextCoordinates)
 
+	InitHttpClient()
 	if _, err := RelaylogContentsTail(otherInstance.Key.Hostname, nextCoordinates, &onResponse); err != nil {
 		goto Cleanup
 	}

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -834,7 +834,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if instance == nil {
 				log.Fatalf("Instance not found: %+v", *instanceKey)
 			}
-			coordinates, text, err := inst.FindLastPseudoGTIDEntry(instance, instance.RelaylogCoordinates, nil, strict, nil, *config.RuntimeCLIFlags.SkipBinlogSearch)
+			coordinates, text, err := inst.FindLastPseudoGTIDEntry(instance, instance.RelaylogCoordinates, nil, strict, nil)
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -834,7 +834,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if instance == nil {
 				log.Fatalf("Instance not found: %+v", *instanceKey)
 			}
-			coordinates, text, err := inst.FindLastPseudoGTIDEntry(instance, instance.RelaylogCoordinates, nil, strict, nil)
+			coordinates, text, err := inst.FindLastPseudoGTIDEntry(instance, instance.RelaylogCoordinates, nil, strict, nil, *config.RuntimeCLIFlags.SkipBinlogSearch)
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -614,7 +614,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatalf("Instance not found: %+v", *destinationKey)
 			}
 
-			err := inst.AlignViaRelaylogCorrelation(instance, otherInstance)
+			_, err = agent.AlignViaRelaylogCorrelation(instance, otherInstance)
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -614,11 +614,11 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatalf("Instance not found: %+v", *destinationKey)
 			}
 
-			instanceCoordinates, correlatedCoordinates, nextCoordinates, _, err := inst.CorrelateRelaylogCoordinates(instance, nil, otherInstance)
+			err := inst.AlignViaRelaylogCorrelation(instance, otherInstance)
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%+v;%+v;%+v", *instanceCoordinates, *correlatedCoordinates, *nextCoordinates))
+			fmt.Println(instance.Key.DisplayString())
 		}
 		// General replication commands
 	case registerCliCommand("enable-gtid", "Replication, general", `If possible, turn on GTID replication`):

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -614,11 +614,11 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatalf("Instance not found: %+v", *destinationKey)
 			}
 
-			coordinates, otherRelaylogCoordinates, _, err := inst.CorrelateRelaylogCoordinates(instance, nil, otherInstance)
+			instanceCoordinates, coordinates, otherRelaylogCoordinates, _, err := inst.CorrelateRelaylogCoordinates(instance, nil, otherInstance)
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%+v;%+v", *coordinates, *otherRelaylogCoordinates))
+			fmt.Println(fmt.Sprintf("%+v;%+v;%+v", *instanceCoordinates, *coordinates, *otherRelaylogCoordinates))
 		}
 		// General replication commands
 	case registerCliCommand("enable-gtid", "Replication, general", `If possible, turn on GTID replication`):
@@ -893,11 +893,11 @@ func Cli(command string, strict bool, instance string, destination string, owner
 					log.Fatalf("Expecing --binlog argument as file:pos")
 				}
 			}
-			coordinates, nextCoordinates, _, err := inst.CorrelateRelaylogCoordinates(instance, relaylogCoordinates, otherInstance)
+			instanceCoordinates, correlatedCoordinates, nextCoordinates, _, err := inst.CorrelateRelaylogCoordinates(instance, relaylogCoordinates, otherInstance)
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%+v;%+v", *coordinates, *nextCoordinates))
+			fmt.Println(fmt.Sprintf("%+v;%+v;%+v", *instanceCoordinates, *correlatedCoordinates, *nextCoordinates))
 		}
 	case registerCliCommand("find-binlog-entry", "Binary logs", `Get binlog file:pos of entry given by --pattern (exact full match, not a regular expression) in a given instance`):
 		{

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -614,11 +614,11 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatalf("Instance not found: %+v", *destinationKey)
 			}
 
-			instanceCoordinates, coordinates, otherRelaylogCoordinates, _, err := inst.CorrelateRelaylogCoordinates(instance, nil, otherInstance)
+			instanceCoordinates, correlatedCoordinates, nextCoordinates, _, err := inst.CorrelateRelaylogCoordinates(instance, nil, otherInstance)
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%+v;%+v;%+v", *instanceCoordinates, *coordinates, *otherRelaylogCoordinates))
+			fmt.Println(fmt.Sprintf("%+v;%+v;%+v", *instanceCoordinates, *correlatedCoordinates, *nextCoordinates))
 		}
 		// General replication commands
 	case registerCliCommand("enable-gtid", "Replication, general", `If possible, turn on GTID replication`):

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -853,7 +853,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if instance == nil {
 				log.Fatalf("Instance not found: %+v", *instanceKey)
 			}
-			_, minCoordinates, err := inst.GetLastKnownCoordinatesForInstance(&instance.Key)
+			minCoordinates, err := inst.GetPreviousKnownRelayLogCoordinatesForInstance(instance)
 			if err != nil {
 				log.Fatalf("Error reading last known coordinates for %+v: %+v", instance.Key, err)
 			}

--- a/go/cmd/orchestrator/main.go
+++ b/go/cmd/orchestrator/main.go
@@ -51,7 +51,7 @@ func main() {
 	verbose := flag.Bool("verbose", false, "verbose")
 	debug := flag.Bool("debug", false, "debug mode (very verbose)")
 	stack := flag.Bool("stack", false, "add stack trace upon error")
-	config.RuntimeCLIFlags.SkipBinlogSearch = flag.Bool("skip-binlog", false, "when matching via Pseudo-GTID, only use relay logs")
+	config.RuntimeCLIFlags.SkipBinlogSearch = flag.Bool("skip-binlog-search", false, "when matching via Pseudo-GTID, only use relay logs. This can save the hassle of searching for a non-existend pseudo-GTID entry, for example in servers with replication filters.")
 	config.RuntimeCLIFlags.Databaseless = flag.Bool("databaseless", false, "EXPERIMENTAL! Work without backend database")
 	config.RuntimeCLIFlags.SkipUnresolve = flag.Bool("skip-unresolve", false, "Do not unresolve a host name")
 	config.RuntimeCLIFlags.SkipUnresolveCheck = flag.Bool("skip-unresolve-check", false, "Skip/ignore checking an unresolve mapping (via hostname_unresolve table) resolves back to same hostname")

--- a/go/cmd/orchestrator/main.go
+++ b/go/cmd/orchestrator/main.go
@@ -51,6 +51,7 @@ func main() {
 	verbose := flag.Bool("verbose", false, "verbose")
 	debug := flag.Bool("debug", false, "debug mode (very verbose)")
 	stack := flag.Bool("stack", false, "add stack trace upon error")
+	config.RuntimeCLIFlags.SkipBinlogSearch = flag.Bool("skip-binlog", false, "when matching via Pseudo-GTID, only use relay logs")
 	config.RuntimeCLIFlags.Databaseless = flag.Bool("databaseless", false, "EXPERIMENTAL! Work without backend database")
 	config.RuntimeCLIFlags.SkipUnresolve = flag.Bool("skip-unresolve", false, "Do not unresolve a host name")
 	config.RuntimeCLIFlags.SkipUnresolveCheck = flag.Bool("skip-unresolve-check", false, "Skip/ignore checking an unresolve mapping (via hostname_unresolve table) resolves back to same hostname")

--- a/go/config/cli_flags.go
+++ b/go/config/cli_flags.go
@@ -28,6 +28,7 @@ type CLIFlags struct {
 	Statement          *string
 	PromotionRule      *string
 	ConfiguredVersion  string
+	SkipBinlogSearch   *bool
 }
 
 var RuntimeCLIFlags CLIFlags

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -763,7 +763,7 @@ func (this *HttpAPI) LastPseudoGTID(params martini.Params, r render.Render, req 
 		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Instance not found: %+v", instanceKey)})
 		return
 	}
-	coordinates, text, err := inst.FindLastPseudoGTIDEntry(instance, instance.RelaylogCoordinates, nil, false, nil, false)
+	coordinates, text, err := inst.FindLastPseudoGTIDEntry(instance, instance.RelaylogCoordinates, nil, false, nil)
 	if err != nil {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
 		return

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -763,7 +763,7 @@ func (this *HttpAPI) LastPseudoGTID(params martini.Params, r render.Render, req 
 		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Instance not found: %+v", instanceKey)})
 		return
 	}
-	coordinates, text, err := inst.FindLastPseudoGTIDEntry(instance, instance.RelaylogCoordinates, nil, false, nil)
+	coordinates, text, err := inst.FindLastPseudoGTIDEntry(instance, instance.RelaylogCoordinates, nil, false, nil, false)
 	if err != nil {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
 		return

--- a/go/inst/instance_binlog_dao.go
+++ b/go/inst/instance_binlog_dao.go
@@ -385,6 +385,9 @@ func SearchEventInRelayLogs(searchEvent *BinlogEvent, instance *Instance, minBin
 	// Since MySQL does not provide with a SHOW RELAY LOGS command, we heuristically start from current
 	// relay log (indiciated by Relay_log_file) and walk backwards.
 	log.Debugf("will search for event %+v", *searchEvent)
+	if minBinlogCoordinates != nil {
+		log.Debugf("Starting with coordinates: %+v", *minBinlogCoordinates)
+	}
 	currentRelayLog := recordedInstanceRelayLogCoordinates
 	for err == nil {
 		log.Debugf("Searching for event in relaylog %+v of %+v, up to pos %+v", currentRelayLog.LogFile, instance.Key, recordedInstanceRelayLogCoordinates)

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1331,7 +1331,10 @@ func CorrelateRelaylogCoordinates(instance *Instance, relaylogCoordinates *Binlo
 	}
 	var binlogEvent *BinlogEvent
 	if relaylogCoordinates == nil {
-		if binlogEvent, err = GetLastExecutedEntryInRelayLogs(instance, nil, instance.RelaylogCoordinates); err != nil {
+
+		if _, minCoordinates, err := GetLastKnownCoordinatesForInstance(&instance.Key); err != nil {
+			return correlatedCoordinates, nextCoordinates, found, err
+		} else if binlogEvent, err = GetLastExecutedEntryInRelayLogs(instance, minCoordinates, instance.RelaylogCoordinates); err != nil {
 			return correlatedCoordinates, nextCoordinates, found, err
 		}
 	} else {

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1260,8 +1260,8 @@ func FindLastPseudoGTIDEntry(instance *Instance, recordedInstanceRelayLogCoordin
 		return instancePseudoGtidCoordinates, instancePseudoGtidText, fmt.Errorf("PseudoGTIDPattern not configured; cannot use Pseudo-GTID")
 	}
 
-	minBinlogCoordinates, minRelaylogCoordinates, err := GetHeuristiclyRecentCoordinatesForInstance(&instance.Key)
 	if instance.LogBinEnabled && instance.LogSlaveUpdatesEnabled && !*config.RuntimeCLIFlags.SkipBinlogSearch && (expectedBinlogFormat == nil || instance.Binlog_format == *expectedBinlogFormat) {
+		minBinlogCoordinates, _, _ := GetHeuristiclyRecentCoordinatesForInstance(&instance.Key)
 		// Well no need to search this instance's binary logs if it doesn't have any...
 		// With regard log-slave-updates, some edge cases are possible, like having this instance's log-slave-updates
 		// enabled/disabled (of course having restarted it)
@@ -1273,6 +1273,7 @@ func FindLastPseudoGTIDEntry(instance *Instance, recordedInstanceRelayLogCoordin
 		instancePseudoGtidCoordinates, instancePseudoGtidText, err = getLastPseudoGTIDEntryInInstance(instance, minBinlogCoordinates, maxBinlogCoordinates, exhaustiveSearch)
 	}
 	if err != nil || instancePseudoGtidCoordinates == nil {
+		minRelaylogCoordinates, _ := GetPreviousKnownRelayLogCoordinatesForInstance(instance)
 		// Unable to find pseudo GTID in binary logs.
 		// Then MAYBE we are lucky enough (chances are we are, if this replica did not crash) that we can
 		// extract the Pseudo GTID entry from the last (current) relay log file.

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1332,7 +1332,7 @@ func CorrelateRelaylogCoordinates(instance *Instance, relaylogCoordinates *Binlo
 	var binlogEvent *BinlogEvent
 	if relaylogCoordinates == nil {
 
-		if _, minCoordinates, err := GetLastKnownCoordinatesForInstance(&instance.Key); err != nil {
+		if minCoordinates, err := GetPreviousKnownRelayLogCoordinatesForInstance(instance); err != nil {
 			return correlatedCoordinates, nextCoordinates, found, err
 		} else if binlogEvent, err = GetLastExecutedEntryInRelayLogs(instance, minCoordinates, instance.RelaylogCoordinates); err != nil {
 			return correlatedCoordinates, nextCoordinates, found, err
@@ -1344,7 +1344,11 @@ func CorrelateRelaylogCoordinates(instance *Instance, relaylogCoordinates *Binlo
 		}
 	}
 
-	correlatedCoordinates, nextCoordinates, found, err = SearchEventInRelayLogs(binlogEvent, otherInstance, nil, otherInstance.RelaylogCoordinates)
+	_, minCoordinates, err := GetHeuristiclyRecentCoordinatesForInstance(&otherInstance.Key)
+	if err != nil {
+		return correlatedCoordinates, nextCoordinates, found, err
+	}
+	correlatedCoordinates, nextCoordinates, found, err = SearchEventInRelayLogs(binlogEvent, otherInstance, minCoordinates, otherInstance.RelaylogCoordinates)
 	return correlatedCoordinates, nextCoordinates, found, err
 }
 

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1254,7 +1254,7 @@ Cleanup:
 
 // FindLastPseudoGTIDEntry will search an instance's binary logs or relay logs for the last pseudo-GTID entry,
 // and return found coordinates as well as entry text
-func FindLastPseudoGTIDEntry(instance *Instance, recordedInstanceRelayLogCoordinates BinlogCoordinates, maxBinlogCoordinates *BinlogCoordinates, exhaustiveSearch bool, expectedBinlogFormat *string, onlyRelayLogSearch bool) (instancePseudoGtidCoordinates *BinlogCoordinates, instancePseudoGtidText string, err error) {
+func FindLastPseudoGTIDEntry(instance *Instance, recordedInstanceRelayLogCoordinates BinlogCoordinates, maxBinlogCoordinates *BinlogCoordinates, exhaustiveSearch bool, expectedBinlogFormat *string) (instancePseudoGtidCoordinates *BinlogCoordinates, instancePseudoGtidText string, err error) {
 
 	if config.Config.PseudoGTIDPattern == "" {
 		return instancePseudoGtidCoordinates, instancePseudoGtidText, fmt.Errorf("PseudoGTIDPattern not configured; cannot use Pseudo-GTID")
@@ -1288,7 +1288,7 @@ func CorrelateBinlogCoordinates(instance *Instance, binlogCoordinates *BinlogCoo
 	// a FLUSH LOGS/FLUSH RELAY LOGS (or a START SLAVE, though that's an altogether different problem) etc.
 	// We want to be on the safe side; we don't utterly trust that we are the only ones playing with the instance.
 	recordedInstanceRelayLogCoordinates := instance.RelaylogCoordinates
-	instancePseudoGtidCoordinates, instancePseudoGtidText, err := FindLastPseudoGTIDEntry(instance, recordedInstanceRelayLogCoordinates, binlogCoordinates, true, &otherInstance.Binlog_format, false)
+	instancePseudoGtidCoordinates, instancePseudoGtidText, err := FindLastPseudoGTIDEntry(instance, recordedInstanceRelayLogCoordinates, binlogCoordinates, true, &otherInstance.Binlog_format)
 
 	if err != nil {
 		return nil, 0, err

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1261,7 +1261,7 @@ func FindLastPseudoGTIDEntry(instance *Instance, recordedInstanceRelayLogCoordin
 	}
 
 	minBinlogCoordinates, minRelaylogCoordinates, err := GetHeuristiclyRecentCoordinatesForInstance(&instance.Key)
-	if instance.LogBinEnabled && instance.LogSlaveUpdatesEnabled && !onlyRelayLogSearch && (expectedBinlogFormat == nil || instance.Binlog_format == *expectedBinlogFormat) {
+	if instance.LogBinEnabled && instance.LogSlaveUpdatesEnabled && !*config.RuntimeCLIFlags.SkipBinlogSearch && (expectedBinlogFormat == nil || instance.Binlog_format == *expectedBinlogFormat) {
 		// Well no need to search this instance's binary logs if it doesn't have any...
 		// With regard log-slave-updates, some edge cases are possible, like having this instance's log-slave-updates
 		// enabled/disabled (of course having restarted it)

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -581,6 +581,7 @@ func ChangeMasterTo(instanceKey *InstanceKey, masterKey *InstanceKey, masterBinl
 		return instance, log.Errore(err)
 	}
 	WriteMasterPositionEquivalence(&originalMasterKey, &originalExecBinlogCoordinates, changeToMasterKey, masterBinlogCoordinates)
+	ResetInstanceRelaylogCoordinatesHistory(instanceKey)
 
 	log.Infof("ChangeMasterTo: Changed master on %+v to: %+v, %+v. GTID: %+v", *instanceKey, masterKey, masterBinlogCoordinates, changedViaGTID)
 


### PR DESCRIPTION
Following up on https://github.com/github/orchestrator/pull/1, in the objective of aligning replicas at failover.

At this time this will cooperate with `orchestrator-agent` at https://github.com/github/orchestrator-agent/pull/13, though the same can be accomplished via remote SSH.

When master fails, `orchestrator` is able to use GTID/Pseudo-GTID to match replicas. However there are a few constraints: what if the most up-to-date replica doesn't have binlogging or `log-slave-updates`? What if it uses a `ROW` based replication where all others use `STATEMENT` based? What if it's of a higher MySQL version? `orchestrator` would have to lose it, even though it contained more data than others.

This PR follows on the MHA approach, which requires either remote agents on MySQL boxes, or remote SSH. The intention is to correlate relay logs between failed replicas (done, optimized speed), then copy & apply such logs from the most up-to-date replica onto a (single) candidate replica.

Why single? Because the candidate replica would have `log-slave-updates` and `orchestrator` would be able to point all other replicas under that one. It is yet to be seen whether comparing and copying relay logs onto a single replica, then applying Pseudo-GTID/GTID logic to heal the rest of the replicas, is faster or slower than comparing and copying relay logs from the most up-to-date replica onto all other replicas.

Initial commits in this PR provide heuristic search for relay log coordinates & entries, which turn relay-log correlation into a subsecond operation, within `1` minute from failure.

