### PR TITLE
Failover correlate relay logs ssh

### DIFF
--- a/go/agent/instance_topology_agent.go
+++ b/go/agent/instance_topology_agent.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2014 Outbrain Inc.
+   Copyright 2017 GitHub Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -30,6 +30,7 @@ import (
 	"github.com/github/orchestrator/go/inst"
 	"github.com/github/orchestrator/go/logic"
 	"github.com/github/orchestrator/go/process"
+	"github.com/github/orchestrator/go/remote"
 	"github.com/outbrain/golib/log"
 	"github.com/outbrain/golib/util"
 )
@@ -615,6 +616,37 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			}
 
 			_, err = agent.AlignViaRelaylogCorrelation(instance, otherInstance)
+			if err != nil {
+				log.Fatale(err)
+			}
+			fmt.Println(instance.Key.DisplayString())
+		}
+		// relay-log based synchronization
+	case registerCliCommand("align-via-relay-logs-ssh", "Remote relay log relocation", `Align instance's data by comparing and applying another instance's relay logs`):
+		{
+			instanceKey = deduceInstanceKeyIfNeeded(instance, instanceKey, true)
+			if instanceKey == nil {
+				log.Fatalf("Unresolved instance")
+			}
+			instance, err := inst.ReadTopologyInstance(instanceKey)
+			if err != nil {
+				log.Fatale(err)
+			}
+			if instance == nil {
+				log.Fatalf("Instance not found: %+v", *instanceKey)
+			}
+			if destinationKey == nil {
+				log.Fatal("Cannot deduce target instance:", destination)
+			}
+			otherInstance, err := inst.ReadTopologyInstance(destinationKey)
+			if err != nil {
+				log.Fatale(err)
+			}
+			if otherInstance == nil {
+				log.Fatalf("Instance not found: %+v", *destinationKey)
+			}
+
+			_, err = remote.AlignViaRelaylogCorrelation(instance, otherInstance)
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -185,6 +185,7 @@ type Configuration struct {
 	MasterFailoverDetachReplicaMasterHost        bool              // Should orchestrator issue a detach-replica-master-host on newly promoted master (this makes sure the new master will not attempt to replicate old master if that comes back to life). Defaults 'false'. Meaningless if ApplyMySQLPromotionAfterMasterFailover is 'true'.
 	PostponeSlaveRecoveryOnLagMinutes            uint              // Synonym to PostponeReplicaRecoveryOnLagMinutes
 	PostponeReplicaRecoveryOnLagMinutes          uint              // On crash recovery, replicas that are lagging more than given minutes are only resurrected late in the recovery process, after master/IM has been elected and processes executed. Value of 0 disables this feature
+	RemoteSSHCommand                             string            // A `ssh` command to be used by recovery process to read/apply relaylogs. If provided, this variable must contain the text "{hostname}". The remote SSH login must have the privileges to read/write relay logs. Example: "setuidgid remoteuser ssh {hostname} 'sudo -i'"
 	OSCIgnoreHostnameFilters                     []string          // OSC replicas recommendation will ignore replica hostnames matching given patterns
 	GraphiteAddr                                 string            // Optional; address of graphite port. If supplied, metrics will be written here
 	GraphitePath                                 string            // Prefix for graphite path. May include {hostname} magic placeholder
@@ -339,6 +340,7 @@ func newConfiguration() *Configuration {
 		MasterFailoverLostInstancesDowntimeMinutes:   0,
 		MasterFailoverDetachSlaveMasterHost:          false,
 		PostponeSlaveRecoveryOnLagMinutes:            0,
+		RemoteSSHCommand:                             "",
 		OSCIgnoreHostnameFilters:                     []string{},
 		GraphiteAddr:                                 "",
 		GraphitePath:                                 "",
@@ -442,6 +444,12 @@ func (this *Configuration) postReadAdjustments() error {
 		this.URLPrefix = strings.TrimLeft(this.URLPrefix, "/")
 		this.URLPrefix = strings.TrimRight(this.URLPrefix, "/")
 		this.URLPrefix = "/" + this.URLPrefix
+	}
+
+	if this.RemoteSSHCommand != "" {
+		if !strings.Contains(this.RemoteSSHCommand, "{hostname}") {
+			return fmt.Errorf("config's RemoteSSHCommand must either be empty, or contain a '{hostname}' placeholder")
+		}
 	}
 	return nil
 }

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -185,7 +185,8 @@ type Configuration struct {
 	MasterFailoverDetachReplicaMasterHost        bool              // Should orchestrator issue a detach-replica-master-host on newly promoted master (this makes sure the new master will not attempt to replicate old master if that comes back to life). Defaults 'false'. Meaningless if ApplyMySQLPromotionAfterMasterFailover is 'true'.
 	PostponeSlaveRecoveryOnLagMinutes            uint              // Synonym to PostponeReplicaRecoveryOnLagMinutes
 	PostponeReplicaRecoveryOnLagMinutes          uint              // On crash recovery, replicas that are lagging more than given minutes are only resurrected late in the recovery process, after master/IM has been elected and processes executed. Value of 0 disables this feature
-	RemoteSSHCommand                             string            // A `ssh` command to be used by recovery process to read/apply relaylogs. If provided, this variable must contain the text "{hostname}". The remote SSH login must have the privileges to read/write relay logs. Example: "setuidgid remoteuser ssh {hostname} 'sudo -i'"
+	RemoteSSHCommand                             string            // A `ssh` command to be used by recovery process to read/apply relaylogs. If provided, this variable must contain the text "{hostname}". The remote SSH login must have the privileges to read/write relay logs. Example: "setuidgid remoteuser ssh {hostname}"
+	RemoteSSHCommandUseSudo                      bool              // Should orchestrator apply 'sudo' on the remote host upon SSH command
 	OSCIgnoreHostnameFilters                     []string          // OSC replicas recommendation will ignore replica hostnames matching given patterns
 	GraphiteAddr                                 string            // Optional; address of graphite port. If supplied, metrics will be written here
 	GraphitePath                                 string            // Prefix for graphite path. May include {hostname} magic placeholder
@@ -341,6 +342,7 @@ func newConfiguration() *Configuration {
 		MasterFailoverDetachSlaveMasterHost:          false,
 		PostponeSlaveRecoveryOnLagMinutes:            0,
 		RemoteSSHCommand:                             "",
+		RemoteSSHCommandUseSudo:                      true,
 		OSCIgnoreHostnameFilters:                     []string{},
 		GraphiteAddr:                                 "",
 		GraphitePath:                                 "",

--- a/go/os/process.go
+++ b/go/os/process.go
@@ -28,6 +28,8 @@ import (
 	"github.com/outbrain/golib/log"
 )
 
+var EmptyEnv = []string{}
+
 // CommandRun executes some text as a command. This is assumed to be
 // text that will be run by a shell so we need to write out the
 // command to a temporary file and then ask the shell to execute

--- a/go/remote/instance_topology_remote.go
+++ b/go/remote/instance_topology_remote.go
@@ -67,6 +67,7 @@ func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.
 	if err != nil {
 		return instance, err
 	}
+	localRelayLogContentsCopyFileName := fmt.Sprintf("%s.copy", localRelayLogContentsFile.Name())
 
 	{
 		command := config.Config.RemoteSSHCommand
@@ -80,7 +81,7 @@ func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.
 	{
 		command := config.Config.RemoteSSHCommand
 		command = strings.Replace(command, "{hostname}", instance.Key.Hostname, -1)
-		command = fmt.Sprintf("cat %s | %s cat - > %s.copy", localRelayLogContentsFile.Name(), command, localRelayLogContentsFile.Name())
+		command = fmt.Sprintf("cat %s | %s cat - > %s", localRelayLogContentsFile.Name(), command, localRelayLogContentsCopyFileName)
 		if err := os.CommandRun(command, os.EmptyEnv); err != nil {
 			return instance, err
 		}
@@ -93,7 +94,7 @@ func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.
 	} else {
 		script := ApplyRelayLogContentsScript
 		script = strings.Replace(script, "$MAGIC_MYSQL_COMMAND", "", -1)
-		script = strings.Replace(script, "$MAGIC_CONTENTS_FILE", fmt.Sprintf("%s.copy", localRelayLogContentsFile.Name()), -1)
+		script = strings.Replace(script, "$MAGIC_CONTENTS_FILE", localRelayLogContentsCopyFileName, -1)
 
 		if err := ioutil.WriteFile(applyRelayLogContentsScriptFile.Name(), []byte(script), 0640); err != nil {
 			return instance, err

--- a/go/remote/instance_topology_remote.go
+++ b/go/remote/instance_topology_remote.go
@@ -72,6 +72,7 @@ func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.
 		return instance, err
 	} else {
 		script := ApplyRelayLogContentsScript
+		script = strings.Replace(script, "$MAGIC_MYSQL_COMMAND", "", -1)
 		if err := ioutil.WriteFile(applyRelayLogContentsScriptFile.Name(), []byte(script), 0640); err != nil {
 			return instance, err
 		}
@@ -87,15 +88,15 @@ func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.
 		}
 	}
 	log.Debugf("Have executed on %s, output file is %s", otherInstance.Key.Hostname, localRelayLogContentsFile.Name())
-	return instance, fmt.Errorf("That;s it for now, I'm just testing, not applying")
 	{
 		command := config.Config.RemoteSSHCommand
 		command = strings.Replace(command, "{hostname}", instance.Key.Hostname, -1)
-		command = fmt.Sprintf("cat %s | %s > %s", getRelayLogContentsScriptFile.Name(), command, localRelayLogContentsFile.Name())
+		command = fmt.Sprintf("cat %s | %s", localRelayLogContentsFile.Name(), command)
 		if err := os.CommandRun(command, os.EmptyEnv); err != nil {
 			return instance, err
 		}
 	}
+	log.Debugf("Have applied on %s. Whoa", instance.Key.Hostname)
 
 	instance, err = inst.ChangeMasterTo(&instance.Key, &otherInstance.MasterKey, &otherInstance.ExecBinlogCoordinates, false, inst.GTIDHintNeutral)
 	if err != nil {

--- a/go/remote/instance_topology_remote.go
+++ b/go/remote/instance_topology_remote.go
@@ -1,0 +1,106 @@
+/*
+   Copyright 2017 GitHub Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package remote
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/github/orchestrator/go/config"
+	"github.com/github/orchestrator/go/inst"
+	"github.com/github/orchestrator/go/os"
+	"github.com/outbrain/golib/log"
+)
+
+// AlignViaRelaylogCorrelation will align siblings by applying relaylogs from one to the other, via remote SSH
+func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.Instance, error) {
+	if config.Config.RemoteSSHCommand == "" {
+		return instance, fmt.Errorf("RemoteSSHCommand not configured")
+	}
+
+	log.Debugf("AlignViaRelaylogCorrelation: stopping replication")
+	if instance.ReplicaRunning() {
+		return instance, log.Errorf("AlignViaRelaylogCorrelation: replication on %+v must not run", instance.Key)
+	}
+	if otherInstance.ReplicaRunning() {
+		return instance, log.Errorf("AlignViaRelaylogCorrelation: replication on %+v must not run", otherInstance.Key)
+	}
+
+	log.Debugf("AlignViaRelaylogCorrelation: correlating coordinates of %+v on %+v", instance.Key, otherInstance.Key)
+	_, _, nextCoordinates, found, err := inst.CorrelateRelaylogCoordinates(instance, nil, otherInstance)
+	if err != nil {
+		return instance, err
+	}
+	if !found {
+		return instance, err
+	}
+	log.Debugf("AlignViaRelaylogCorrelation: correlated next-coordinates are %+v", *nextCoordinates)
+
+	getRelayLogContentsScriptFile, err := ioutil.TempFile("", "orchestrator-remote-get-relaylogs-content-")
+	if err != nil {
+		return instance, err
+	} else {
+		script := GetRelayLogContentsScript
+		script = strings.Replace(script, "$MAGIC_FIRST_RELAYLOG_FILE", nextCoordinates.LogFile, -1)
+		script = strings.Replace(script, "$MAGIC_START_POSITION", fmt.Sprintf("%d", nextCoordinates.LogPos), -1)
+		if err := ioutil.WriteFile(getRelayLogContentsScriptFile.Name(), []byte(script), 0640); err != nil {
+			return instance, err
+		}
+	}
+	log.Debugf("getRelayLogContentsScriptFile: %+v", getRelayLogContentsScriptFile.Name())
+	localRelayLogContentsFile, err := ioutil.TempFile("", "orchestrator-remote-relaylogs-content-")
+	if err != nil {
+		return instance, err
+	}
+	applyRelayLogContentsScriptFile, err := ioutil.TempFile("", "orchestrator-remote-apply-relaylogs-content-")
+	if err != nil {
+		return instance, err
+	} else {
+		script := ApplyRelayLogContentsScript
+		if err := ioutil.WriteFile(applyRelayLogContentsScriptFile.Name(), []byte(script), 0640); err != nil {
+			return instance, err
+		}
+	}
+	log.Debugf("applyRelayLogContentsScriptFile: %+v", applyRelayLogContentsScriptFile.Name())
+
+	{
+		command := config.Config.RemoteSSHCommand
+		command = strings.Replace(command, "{hostname}", otherInstance.Key.Hostname, -1)
+		command = fmt.Sprintf("cat %s | %s > %s", getRelayLogContentsScriptFile.Name(), command, localRelayLogContentsFile.Name())
+		if err := os.CommandRun(command, os.EmptyEnv); err != nil {
+			return instance, err
+		}
+	}
+	log.Debugf("Have executed on %s, output file is %s", otherInstance.Key.Hostname, localRelayLogContentsFile.Name())
+	return instance, fmt.Errorf("That;s it for now, I'm just testing, not applying")
+	{
+		command := config.Config.RemoteSSHCommand
+		command = strings.Replace(command, "{hostname}", instance.Key.Hostname, -1)
+		command = fmt.Sprintf("cat %s | %s > %s", getRelayLogContentsScriptFile.Name(), command, localRelayLogContentsFile.Name())
+		if err := os.CommandRun(command, os.EmptyEnv); err != nil {
+			return instance, err
+		}
+	}
+
+	instance, err = inst.ChangeMasterTo(&instance.Key, &otherInstance.MasterKey, &otherInstance.ExecBinlogCoordinates, false, inst.GTIDHintNeutral)
+	if err != nil {
+		return instance, err
+	}
+	inst.AuditOperation("align-via-relaylogs-remote", &instance.Key, fmt.Sprintf("aligned %+v by relaylogs from %+v", instance.Key, otherInstance.Key))
+	return instance, err
+}

--- a/go/remote/instance_topology_remote.go
+++ b/go/remote/instance_topology_remote.go
@@ -80,7 +80,7 @@ func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.
 	{
 		command := config.Config.RemoteSSHCommand
 		command = strings.Replace(command, "{hostname}", instance.Key.Hostname, -1)
-		command = fmt.Sprintf("cat %s | %s cat - > %s", localRelayLogContentsFile.Name(), command, localRelayLogContentsFile.Name())
+		command = fmt.Sprintf("cat %s | %s cat - > %s.copy", localRelayLogContentsFile.Name(), command, localRelayLogContentsFile.Name())
 		if err := os.CommandRun(command, os.EmptyEnv); err != nil {
 			return instance, err
 		}
@@ -93,7 +93,7 @@ func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.
 	} else {
 		script := ApplyRelayLogContentsScript
 		script = strings.Replace(script, "$MAGIC_MYSQL_COMMAND", "", -1)
-		script = strings.Replace(script, "$MAGIC_CONTENTS_FILE", localRelayLogContentsFile.Name(), -1)
+		script = strings.Replace(script, "$MAGIC_CONTENTS_FILE", fmt.Sprintf("%s.copy", localRelayLogContentsFile.Name()), -1)
 
 		if err := ioutil.WriteFile(applyRelayLogContentsScriptFile.Name(), []byte(script), 0640); err != nil {
 			return instance, err

--- a/go/remote/instance_topology_remote.go
+++ b/go/remote/instance_topology_remote.go
@@ -165,7 +165,7 @@ func AlignViaRelaylogCorrelation(instance, otherInstance *inst.Instance) (*inst.
 			return instance, err
 		}
 	}
-	log.Debugf("Have applied on %s. Whoa", instance.Key.Hostname)
+	log.Debugf("Have successfully applied relay logs on %s", instance.Key.Hostname)
 
 	instance, err = inst.ChangeMasterTo(&instance.Key, &otherInstance.MasterKey, &otherInstance.ExecBinlogCoordinates, false, inst.GTIDHintNeutral)
 	if err != nil {

--- a/go/remote/instance_topology_remote.go
+++ b/go/remote/instance_topology_remote.go
@@ -156,6 +156,11 @@ func AlignViaRelaylogCorrelation(instance, fromInstance *inst.Instance) (*inst.I
 		}
 	}
 	log.Debugf("applyRelayLogContentsScriptFile: %+v", applyRelayLogContentsScriptFile.Name())
+
+	if *config.RuntimeCLIFlags.Noop {
+		return instance, fmt.Errorf("noop: Not really applying scripts onto %+v; signalling error but nothing went wrong", instance.Key)
+	}
+
 	// apply relaylog contents on target host:
 	{
 		command := config.Config.RemoteSSHCommand

--- a/go/remote/relaylogs.go
+++ b/go/remote/relaylogs.go
@@ -117,13 +117,16 @@ var ApplyRelayLogContentsScript = `#!/bin/bash
 
 mysql_command="$MAGIC_MYSQL_COMMAND"
 mysql_command="${mysql_command:-mysql}"
+contents_file="$MAGIC_CONTENTS_FILE"
+contents_file="${contents_file:-"-"}"
+
 
 set -e
 
 apply_relaylog() {
   binlog_file=$(mktemp)
 
-  cat - | base64 --decode | gunzip > $binlog_file
+  cat "$contents_file" | base64 --decode | gunzip > $binlog_file
   mysqlbinlog $binlog_file | $mysql_command
 }
 

--- a/go/remote/relaylogs.go
+++ b/go/remote/relaylogs.go
@@ -115,11 +115,12 @@ var ApplyRelayLogContentsScript = `#!/bin/bash
 #   for example: "mysql --default-file=/root/.my.cnf"
 #   Notice this should be quoted as one argument to the program
 
+mysql_command="$MAGIC_MYSQL_COMMAND"
+mysql_command="${mysql_command:-mysql}"
+
 set -e
 
 apply_relaylog() {
-  mysql_command="${1:-mysql}"
-
   binlog_file=$(mktemp)
 
   cat - | base64 --decode | gunzip > $binlog_file
@@ -127,8 +128,8 @@ apply_relaylog() {
 }
 
 main() {
-  apply_relaylog "$@"
+  apply_relaylog
 }
 
-main "$@"
+main
 `

--- a/go/remote/relaylogs.go
+++ b/go/remote/relaylogs.go
@@ -73,12 +73,12 @@ relaylog_tail() {
   contents_file=$(mktemp)
 
   [ "$start_position" == "0" ] && start_position=""
-  counter=0
+  is_first_relaylog=1
   relaylogs_starting_at $starting_relay_log
   for relay_log in $relay_logs ; do
     binlog_header_size $relay_log
     # header_size variable is now populated
-    if ((counter==0)) ; then
+    if [ $is_first_relaylog -eq 1 ] ; then
       # First relaylog file. We only get the header from the first file.
       # Then, we also filter by --start-position
       cat $relay_log | head -c$header_size >> $contents_file
@@ -92,7 +92,7 @@ relaylog_tail() {
       ((header_size++))
       cat $relay_log | tail -c+$header_size >> $contents_file
     fi
-    ((counter++))
+    is_first_relaylog=0
   done
 
   cat $contents_file | gzip | base64

--- a/go/remote/relaylogs.go
+++ b/go/remote/relaylogs.go
@@ -19,8 +19,8 @@ package remote
 var GetRelayLogContentsScript = `#!/bin/bash
 #
 # We will magically set these variables:
-FIRST_RELAYLOG_FILE=$MAGIC_FIRST_RELAYLOG_FILE
-START_POSITION=$MAGIC_START_POSITION
+FIRST_RELAYLOG_FILE="$MAGIC_FIRST_RELAYLOG_FILE"
+START_POSITION="$MAGIC_START_POSITION"
 
 set -e
 
@@ -68,8 +68,8 @@ binlog_header_size() {
 
 
 relaylog_tail() {
-  starting_relay_log=$(basename "$1")
-  start_position="$2"
+  starting_relay_log=$(basename "$FIRST_RELAYLOG_FILE")
+  start_position="$START_POSITION"
   contents_file=$(mktemp)
 
   [ "$start_position" == "0" ] && start_position=""
@@ -100,10 +100,10 @@ relaylog_tail() {
 
 main() {
   bootstrap
-  relaylog_tail "$@"
+  relaylog_tail
 }
 
-main "$@"
+main
 `
 
 var ApplyRelayLogContentsScript = `#!/bin/bash

--- a/go/remote/relaylogs.go
+++ b/go/remote/relaylogs.go
@@ -18,9 +18,9 @@ package remote
 
 var GetRelayLogContentsScript = `#!/bin/bash
 #
-# Expected system variables:
-# FIRST_RELAYLOG_FILE
-# START_POSITION
+# We will magically set these variables:
+FIRST_RELAYLOG_FILE=$MAGIC_FIRST_RELAYLOG_FILE
+START_POSITION=$MAGIC_START_POSITION
 
 set -e
 

--- a/go/remote/relaylogs.go
+++ b/go/remote/relaylogs.go
@@ -1,0 +1,134 @@
+/*
+   Copyright 2017 GitHub Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package remote
+
+var GetRelayLogContentsScript = `#!/bin/bash
+#
+# Expected system variables:
+# FIRST_RELAYLOG_FILE
+# START_POSITION
+
+set -e
+
+header_size=""
+datadir=""
+relaylog_index_file=""
+relay_logs=""
+
+bootstrap() {
+  datadir=$(find /etc -name "my.cnf" | xargs grep datadir | head -1 | cut -d"=" -f2 | xargs echo)
+  [ -z "$datadir" ] && datadir=$(ps aux | grep mysqld | egrep -o '[-][-]datadir=[^ ]+' | cut -d"=" -f2)
+  if [ -z "$datadir" ] ; then
+    echo "Cannot find @@datadir"
+    exit 1
+  fi
+
+  relaylog_index_file=$(find $datadir -name "*relay*.index" | head -1)
+  if [ -z "$relaylog_index_file" ] ; then
+    echo "Cannot find relaylog index file"
+    exit 1
+  fi
+}
+
+relaylogs_starting_at() {
+  starting_relay_log=$(basename "$1")
+
+  relay_logs_file=$(mktemp)
+  basedir=$(dirname $relaylog_index_file)
+  cat $relaylog_index_file | awk "/$starting_relay_log/,0" | while read f ; do
+    echo "${basedir}/${f}" >> $relay_logs_file
+  done
+  relay_logs=$(cat $relay_logs_file)
+}
+
+binlog_header_size() {
+  binlog_file="$1"
+	# magic header
+	# There are the first 4 bytes, and then there's also the first entry (the format-description).
+	# We need both from the first log file.
+	# Typically, the format description ends at pos 120, but let's verify...
+
+  header_size=""
+	header_size=$(mysqlbinlog $binlog_file --start-position=4 | head | egrep -o 'end_log_pos [^ ]+' | head -1 | awk '{print $2}')
+}
+
+
+relaylog_tail() {
+  starting_relay_log=$(basename "$1")
+  start_position="$2"
+  contents_file=$(mktemp)
+
+  [ "$start_position" == "0" ] && start_position=""
+  counter=0
+  relaylogs_starting_at $starting_relay_log
+  for relay_log in $relay_logs ; do
+    binlog_header_size $relay_log
+    # header_size variable is now populated
+    if ((counter==0)) ; then
+      # First relaylog file. We only get the header from the first file.
+      # Then, we also filter by --start-position
+      cat $relay_log | head -c$header_size >> $contents_file
+      [ -z "$start_position" ] && start_position="$header_size"
+      # _tail_ command is unfortunately 1-based, which is why we ++
+      ((start_position++))
+      cat $relay_log | tail -c+$start_position >> $contents_file
+    else
+      # Skip header
+      # _tail_ command is unfortunately 1-based, which is why we ++
+      ((header_size++))
+      cat $relay_log | tail -c+$header_size >> $contents_file
+    fi
+    ((counter++))
+  done
+
+  cat $contents_file | gzip | base64
+}
+
+main() {
+  bootstrap
+  relaylog_tail "$@"
+}
+
+main "$@"
+`
+
+var ApplyRelayLogContentsScript = `#!/bin/bash
+#
+# Usage:
+#
+# apply-relaylog-contents [path-to-mysql]
+# - [path-to-mysql] would be a mysql command that has full privileges (including GRANT privileges).
+#   for example: "mysql --default-file=/root/.my.cnf"
+#   Notice this should be quoted as one argument to the program
+
+set -e
+
+apply_relaylog() {
+  mysql_command="${1:-mysql}"
+
+  binlog_file=$(mktemp)
+
+  cat - | base64 --decode | gunzip > $binlog_file
+  mysqlbinlog $binlog_file | $mysql_command
+}
+
+main() {
+  apply_relaylog "$@"
+}
+
+main "$@"
+`


### PR DESCRIPTION
continued work from https://github.com/github/orchestrator/pull/32
this PR will support relaylog synching via remote SSH rather than `orchestrator-agent`.

I'm unsure at this time which of the two is the "better" way. `orchestrator-agent` requires further setup: installing and running an agent on each box. Remote SSH also has its own setup and security issues. Anyway at this time I'd like to see both running, and I'll follow up with tests.