### PR TITLE
Fix api register request url for bulk-* calls

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -2469,8 +2469,8 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerRequest(m, "deregister-hostname-unresolve/:host/:port", this.DeregisterHostnameUnresolve)
 	this.registerRequest(m, "register-hostname-unresolve/:host/:port/:virtualname", this.RegisterHostnameUnresolve)
 	// Bulk access to information
-	this.registerRequest(m, "/api/bulk-instances", this.BulkInstances)
-	this.registerRequest(m, "/api/bulk-promotion-rules", this.BulkPromotionRules)
+	this.registerRequest(m, "bulk-instances", this.BulkInstances)
+	this.registerRequest(m, "bulk-promotion-rules", this.BulkPromotionRules)
 
 	// Agents
 	this.registerRequest(m, "agents", this.Agents)


### PR DESCRIPTION
Minor change as there was a difference between outbrain/orchestrator and github/orchestrator code and the api url registration was incorrect. This patch fixes that.
