### PR TITLE
Made pseudo gtid event aware of server read_only

### DIFF
--- a/docs/pseudo-gtid.md
+++ b/docs/pseudo-gtid.md
@@ -50,9 +50,13 @@ create event if not exists
   on completion preserve
   enable
   do
-    begin
+    main: begin
       DECLARE lock_result INT;
       DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+
+      IF @@global.read_only = 1 THEN
+        LEAVE main;
+      END IF;
 
       set @connection_id := connection_id();
       set @now := now();
@@ -92,7 +96,7 @@ create event if not exists
         ;
         SET lock_result = RELEASE_LOCK('pseudo_gtid_status');
       END IF;
-    end
+    end main
 $$
 
 delimiter ;

--- a/resources/pseudo-gtid/pseudo-gtid.sql
+++ b/resources/pseudo-gtid/pseudo-gtid.sql
@@ -40,9 +40,13 @@ create event if not exists
   on completion preserve
   enable
   do
-    begin
+    main: begin
       DECLARE lock_result INT;
       DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+
+      IF @@global.read_only = 1 THEN
+        LEAVE main;
+      END IF;
 
       SET lock_result = GET_LOCK('pseudo_gtid_status', 0);
       IF lock_result = 1 THEN
@@ -82,7 +86,7 @@ create event if not exists
         ;
         SET lock_result = RELEASE_LOCK('pseudo_gtid_status');
       END IF;
-    end
+    end main
 $$
 
 delimiter ;


### PR DESCRIPTION
This PR makes the pseudo-gtid insertion event aware of the server's `read_only` flag. This way, the event can be loaded on co-masters without corrupting the GTID. 

With the previous version you need to manually make sure that you insert GTID binlog event only on master by running an external process. The event scheduler is disabled on replicas but in a co-master situation both servers are masters and execute events.