### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,25 @@
-FROM golang:1.6-alpine
+FROM alpine
 
 EXPOSE  3000
 
-ADD . /go/src/github.com/github/orchestrator
-WORKDIR /go/src/github.com/github/orchestrator
+ENV GOPATH=/tmp/go
 
 RUN set -ex \
-    && apk add --no-cache --virtual .build-deps \
+    && apk add --update --no-cache --virtual .build-deps \
         bash \
         rsync \
         git \
+        go \
+        build-base \
+    && cd /tmp \
+    && { go get -d github.com/github/orchestrator ; : ; } \
+    && cd $GOPATH/src/github.com/github/orchestrator \
     && bash build.sh -b \
+    && cp ./docker/entrypoint.sh /entrypoint.sh \
     && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator -maxdepth 2)/ / \
     && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator-cli -maxdepth 2)/ / \
+    && cd / \
     && apk del .build-deps \
-    && rm -rf /tmp/orchestrator-release \
-    && cp ./docker/entrypoint.sh /entrypoint.sh
+    && rm -rf /tmp/*
 
 CMD /entrypoint.sh


### PR DESCRIPTION
### Issue
https://github.com/github/orchestrator/issues/66

### Description

This PR reduces the size of the docker image from 3xxMB to 40MB.
Started from importing from a smaller image, plain alpine, then installed go and build-base to compile the project.
All the rest is almost the same as the original, just opted to store GOPATH under /tmp and also delete it at the end of the build.

I hope it helps. Keep up the great work!
Orchestrator is a hell of a tool!
