### PR TITLE
elaborate info in status page: active time, startup time

### DIFF
--- a/go/db/db.go
+++ b/go/db/db.go
@@ -875,6 +875,14 @@ var generateSQLPatches = []string{
 			database_instance
 			ADD COLUMN version_comment varchar(128) NOT NULL DEFAULT ''
 	`,
+	`
+		ALTER TABLE active_node
+			ADD COLUMN first_seen_active timestamp NOT NULL DEFAULT '1971-01-01 00:00:00'
+	`,
+	`
+		ALTER TABLE node_health
+			ADD COLUMN first_seen_active timestamp NOT NULL DEFAULT '1971-01-01 00:00:00'
+	`,
 }
 
 // Track if a TLS has already been configured for topology

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -239,9 +239,8 @@ func ContinuousDiscovery() {
 						go process.RegisterNode("", "", false)
 					}
 				} else {
-					hostname, _, _, err := process.ElectedNode()
-					if err == nil {
-						log.Debugf("Not elected as active node; active node: %v; polling", hostname)
+					if electedNode, _, err := process.ElectedNode(); err == nil {
+						log.Debugf("Not elected as active node; active node: %v; polling", electedNode.Hostname)
 					} else {
 						log.Debugf("Not elected as active node; active node: Unable to determine: %v; polling", err)
 					}

--- a/go/process/election_dao.go
+++ b/go/process/election_dao.go
@@ -27,15 +27,16 @@ import (
 func AttemptElection() (bool, error) {
 	sqlResult, err := db.ExecOrchestrator(`
 			insert ignore into active_node (
-					anchor, hostname, token, last_seen_active
+					anchor, hostname, token, first_seen_active, last_seen_active
 				) values (
-					1, ?, ?, now()
+					1, ?, ?, now(), now()
 				) on duplicate key update
-					hostname = if(last_seen_active < now() - interval ? second, values(hostname), hostname),
-					token    = if(last_seen_active < now() - interval ? second, values(token),    token),
-					last_seen_active = if(hostname = values(hostname) and token = values(token), values(last_seen_active), last_seen_active)					
+					hostname          = if(last_seen_active < now() - interval ? second, values(hostname),          hostname),
+					token             = if(last_seen_active < now() - interval ? second, values(token),             token),
+					first_seen_active = if(last_seen_active < now() - interval ? second, values(first_seen_active), first_seen_active),
+					last_seen_active = if(hostname = values(hostname) and token = values(token), values(last_seen_active), last_seen_active)
 			`,
-		ThisHostname, ProcessToken.Hash, config.Config.ActiveNodeExpireSeconds, config.Config.ActiveNodeExpireSeconds,
+		ThisHostname, ProcessToken.Hash, config.Config.ActiveNodeExpireSeconds, config.Config.ActiveNodeExpireSeconds, config.Config.ActiveNodeExpireSeconds,
 	)
 	if err != nil {
 		return false, log.Errore(err)
@@ -48,9 +49,9 @@ func AttemptElection() (bool, error) {
 func GrabElection() error {
 	_, err := db.ExecOrchestrator(`
 			replace into active_node (
-					anchor, hostname, token, last_seen_active
+					anchor, hostname, token, first_seen_active, last_seen_active
 				) values (
-					1, ?, ?, NOW()
+					1, ?, ?, now(), now()
 				)
 			`,
 		ThisHostname, ProcessToken.Hash,
@@ -65,25 +66,27 @@ func Reelect() error {
 }
 
 // ElectedNode returns the details of the elected node, as well as answering the question "is this process the elected one"?
-func ElectedNode() (hostname string, token string, isElected bool, err error) {
+func ElectedNode() (node NodeHealth, isElected bool, err error) {
 	query := `
-		select 
+		select
 			hostname,
-			token
-		from 
+			token,
+			first_seen_active,
+			last_seen_Active
+		from
 			active_node
 		where
 			anchor = 1
 		`
 	err = db.QueryOrchestratorRowsMap(query, func(m sqlutils.RowMap) error {
-		hostname = m.GetString("hostname")
-		token = m.GetString("token")
+		node.Hostname = m.GetString("hostname")
+		node.Token = m.GetString("token")
+		node.FirstSeenActive = m.GetString("first_seen_active")
+		node.LastSeenActive = m.GetString("last_seen_active")
+
 		return nil
 	})
 
-	if err != nil {
-		log.Errore(err)
-	}
-	isElected = (hostname == ThisHostname && token == ProcessToken.Hash)
-	return hostname, token, isElected, err
+	isElected = (node.Hostname == ThisHostname && node.Token == ProcessToken.Hash)
+	return node, isElected, log.Errore(err)
 }

--- a/resources/public/js/status.js
+++ b/resources/public/js/status.js
@@ -23,20 +23,22 @@ $(document).ready(function () {
     $.get(appUrl("/api/health/"), function (health) {
     	statusObject.prepend('<h4>'+health.Message+'</h4>')
     	health.Details.AvailableNodes.forEach(function(node) {
-    		var values = node.split(";");
-    		var hostname = values[0];
-    		var token = values[1];
-    		var app_version = values[2];
-    		var message = hostname;
-    		if (hostname + ";" + token == health.Details.ActiveNode) {
-    			message += ' <span class="text-success">[Active]</span>';
-    		}
-    		if (hostname == health.Details.Hostname) {
+				var app_version = node.AppVersion;
+				if (app_version == "") {
+					app_version = "unknown version";
+				}
+				var message = node.Hostname;
+				if (node.Hostname == health.Details.ActiveNode.Hostname && node.Token == health.Details.ActiveNode.Token) {
+					message += ' <span class="text-success">[Active since '+health.Details.ActiveNode.FirstSeenActive+']</span>';
+				}
+				if (node.Hostname == health.Details.Hostname) {
     			message += ' <span class="text-primary">[This node]</span>';
     		}
+				message += ' <span class="text-info">[Running since '+node.FirstSeenActive+']</span>';
+
     		addStatusTableData("Available node", message, app_version);
     	})
-    	
+
     	var userId = getUserId();
     	if (userId == "") {
     		userId = "[unknown]"
@@ -49,6 +51,6 @@ $(document).ready(function () {
     		addStatusActionButton("Reset hostname resolve cache", "reset-hostname-resolve-cache");
     		addStatusActionButton("Reelect", "reelect");
     	}
-    
-    }, "json");   
+
+    }, "json");
 });

--- a/resources/public/js/status.js
+++ b/resources/public/js/status.js
@@ -36,7 +36,7 @@ $(document).ready(function () {
 
 				message += '<code class="text-info">';
 				if (node.Hostname == health.Details.ActiveNode.Hostname && node.Token == health.Details.ActiveNode.Token) {
-					message += '<span class="text-success">[Active since '+health.Details.ActiveNode.FirstSeenActive+']</span>';
+					message += '<span class="text-success">[Elected at '+health.Details.ActiveNode.FirstSeenActive+']</span>';
 				}
 				if (node.Hostname == health.Details.Hostname) {
     			message += ' <span class="text-primary">[This node]</span>';

--- a/resources/public/js/status.js
+++ b/resources/public/js/status.js
@@ -2,7 +2,7 @@
 function addStatusTableData(name, column1, column2) {
 	$("#orchestratorStatusTable").append(
 	        '<tr><td>' + name + '</td>' +
-                '<td><code class="text-info"><strong>' + column1 + '</strong></code></td>' +
+                '<td>' + column1 + '</td>' +
                 '<td><code class="text-info">' + column2 + '</code></td></tr>'
 	);
 }
@@ -27,14 +27,21 @@ $(document).ready(function () {
 				if (app_version == "") {
 					app_version = "unknown version";
 				}
-				var message = node.Hostname;
+				var message = '';
+				message += '<code class="text-info"><strong>';
+				message += node.Hostname;
+				message += ' <span class="text-info">[Running since '+node.FirstSeenActive+']</span>';
+				message += '</strong></code>';
+				message += '</br>';
+
+				message += '<code class="text-info">';
 				if (node.Hostname == health.Details.ActiveNode.Hostname && node.Token == health.Details.ActiveNode.Token) {
-					message += ' <span class="text-success">[Active since '+health.Details.ActiveNode.FirstSeenActive+']</span>';
+					message += '<span class="text-success">[Active since '+health.Details.ActiveNode.FirstSeenActive+']</span>';
 				}
 				if (node.Hostname == health.Details.Hostname) {
     			message += ' <span class="text-primary">[This node]</span>';
     		}
-				message += ' <span class="text-info">[Running since '+node.FirstSeenActive+']</span>';
+				message += '</code>';
 
     		addStatusTableData("Available node", message, app_version);
     	})


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/37

- `node_health` table has `first_seen_active` column: time of first report, i.e. startup time
- `active_node` table has `first_seen_active` column: time at which node became active (elected leader)
- Added `NodeHealth` structure and formalized much of the string manipulation voodoo.
- Web UI presents time of becoming active, startup time for each node.

cc @sjmudd 
