### PR TITLE
Fixed md5 JavaScript dependency

### DIFF
--- a/resources/templates/cluster.tmpl
+++ b/resources/templates/cluster.tmpl
@@ -69,7 +69,6 @@
 
 <script src="{{.prefix}}/js/jquery-ui.min.js"></script>
 <script src="{{.prefix}}/js/d3.v3.min.js"></script>
-<script src="{{.prefix}}/js/md5.js"></script>
 <script src="{{.prefix}}/js/cluster-analysis-shared.js"></script>
 <script src="{{.prefix}}/js/cluster.js"></script>
 <script src="{{.prefix}}/js/cluster-tree.js"></script>

--- a/resources/templates/layout.tmpl
+++ b/resources/templates/layout.tmpl
@@ -13,6 +13,7 @@
 	<script type="text/javascript" src="{{.prefix}}/js/jquery.cookie-1.4.1.min.js"></script>
 	<script type="text/javascript" src="{{.prefix}}/js/corex.js"></script>
 	<script type="text/javascript" src="{{.prefix}}/js/corex-jquery.js"></script>
+	<script src="{{.prefix}}/js/md5.js"></script>
 	<script src="{{.prefix}}/js/common.js"></script>
 	<script src="{{.prefix}}/js/orchestrator.js"></script>
 	<link href="{{.prefix}}/bootstrap/css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
Since https://github.com/github/orchestrator/pull/52 some logic moved to `orchestrator.js`. This PR fixes a dependency on `md5.js`