### PR TITLE
Graceful takeover repoint replica

### DIFF
--- a/go/inst/cluster.go
+++ b/go/inst/cluster.go
@@ -42,6 +42,12 @@ func (this *ClusterInfo) ReadRecoveryInfo() {
 // filtersMatchCluster will see whether the given filters match the given cluster details
 func (this *ClusterInfo) filtersMatchCluster(filters []string) bool {
 	for _, filter := range filters {
+		if filter == this.ClusterName {
+			return true
+		}
+		if filter == this.ClusterAlias {
+			return true
+		}
 		if strings.HasPrefix(filter, "alias=") {
 			// Match by exact cluster alias name
 			alias := strings.SplitN(filter, "=", 2)[1]


### PR DESCRIPTION
At the end of `graceful-master-takeover`, the old master is set as replica of the promoted master, but without `START SLAVE`.

All that is done is a `CHANGE MASTER TO MASTER_HOST=..., MASTER_PORT=..., MASTER_LOG_FILE=..., MASTER_LOG_POS=...`

What's missing in this story is the `MASTER_USER` and `MASTER_PASSWORD`, which are likely to not exist, because the old master was like not having replication info.

So that leads to the case where even after positioning, the old master cant truly replicate from the promoted master. Nonetheless, it is placed in the correct position to assume replication once credential settings are applied.

Regardless, and catching a ride on this PR, we run better filter-to-alias matching for `RecoverMasterClusterFilters` and `RecoverIntermediateMasterClusterFilters`.
