### PR TITLE
Add more detailed timing metrics to orchestrator

### DIFF
--- a/docs/using-the-web-api.md
+++ b/docs/using-the-web-api.md
@@ -62,9 +62,13 @@ The following bulk retrieval rules are intended for allowing the information ins
 * `/api/bulk-instance`: provide a json list of instances in the form of Hostname Port
 * `/api/bulk-promotion-rules`: provide a json list of instance promotion rules in the form of Hostname Port PromotionRule
 
-The following monitoring URLs provide more timing information for discovery processes
+The following URLs for collecting monitoring information
+* `/api/discovery-metrics-raw/:seconds`: list the raw discovery metrics for the last specified number of seconds. Raw discovery metric data is kept for DiscoveryCollectionRetentionSeconds seconds (default: 120)
+* `/api/discovery-metrics-aggregated/:seconds`: provide aggregated data for the discovery metrics over the last specified number of seconds.
 * `/api/discovery-queue-metrics-raw/:seconds`: return a list of active and queued number discovery keys over the requested number of seconds
 * `/api/discovery-queue-metrics-aggregated/:seconds`: return aggregated data based on the raw data mentioned above
+* `/api/backend-query-metrics-raw/:seconds`: return the raw metrics on queries sent to the backend in the period specified
+* `/api/backend-query-metrics-aggregated/:seconds`: return a set of aggregated values based on the raw numbers above
 
 #### Instance JSON breakdown
 

--- a/go/app/http.go
+++ b/go/app/http.go
@@ -20,8 +20,10 @@ import (
 	"net"
 	nethttp "net/http"
 	"strings"
+	"time"
 
 	"github.com/github/orchestrator/go/agent"
+	"github.com/github/orchestrator/go/collection"
 	"github.com/github/orchestrator/go/config"
 	"github.com/github/orchestrator/go/http"
 	"github.com/github/orchestrator/go/inst"
@@ -35,11 +37,14 @@ import (
 	"github.com/openark/golib/log"
 )
 
+const discoveryMetricsName = "DISCOVERY_METRICS"
+
 var sslPEMPassword []byte
 var agentSSLPEMPassword []byte
+var discoveryMetrics *collection.Collection
 
 // Http starts serving
-func Http(discovery bool) {
+func Http(continuousDiscovery bool) {
 	promptForSSLPasswords()
 	process.ContinuousRegistration(process.OrchestratorExecutionHttpMode, "")
 
@@ -47,7 +52,7 @@ func Http(discovery bool) {
 	if config.Config.ServeAgentsHttp {
 		go agentsHttp()
 	}
-	standardHttp(discovery)
+	standardHttp(continuousDiscovery)
 }
 
 // Iterate over the private keys and get passwords for them
@@ -66,7 +71,7 @@ func promptForSSLPasswords() {
 }
 
 // standardHttp starts serving HTTP or HTTPS (api/web) requests, to be used by normal clients
-func standardHttp(discovery bool) {
+func standardHttp(continuousDiscovery bool) {
 	m := martini.Classic()
 
 	switch strings.ToLower(config.Config.AuthenticationMethod) {
@@ -114,7 +119,11 @@ func standardHttp(discovery bool) {
 
 	inst.SetMaintenanceOwner(process.ThisHostname)
 
-	if discovery {
+	if continuousDiscovery {
+		// start to expire metric collection info
+		discoveryMetrics = collection.CreateOrReturnCollection(discoveryMetricsName)
+		discoveryMetrics.SetExpirePeriod(time.Duration(config.Config.DiscoveryCollectionRetentionSeconds) * time.Second)
+
 		log.Info("Starting Discovery")
 		go logic.ContinuousDiscovery()
 	}

--- a/go/collection/collection.go
+++ b/go/collection/collection.go
@@ -1,0 +1,292 @@
+/*
+   Copyright 2017 Simon J Mudd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+
+Package collection holds routines for collecting "high frequency"
+metrics and handling their auto-expiry based on a configured retention
+time. This becomes more interesting as the number of MySQL servers
+monitored by orchestrator increases.
+
+Most monitoring systems look at different metrics over a period
+like 1, 10, 30 or 60 seconds but even at second resolution orchestrator
+may have polled a number of servers.
+
+It can be helpful to collect the raw values, and then allow external
+monitoring to pull via an http api call either pre-cooked aggregate
+data or the raw data for custom analysis over the period requested.
+
+This is expected to be used for the following types of metric:
+
+* discovery metrics (time to poll a MySQL server and collect status)
+* queue metrics (statistics within the discovery queue itself)
+* query metrics (statistics on the number of queries made to the
+  backend MySQL database)
+
+Orchestrator code can just add a new metric without worrying about
+removing it later, and other code which serves API requests can
+pull out the data when needed for the requested time period.
+
+For current metrics two api urls have been provided: one provides
+the raw data and the other one provides a single set of aggregate
+data which is suitable for easy collection by monitoring systems.
+
+Expiry is triggered by default if the collection is created via
+CreateOrReturnCollection() and uses an expiry period of
+DiscoveryCollectionRetentionSeconds. It can also be enabled by
+calling StartAutoExpiration() after setting the required expire
+period with SetExpirePeriod().
+
+This will trigger periodic calls (every second) to ensure the removal
+of metrics which have passed the time specified. Not enabling expiry
+will mean data is collected but never freed which will make
+orchestrator run out of memory eventually.
+
+Current code uses DiscoveryCollectionRetentionSeconds as the
+time to keep metric data.
+
+*/
+package collection
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	//	"github.com/openark/golib/log"
+
+	"github.com/github/orchestrator/go/config"
+)
+
+// Metric is an interface containing a metric
+type Metric interface {
+	When() time.Time // when the metric was taken
+}
+
+// Collection contains a collection of Metrics
+type Collection struct {
+	sync.Mutex        // for locking the structure
+	monitoring   bool // am I monitoring the queue size?
+	collection   []Metric
+	done         chan struct{} // to indicate that we are finishing expiry processing
+	expirePeriod time.Duration // time to keep the collection information for
+}
+
+// hard-coded at every second
+const defaultExpireTickerPeriod = time.Second
+
+// backendMetricCollection contains the last N backend "channelled"
+// metrics which can then be accessed via an API call for monitoring.
+var (
+	namedCollection     map[string](*Collection)
+	namedCollectionLock sync.Mutex
+)
+
+func init() {
+	namedCollection = make(map[string](*Collection))
+}
+
+// StopMonitoring stops monitoring all the collections
+func StopMonitoring() {
+	for _, q := range namedCollection {
+		q.StopAutoExpiration()
+	}
+}
+
+// CreateOrReturnCollection allows for creation of a new collection or
+// returning a pointer to an existing one given the name. This allows access
+// to the data structure from the api interface (http/api.go) and also when writing (inst).
+func CreateOrReturnCollection(name string) *Collection {
+	namedCollectionLock.Lock()
+	defer namedCollectionLock.Unlock()
+	if q, found := namedCollection[name]; found {
+		return q
+	}
+
+	qmc := &Collection{
+		collection: nil,
+		done:       make(chan struct{}),
+		// WARNING: use a different configuration name
+		expirePeriod: time.Duration(config.Config.DiscoveryCollectionRetentionSeconds) * time.Second,
+	}
+	go qmc.StartAutoExpiration()
+
+	namedCollection[name] = qmc
+
+	return qmc
+}
+
+// SetExpirePeriod determines after how long the collected data should be removed
+func (c *Collection) SetExpirePeriod(duration time.Duration) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.expirePeriod = duration
+}
+
+// ExpirePeriod returns the currently configured expiration period
+func (c *Collection) ExpirePeriod() time.Duration {
+	c.Lock()
+	defer c.Unlock()
+	return c.expirePeriod
+}
+
+// StopAutoExpiration prepares to stop by terminating the auto-expiration process
+func (c *Collection) StopAutoExpiration() {
+	if c == nil {
+		return
+	}
+	c.Lock()
+	if !c.monitoring {
+		c.Unlock()
+		return
+	}
+	c.monitoring = false
+	c.Unlock()
+
+	// no locking here deliberately
+	c.done <- struct{}{}
+}
+
+// StartAutoExpiration initiates the auto expiry procedure which
+// periodically checks for metrics in the collection which need to
+// be expired according to bc.ExpirePeriod.
+func (c *Collection) StartAutoExpiration() {
+	if c == nil {
+		return
+	}
+	c.Lock()
+	if c.monitoring {
+		c.Unlock()
+		return
+	}
+	c.monitoring = true
+	c.Unlock()
+
+	// log.Infof("StartAutoExpiration: %p with expirePeriod: %v", c, c.expirePeriod)
+	ticker := time.NewTicker(defaultExpireTickerPeriod)
+
+	for {
+		select {
+		case <-ticker.C: // do the periodic expiry
+			c.removeBefore(time.Now().Add(-c.expirePeriod))
+		case <-c.done: // stop the ticker and return
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+// Metrics returns a slice containing all the metric values
+func (c *Collection) Metrics() []Metric {
+	if c == nil {
+		return nil
+	}
+	c.Lock()
+	defer c.Unlock()
+
+	if len(c.collection) == 0 {
+		return nil // nothing to return
+	}
+	return c.collection
+}
+
+// Since returns the Metrics on or after the given time. We assume
+// the metrics are stored in ascending time.
+// Iterate backwards until we reach the first value before the given time
+// or the end of the array.
+func (c *Collection) Since(t time.Time) ([]Metric, error) {
+	if c == nil {
+		return nil, errors.New("Collection.Since: c == nil")
+	}
+	c.Lock()
+	defer c.Unlock()
+	if len(c.collection) == 0 {
+		return nil, nil // nothing to return
+	}
+	last := len(c.collection)
+	first := last - 1
+
+	done := false
+	for !done {
+		if c.collection[first].When().After(t) || c.collection[first].When().Equal(t) {
+			if first == 0 {
+				break // as can't go lower
+			}
+			first--
+		} else {
+			if first != last {
+				first++ // go back one (except if we're already at the end)
+			}
+			break
+		}
+	}
+
+	return c.collection[first:last], nil
+}
+
+// removeBefore is called by StartAutoExpiration and removes collection values
+// before the given time.
+func (c *Collection) removeBefore(t time.Time) error {
+	if c == nil {
+		return errors.New("Collection.removeBefore: c == nil")
+	}
+	c.Lock()
+	defer c.Unlock()
+
+	cLen := len(c.collection)
+	if cLen == 0 {
+		return nil // we have a collection but no data
+	}
+	// remove old data here.
+	first := 0
+	done := false
+	for !done {
+		if c.collection[first].When().Before(t) {
+			first++
+			if first == cLen {
+				break
+			}
+		} else {
+			first--
+			break
+		}
+	}
+
+	// get the interval we need.
+	if first == len(c.collection) {
+		c.collection = nil // remove all entries
+	} else if first != -1 {
+		c.collection = c.collection[first:]
+	}
+	return nil // no errors
+}
+
+// Append a new Metric to the existing collection
+func (c *Collection) Append(m Metric) error {
+	if c == nil {
+		return errors.New("Collection.Append: c == nil")
+	}
+	c.Lock()
+	defer c.Unlock()
+	// we don't want to add nil metrics
+	if c == nil {
+		return errors.New("Collection.Append: c == nil")
+	}
+	c.collection = append(c.collection, m)
+
+	return nil
+}

--- a/go/collection/collection_test.go
+++ b/go/collection/collection_test.go
@@ -1,0 +1,104 @@
+/*
+   Copyright 2017 Simon J Mudd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package collection
+
+import (
+	"testing"
+	"time"
+)
+
+var randomString = []string{
+	"RANDOM_STRING",
+	"SOME_OTHER_STRING",
+}
+
+// some random base timestamp
+var ts = time.Date(2016, 12, 27, 13, 36, 40, 0, time.Local)
+
+// TestCreateOrReturn tests the creation of a named Collection
+func TestCreateOrReturnCollection(t *testing.T) {
+	name := randomString[0]
+	// check we get the same reference with a single name
+	c1 := CreateOrReturnCollection(name)
+	if c1 == nil {
+		// should not be empty
+		t.Errorf("TestCreateOrReturn: c1 == nil", name)
+	}
+	c2 := CreateOrReturnCollection(name)
+	if c2 == nil || c2 != c1 {
+		t.Errorf("TestCreateOrReturn: c2 == nil || c2 != c1")
+		// should not be empty, or different to c1
+	}
+
+	name = randomString[1]
+	// check we get a new reference and it's different to what we had before
+	c3 := CreateOrReturnCollection(name)
+	if c3 == nil || c3 == c1 {
+		// should not be empty, or same as c1
+		t.Errorf("TestCreateOrReturn: c3 == nil || c3 == c1")
+	}
+	c4 := CreateOrReturnCollection(name)
+	// check our reference matches c3 but not c2/c1
+	if c4 == nil || c4 != c3 || c4 == c2 {
+		t.Errorf("TestCreateOrReturn: c3 == nil || c4 != c3 || c4 == c2")
+	}
+}
+
+// TestExpirePeriod checks that the set expire period is returned
+func TestExpirePeriod(t *testing.T) {
+	oneSecond := time.Second
+	twoSeconds := 2 * oneSecond
+
+	// create a new collection
+	c := &Collection{}
+
+	// check if we change it we get back the value we provided
+	c.SetExpirePeriod(oneSecond)
+	if c.ExpirePeriod() != oneSecond {
+		t.Errorf("TestExpirePeriod: did not get back oneSecond")
+	}
+
+	// change the period and check again
+	c.SetExpirePeriod(twoSeconds)
+	if c.ExpirePeriod() != twoSeconds {
+		t.Errorf("TestExpirePeriod: did not get back twoSeconds")
+	}
+}
+
+// dummy structure for testing
+type testMetric struct {
+}
+
+func (tm *testMetric) When() time.Time {
+	return ts
+}
+
+// check that Append() works as expected
+func TestAppend(t *testing.T) {
+	c := &Collection{}
+
+	if len(c.Metrics()) != 0 {
+		t.Errorf("TestAppend: len(Metrics) = %d, expecting %d", len(c.Metrics()), 0)
+	}
+	for _, v := range []int{1, 2, 3} {
+		tm := &testMetric{}
+		c.Append(tm)
+		if len(c.Metrics()) != v {
+			t.Errorf("TestExpirePeriod: len(Metrics) = %d, expecting %d", len(c.Metrics()), v)
+		}
+	}
+}

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -84,6 +84,7 @@ type Configuration struct {
 	DiscoveryMaxConcurrency                      uint     // Number of goroutines doing hosts discovery
 	DiscoveryQueueCapacity                       uint     // Buffer size of the discovery queue. Should be greater than the number of DB instances being discovered
 	DiscoveryQueueMaxStatisticsSize              int      // The maximum number of individual secondly statistics taken of the discovery queue
+	DiscoveryCollectionRetentionSeconds          uint     // Number of seconds to retain the discovery collection information
 	InstanceBulkOperationsWaitTimeoutSeconds     uint     // Time to wait on a single instance when doing bulk (many instances) operation
 	ActiveNodeExpireSeconds                      uint     // Maximum time to wait for active node to send keepalive before attempting to take over as active node.
 	NodeHealthExpiry                             bool     // Do we expire the node_health table? Usually this is true but it might be disabled on command line tools if an orchestrator daemon is running.
@@ -251,6 +252,7 @@ func newConfiguration() *Configuration {
 		DiscoveryMaxConcurrency:                      300,
 		DiscoveryQueueCapacity:                       100000,
 		DiscoveryQueueMaxStatisticsSize:              120,
+		DiscoveryCollectionRetentionSeconds:          120,
 		InstanceBulkOperationsWaitTimeoutSeconds:     10,
 		ActiveNodeExpireSeconds:                      5,
 		NodeHealthExpiry:                             true,

--- a/go/discovery/aggregated.go
+++ b/go/discovery/aggregated.go
@@ -1,0 +1,175 @@
+/*
+   Copyright 2017 Simon J Mudd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package discovery
+
+import (
+	"time"
+
+	"github.com/montanaflynn/stats"
+
+	"github.com/github/orchestrator/go/collection"
+)
+
+// AggregatedDiscoveryMetrics contains aggregated metrics for instance discovery.
+// Called from api/discovery-metrics-aggregated/:seconds
+type AggregatedDiscoveryMetrics struct {
+	FirstSeen                       time.Time // timestamp of the first data seen
+	LastSeen                        time.Time // timestamp of the last data seen
+	CountDistinctInstanceKeys       int       // number of distinct Instances seen
+	CountDistinctFailedInstanceKeys int       // number of distinct Instances which failed
+	FailedDiscoveries               uint64    // number of failed discoveries
+	SuccessfulDiscoveries           uint64    // number of successful discoveries
+	MeanTotalSeconds                float64
+	MeanBackendSeconds              float64
+	MeanInstanceSeconds             float64
+	FailedMeanTotalSeconds          float64
+	FailedMeanBackendSeconds        float64
+	FailedMeanInstanceSeconds       float64
+	MaxTotalSeconds                 float64
+	MaxBackendSeconds               float64
+	MaxInstanceSeconds              float64
+	FailedMaxTotalSeconds           float64
+	FailedMaxBackendSeconds         float64
+	FailedMaxInstanceSeconds        float64
+	MedianTotalSeconds              float64
+	MedianBackendSeconds            float64
+	MedianInstanceSeconds           float64
+	FailedMedianTotalSeconds        float64
+	FailedMedianBackendSeconds      float64
+	FailedMedianInstanceSeconds     float64
+	P95TotalSeconds                 float64
+	P95BackendSeconds               float64
+	P95InstanceSeconds              float64
+	FailedP95TotalSeconds           float64
+	FailedP95BackendSeconds         float64
+	FailedP95InstanceSeconds        float64
+}
+
+// aggregate returns the aggregate values of the given metrics (assumed to be Metric)
+func aggregate(results []collection.Metric) AggregatedDiscoveryMetrics {
+	if len(results) == 0 {
+		return AggregatedDiscoveryMetrics{}
+	}
+
+	var (
+		first time.Time
+		last  time.Time
+	)
+
+	counters := make(map[string]uint64)             // map of string based counters
+	names := make(map[string](map[string]int))      // map of string based names (using a map)
+	timings := make(map[string](stats.Float64Data)) // map of string based float64 values
+
+	// initialise counters
+	for _, v := range []string{"FailedDiscoveries", "Discoveries"} {
+		counters[v] = 0
+	}
+	// initialise names
+	for _, v := range []string{"InstanceKeys", "FailedInstanceKeys"} {
+		names[v] = make(map[string]int)
+	}
+	// initialise timers
+	for _, v := range []string{"TotalSeconds", "BackendSeconds", "InstanceSeconds", "FailedTotalSeconds", "FailedBackendSeconds", "FailedInstanceSeconds"} {
+		timings[v] = nil
+	}
+
+	// iterate over results storing required values
+	for _, v2 := range results {
+		v := v2.(*Metric) // convert to the right type
+
+		// first and last
+		if first.IsZero() || first.After(v.Timestamp) {
+			first = v.Timestamp
+		}
+		if last.Before(v.Timestamp) {
+			last = v.Timestamp
+		}
+
+		// successful names
+		x := names["InstanceKeys"]
+		x[v.InstanceKey.String()] = 1 // Value doesn't matter
+		names["InstanceKeys"] = x
+		// failed names
+		if v.Err != nil {
+			x := names["FailedInstanceKeys"]
+			x[v.InstanceKey.String()] = 1 // Value doesn't matter
+			names["FailedInstanceKeys"] = x
+		}
+
+		// discoveries
+		counters["Discoveries"]++
+		if v.Err != nil {
+			counters["FailedDiscoveries"]++
+		}
+
+		// All timings
+		timings["TotalSeconds"] = append(timings["TotalSeconds"], v.TotalLatency.Seconds())
+		timings["BackendSeconds"] = append(timings["BackendSeconds"], v.BackendLatency.Seconds())
+		timings["InstanceSeconds"] = append(timings["InstanceSeconds"], v.InstanceLatency.Seconds())
+
+		// Failed timings
+		if v.Err != nil {
+			timings["FailedTotalSeconds"] = append(timings["FailedTotalSeconds"], v.TotalLatency.Seconds())
+			timings["FailedBackendSeconds"] = append(timings["FailedBackendSeconds"], v.BackendLatency.Seconds())
+			timings["FailedInstanceSeconds"] = append(timings["FailedInstanceSeconds"], v.InstanceLatency.Seconds())
+		}
+	}
+
+	return AggregatedDiscoveryMetrics{
+		FirstSeen:                       first,
+		LastSeen:                        last,
+		CountDistinctInstanceKeys:       len(names["InstanceKeys"]),
+		CountDistinctFailedInstanceKeys: len(names["FailedInstanceKeys"]),
+		FailedDiscoveries:               counters["FailedDiscoveries"],
+		SuccessfulDiscoveries:           counters["Discoveries"],
+		MeanTotalSeconds:                mean(timings["TotalSeconds"]),
+		MeanBackendSeconds:              mean(timings["BackendSeconds"]),
+		MeanInstanceSeconds:             mean(timings["InstanceSeconds"]),
+		FailedMeanTotalSeconds:          mean(timings["FailedTotalSeconds"]),
+		FailedMeanBackendSeconds:        mean(timings["FailedBackendSeconds"]),
+		FailedMeanInstanceSeconds:       mean(timings["FailedInstanceSeconds"]),
+		MaxTotalSeconds:                 max(timings["TotalSeconds"]),
+		MaxBackendSeconds:               max(timings["BackendSeconds"]),
+		MaxInstanceSeconds:              max(timings["InstanceSeconds"]),
+		FailedMaxTotalSeconds:           max(timings["FailedTotalSeconds"]),
+		FailedMaxBackendSeconds:         max(timings["FailedBackendSeconds"]),
+		FailedMaxInstanceSeconds:        max(timings["FailedInstanceSeconds"]),
+		MedianTotalSeconds:              median(timings["TotalSeconds"]),
+		MedianBackendSeconds:            median(timings["BackendSeconds"]),
+		MedianInstanceSeconds:           median(timings["InstanceSeconds"]),
+		FailedMedianTotalSeconds:        median(timings["FailedTotalSeconds"]),
+		FailedMedianBackendSeconds:      median(timings["FailedBackendSeconds"]),
+		FailedMedianInstanceSeconds:     median(timings["FailedInstanceSeconds"]),
+		P95TotalSeconds:                 percentile(timings["TotalSeconds"], 95),
+		P95BackendSeconds:               percentile(timings["BackendSeconds"], 95),
+		P95InstanceSeconds:              percentile(timings["InstanceSeconds"], 95),
+		FailedP95TotalSeconds:           percentile(timings["FailedTotalSeconds"], 95),
+		FailedP95BackendSeconds:         percentile(timings["FailedBackendSeconds"], 95),
+		FailedP95InstanceSeconds:        percentile(timings["FailedInstanceSeconds"], 95),
+	}
+}
+
+// AggregatedSince returns a large number of aggregated metrics
+// based on the raw metrics collected since the given time.
+func AggregatedSince(c *collection.Collection, t time.Time) (AggregatedDiscoveryMetrics, error) {
+	results, err := c.Since(t)
+	if err != nil {
+		return AggregatedDiscoveryMetrics{}, err
+	}
+
+	return aggregate(results), nil
+}

--- a/go/discovery/funcs.go
+++ b/go/discovery/funcs.go
@@ -1,3 +1,19 @@
+/*
+   Copyright 2017 Simon J Mudd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package discovery
 
 import (

--- a/go/discovery/metric.go
+++ b/go/discovery/metric.go
@@ -19,6 +19,7 @@ package discovery
 // Collect discovery metrics and manage their storage and retrieval for monitoring purposes.
 
 import (
+	"reflect"
 	"time"
 
 	"github.com/github/orchestrator/go/inst"
@@ -39,29 +40,13 @@ func (m Metric) When() time.Time {
 	return m.Timestamp
 }
 
-// Equal compares if to Metrics are the same
-func (m *Metric) Equal(m2 *Metric) bool {
-	if m == nil && m2 == nil {
-		return true // assume the same "empty" value
-	}
-	if m == nil || m2 == nil {
-		return false // one or the other is "empty" so they must be different
-	}
-	return m.Timestamp == m2.Timestamp &&
-		m.InstanceKey == m2.InstanceKey &&
-		m.BackendLatency == m2.BackendLatency &&
-		m.InstanceLatency == m2.InstanceLatency &&
-		m.TotalLatency == m2.TotalLatency &&
-		m.Err == m2.Err
-}
-
 // MetricsEqual compares two slices of Metrics to see if they are the same
 func MetricsEqual(m1, m2 [](*Metric)) bool {
 	if len(m1) != len(m2) {
 		return false
 	}
 	for i := range m1 {
-		if !m1[i].Equal(m2[i]) {
+		if !reflect.DeepEqual(m1[i],m2[i]) {
 			return false
 		}
 	}

--- a/go/discovery/metric.go
+++ b/go/discovery/metric.go
@@ -19,7 +19,6 @@ package discovery
 // Collect discovery metrics and manage their storage and retrieval for monitoring purposes.
 
 import (
-	"reflect"
 	"time"
 
 	"github.com/github/orchestrator/go/inst"
@@ -38,17 +37,4 @@ type Metric struct {
 // When did the metric happen
 func (m Metric) When() time.Time {
 	return m.Timestamp
-}
-
-// MetricsEqual compares two slices of Metrics to see if they are the same
-func MetricsEqual(m1, m2 [](*Metric)) bool {
-	if len(m1) != len(m2) {
-		return false
-	}
-	for i := range m1 {
-		if !reflect.DeepEqual(m1[i],m2[i]) {
-			return false
-		}
-	}
-	return true
 }

--- a/go/discovery/metric.go
+++ b/go/discovery/metric.go
@@ -1,0 +1,69 @@
+/*
+   Copyright 2017 Simon J Mudd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package discovery
+
+// Collect discovery metrics and manage their storage and retrieval for monitoring purposes.
+
+import (
+	"time"
+
+	"github.com/github/orchestrator/go/inst"
+)
+
+// Metric holds a set of information of instance discovery metrics
+type Metric struct {
+	Timestamp       time.Time        // time the collection was taken
+	InstanceKey     inst.InstanceKey // instance being monitored
+	BackendLatency  time.Duration    // time taken talking to the backend
+	InstanceLatency time.Duration    // time taken talking to the instance
+	TotalLatency    time.Duration    // total time taken doing the discovery
+	Err             error            // error (if applicable) doing the discovery process
+}
+
+// When did the metric happen
+func (m Metric) When() time.Time {
+	return m.Timestamp
+}
+
+// Equal compares if to Metrics are the same
+func (m *Metric) Equal(m2 *Metric) bool {
+	if m == nil && m2 == nil {
+		return true // assume the same "empty" value
+	}
+	if m == nil || m2 == nil {
+		return false // one or the other is "empty" so they must be different
+	}
+	return m.Timestamp == m2.Timestamp &&
+		m.InstanceKey == m2.InstanceKey &&
+		m.BackendLatency == m2.BackendLatency &&
+		m.InstanceLatency == m2.InstanceLatency &&
+		m.TotalLatency == m2.TotalLatency &&
+		m.Err == m2.Err
+}
+
+// MetricsEqual compares two slices of Metrics to see if they are the same
+func MetricsEqual(m1, m2 [](*Metric)) bool {
+	if len(m1) != len(m2) {
+		return false
+	}
+	for i := range m1 {
+		if !m1[i].Equal(m2[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/go/discovery/metric_json.go
+++ b/go/discovery/metric_json.go
@@ -26,10 +26,10 @@ import (
 	"github.com/github/orchestrator/go/collection"
 )
 
-// myfloat is to force the JSON output to show 3 decimal places
-type myfloat float64
+// formattedFloat is to force the JSON output to show 3 decimal places
+type formattedFloat float64
 
-func (m myfloat) String() string {
+func (m formattedFloat) String() string {
 	return fmt.Sprintf(".3f", m)
 }
 
@@ -38,9 +38,9 @@ type MetricJSON struct {
 	Timestamp              time.Time
 	Hostname               string
 	Port                   int
-	BackendLatencySeconds  myfloat
-	InstanceLatencySeconds myfloat
-	TotalLatencySeconds    myfloat
+	BackendLatencySeconds  formattedFloat
+	InstanceLatencySeconds formattedFloat
+	TotalLatencySeconds    formattedFloat
 	Err                    error
 }
 
@@ -63,9 +63,9 @@ func JSONSince(c *collection.Collection, t time.Time) ([](MetricJSON), error) {
 			Timestamp: m.Timestamp,
 			Hostname:  m.InstanceKey.Hostname,
 			Port:      m.InstanceKey.Port,
-			BackendLatencySeconds:  myfloat(m.BackendLatency.Seconds()),
-			InstanceLatencySeconds: myfloat(m.InstanceLatency.Seconds()),
-			TotalLatencySeconds:    myfloat(m.TotalLatency.Seconds()),
+			BackendLatencySeconds:  formattedFloat(m.BackendLatency.Seconds()),
+			InstanceLatencySeconds: formattedFloat(m.InstanceLatency.Seconds()),
+			TotalLatencySeconds:    formattedFloat(m.TotalLatency.Seconds()),
 			Err:                    m.Err,
 		}
 		s = append(s, mj)

--- a/go/discovery/metric_json.go
+++ b/go/discovery/metric_json.go
@@ -1,0 +1,74 @@
+/*
+   Copyright 2017 Simon J Mudd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package discovery
+
+// Collect discovery metrics and manage their storage and retrieval for monitoring purposes.
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/github/orchestrator/go/collection"
+)
+
+// myfloat is to force the JSON output to show 3 decimal places
+type myfloat float64
+
+func (m myfloat) String() string {
+	return fmt.Sprintf(".3f", m)
+}
+
+// MetricJSON holds a structure which represents some discovery latency information
+type MetricJSON struct {
+	Timestamp              time.Time
+	Hostname               string
+	Port                   int
+	BackendLatencySeconds  myfloat
+	InstanceLatencySeconds myfloat
+	TotalLatencySeconds    myfloat
+	Err                    error
+}
+
+// JSONSince returns an API response of discovery metric collection information
+// in a printable JSON format.
+func JSONSince(c *collection.Collection, t time.Time) ([](MetricJSON), error) {
+	if c == nil {
+		return nil, errors.New("MetricCollection.JSONSince: c == nil")
+	}
+	raw, err := c.Since(t)
+	if err != nil {
+		return nil, err
+	}
+
+	// build up JSON response for each Metric we received
+	var s []MetricJSON
+	for i := range raw {
+		m := raw[i].(*Metric) // convert back to a real Metric rather than collection.Metric interface
+		mj := MetricJSON{
+			Timestamp: m.Timestamp,
+			Hostname:  m.InstanceKey.Hostname,
+			Port:      m.InstanceKey.Port,
+			BackendLatencySeconds:  myfloat(m.BackendLatency.Seconds()),
+			InstanceLatencySeconds: myfloat(m.InstanceLatency.Seconds()),
+			TotalLatencySeconds:    myfloat(m.TotalLatency.Seconds()),
+			Err:                    m.Err,
+		}
+		s = append(s, mj)
+	}
+	return s, nil
+}

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -185,9 +185,9 @@ func discoverInstance(instanceKey inst.InstanceKey) {
 		})
 		log.Warningf("discoverInstance(%+v) instance is nil in %.3fs (Backend: %.3fs, Instance: %.3fs), error=%+v",
 			instanceKey,
-			totalLatency,
-			backendLatency,
-			instanceLatency,
+			totalLatency.Seconds(),
+			backendLatency.Seconds(),
+			instanceLatency.Seconds(),
 			err)
 		return
 	}
@@ -204,9 +204,9 @@ func discoverInstance(instanceKey inst.InstanceKey) {
 		instance.Key,
 		instance.MasterKey,
 		instance.Version,
-		totalLatency,
-		backendLatency,
-		instanceLatency)
+		totalLatency.Seconds(),
+		backendLatency.Seconds(),
+		instanceLatency.Seconds())
 
 	if atomic.LoadInt64(&isElectedNode) == 0 {
 		// Maybe this node was elected before, but isn't elected anymore.

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/github/orchestrator/go/agent"
+	"github.com/github/orchestrator/go/collection"
 	"github.com/github/orchestrator/go/config"
 	"github.com/github/orchestrator/go/discovery"
 	"github.com/github/orchestrator/go/inst"
@@ -32,7 +33,10 @@ import (
 	"github.com/openark/golib/log"
 	"github.com/patrickmn/go-cache"
 	"github.com/rcrowley/go-metrics"
+	"github.com/sjmudd/stopwatch"
 )
+
+const discoveryMetricsName = "DISCOVERY_METRICS"
 
 // discoveryQueue is a channel of deduplicated instanceKey-s
 // that were requested for discovery.  It can be continuously updated
@@ -44,6 +48,7 @@ var failedDiscoveriesCounter = metrics.NewCounter()
 var discoveryQueueLengthGauge = metrics.NewGauge()
 var discoveryRecentCountGauge = metrics.NewGauge()
 var isElectedGauge = metrics.NewGauge()
+var discoveryMetrics = collection.CreateOrReturnCollection(discoveryMetricsName)
 
 var isElectedNode int64 = 0
 
@@ -71,13 +76,21 @@ func acceptSignals() {
 	c := make(chan os.Signal, 1)
 
 	signal.Notify(c, syscall.SIGHUP)
+	signal.Notify(c, syscall.SIGTERM)
 	go func() {
 		for sig := range c {
 			switch sig {
 			case syscall.SIGHUP:
 				log.Debugf("Received SIGHUP. Reloading configuration")
-				config.Reload()
 				inst.AuditOperation("reload-configuration", nil, "Triggered via SIGHUP")
+				config.Reload()
+				discoveryMetrics.SetExpirePeriod(time.Duration(config.Config.DiscoveryCollectionRetentionSeconds) * time.Second)
+			case syscall.SIGTERM:
+				log.Debugf("Received SIGTERM. Shutting down orchestrator")
+				discoveryMetrics.StopAutoExpiration()
+				// probably should poke other go routines to stop cleanly here ...
+				inst.AuditOperation("shutdown", nil, "Triggered via SIGTERM")
+				os.Exit(0)
 			}
 		}
 	}()
@@ -112,12 +125,21 @@ func handleDiscoveryRequests() {
 	}
 }
 
-// discoverInstance will attempt discovering an instance (unless it is already up to date) and will
-// list down its master and replicas (if any) for further discovery.
+// discoverInstance will attempt to discover (poll) an instance (unless
+// it is already up to date) and will also ensure that its master and
+// replicas (if any) are also checked.
 func discoverInstance(instanceKey inst.InstanceKey) {
-	start := time.Now()
+	// create stopwatch entries
+	latency := stopwatch.NewNamedStopwatch()
+	latency.AddMany([]string{
+		"backend",
+		"instance",
+		"total"})
+	latency.Start("total") // start the total stopwatch (not changed anywhere else)
+
 	defer func() {
-		discoveryTime := time.Since(start)
+		latency.Stop("total")
+		discoveryTime := latency.Elapsed("total")
 		if discoveryTime > time.Duration(config.Config.InstancePollSeconds)*time.Second {
 			log.Warningf("discoverInstance for key %v took %.4fs", instanceKey, discoveryTime.Seconds())
 		}
@@ -133,7 +155,9 @@ func discoverInstance(instanceKey inst.InstanceKey) {
 		return
 	}
 
+	latency.Start("backend")
 	instance, found, err := inst.ReadInstance(&instanceKey)
+	latency.Stop("backend")
 	if found && instance.IsUpToDate && instance.IsLastCheckValid {
 		// we've already discovered this one. Skip!
 		return
@@ -142,16 +166,43 @@ func discoverInstance(instanceKey inst.InstanceKey) {
 	discoveriesCounter.Inc(1)
 
 	// First we've ever heard of this instance. Continue investigation:
-	instance, err = inst.ReadTopologyInstanceBufferable(&instanceKey, config.Config.BufferInstanceWrites)
+	instance, err = inst.ReadTopologyInstanceBufferable(&instanceKey, config.Config.BufferInstanceWrites, latency)
 	// panic can occur (IO stuff). Therefore it may happen
 	// that instance is nil. Check it.
 	if instance == nil {
 		failedDiscoveriesCounter.Inc(1)
-		log.Warningf("discoverInstance(%+v) instance is nil in %.3fs, error=%+v", instanceKey, time.Since(start).Seconds(), err)
+		discoveryMetrics.Append(&discovery.Metric{
+			Timestamp:       time.Now(),
+			InstanceKey:     instanceKey,
+			TotalLatency:    latency.Elapsed("total"),
+			BackendLatency:  latency.Elapsed("backend"),
+			InstanceLatency: latency.Elapsed("instance"),
+			Err:             err,
+		})
+		log.Warningf("discoverInstance(%+v) instance is nil in %.3fs (Backend: %.3fs, Instance: %.3fs), error=%+v",
+			instanceKey,
+			latency.ElapsedSeconds("total"),
+			latency.ElapsedSeconds("backend"),
+			latency.ElapsedSeconds("instance"),
+			err)
 		return
 	}
 
-	log.Debugf("Discovered host: %+v, master: %+v, version: %+v in %.3fs", instance.Key, instance.MasterKey, instance.Version, time.Since(start).Seconds())
+	discoveryMetrics.Append(&discovery.Metric{
+		Timestamp:       time.Now(),
+		InstanceKey:     instanceKey,
+		TotalLatency:    latency.Elapsed("total"),
+		BackendLatency:  latency.Elapsed("backend"),
+		InstanceLatency: latency.Elapsed("instance"),
+		Err:             nil,
+	})
+	log.Debugf("Discovered host: %+v, master: %+v, version: %+v in %.3fs (Backend: %.3fs, Instance: %.3fs)",
+		instance.Key,
+		instance.MasterKey,
+		instance.Version,
+		latency.ElapsedSeconds("total"),
+		latency.ElapsedSeconds("backend"),
+		latency.ElapsedSeconds("instance"))
 
 	if atomic.LoadInt64(&isElectedNode) == 0 {
 		// Maybe this node was elected before, but isn't elected anymore.
@@ -172,6 +223,7 @@ func discoverInstance(instanceKey inst.InstanceKey) {
 	}
 }
 
+// onDiscoveryTick handles the actions to take to discover/poll instances
 func onDiscoveryTick() {
 	wasAlreadyElected := atomic.LoadInt64(&isElectedNode)
 	myIsElectedNode, err := process.AttemptElection()
@@ -204,6 +256,7 @@ func onDiscoveryTick() {
 		go process.RegisterNode("", "", false)
 	}
 
+	// avoid any logging unless there's something to be done
 	if len(instanceKeys) > 0 {
 		if len(instanceKeys) > config.Config.MaxOutdatedKeysToShow {
 			log.Debugf("polling %d outdated keys", len(instanceKeys))

--- a/go/metrics/query/aggregated.go
+++ b/go/metrics/query/aggregated.go
@@ -1,0 +1,76 @@
+// Package query provdes query metrics with this file providing
+// aggregared metrics based on the underlying values.
+package query
+
+import (
+	"time"
+
+	"github.com/montanaflynn/stats"
+
+	"github.com/github/orchestrator/go/collection"
+)
+
+type AggregatedQueryMetrics struct {
+	// fill me in here
+	Count                int
+	MaxLatencySeconds    float64
+	MeanLatencySeconds   float64
+	MedianLatencySeconds float64
+	P95LatencySeconds    float64
+	MaxWaitSeconds       float64
+	MeanWaitSeconds      float64
+	MedianWaitSeconds    float64
+	P95WaitSeconds       float64
+}
+
+// AggregatedSince returns the aggregated query metrics for the period
+// given from the values provided.
+func AggregatedSince(c *collection.Collection, t time.Time) AggregatedQueryMetrics {
+
+	// Initialise timing metrics
+	var waitTimings []float64
+	var queryTimings []float64
+
+	// Retrieve values since the time specified
+	values, err := c.Since(t)
+	a := AggregatedQueryMetrics{}
+	if err != nil {
+		return a // empty data
+	}
+
+	// generate the metrics
+	for _, v := range values {
+		waitTimings = append(waitTimings, v.(*Metric).WaitLatency.Seconds())
+		queryTimings = append(queryTimings, v.(*Metric).ExecuteLatency.Seconds())
+	}
+
+	a.Count = len(waitTimings)
+
+	// generate aggregate values
+	if s, err := stats.Max(stats.Float64Data(waitTimings)); err == nil {
+		a.MaxWaitSeconds = s
+	}
+	if s, err := stats.Mean(stats.Float64Data(waitTimings)); err == nil {
+		a.MeanWaitSeconds = s
+	}
+	if s, err := stats.Median(stats.Float64Data(waitTimings)); err == nil {
+		a.MedianWaitSeconds = s
+	}
+	if s, err := stats.Percentile(stats.Float64Data(waitTimings), 95); err == nil {
+		a.P95WaitSeconds = s
+	}
+	if s, err := stats.Max(stats.Float64Data(queryTimings)); err == nil {
+		a.MaxLatencySeconds = s
+	}
+	if s, err := stats.Mean(stats.Float64Data(queryTimings)); err == nil {
+		a.MeanLatencySeconds = s
+	}
+	if s, err := stats.Median(stats.Float64Data(queryTimings)); err == nil {
+		a.MedianLatencySeconds = s
+	}
+	if s, err := stats.Percentile(stats.Float64Data(queryTimings), 95); err == nil {
+		a.P95LatencySeconds = s
+	}
+
+	return a
+}

--- a/go/metrics/query/metric.go
+++ b/go/metrics/query/metric.go
@@ -1,0 +1,51 @@
+/*
+   Copyright 2017 Simon J Mudd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package query
+
+/*
+  query holds information about query metrics and records the time taken
+  waiting before doing the query plus the time taken executing the query.
+*/
+import (
+	"time"
+)
+
+// Metric records query metrics of backend writes that go through
+// a sized channel.  It allows us to compare the time waiting to
+// execute the query against the time needed to run it and in a
+// "sized channel" the wait time may be significant and is good to
+// measure.
+type Metric struct {
+	Timestamp      time.Time     // time the metric was started
+	WaitLatency    time.Duration // time that we had to wait before starting query execution
+	ExecuteLatency time.Duration // time the query took to execute
+	Err            error         // any error resulting from the query execution
+}
+
+// NewMetric returns a new metric with timestamp starting from now
+func NewMetric() *Metric {
+	bqm := &Metric{
+		Timestamp: time.Now(),
+	}
+
+	return bqm
+}
+
+// When records the timestamp of the start of the recording
+func (m Metric) When() time.Time {
+	return m.Timestamp
+}

--- a/vendor/github.com/sjmudd/stopwatch/LICENSE
+++ b/vendor/github.com/sjmudd/stopwatch/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2016, Simon J Mudd
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/sjmudd/stopwatch/README.md
+++ b/vendor/github.com/sjmudd/stopwatch/README.md
@@ -1,0 +1,31 @@
+## stopwatch
+
+stopwatch - a simple package to provide timer functionality
+
+While there are other stopwatch implementations none of them
+seemed to exactly match what I was looking for. This is very
+simple and intended for collecting run times inside an
+application.
+
+### Installation
+
+Install the package with:
+`go get github.com/sjmudd/stopwatch`
+
+### Contributing
+
+Patches and improvements to this package are welcome.
+
+### Licensing
+
+BSD 2-Clause License
+
+### Feedback
+
+Feedback and patches welcome.
+
+Simon J Mudd
+<sjmudd@pobox.com>
+
+### Code Documenton
+[godoc.org/github.com/sjmudd/stopwatch](http://godoc.org/github.com/sjmudd/stopwatch)

--- a/vendor/github.com/sjmudd/stopwatch/named_stopwatch.go
+++ b/vendor/github.com/sjmudd/stopwatch/named_stopwatch.go
@@ -1,0 +1,175 @@
+/*
+Copyright (c) 2016, Simon J Mudd
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Package stopwatch implements simple stopwatch functionality
+package stopwatch
+
+import (
+	"fmt"
+	"time"
+)
+
+// NamedStopwatch holds a map of string named stopwatches. Intended to be used when several
+// Stopwatches are being used at once, and easy to use as they are name based.
+type NamedStopwatch struct {
+	stopwatches map[string](*Stopwatch)
+}
+
+// NewNamedStopwatch creates an empty Stopwatch list
+func NewNamedStopwatch() *NamedStopwatch {
+	return new(NamedStopwatch)
+}
+
+// Add adds a single Stopwatch name with the given name.
+func (ns *NamedStopwatch) Add(name string) error {
+	return ns.AddMany([]string{name})
+}
+
+// AddMany adds several named stopwatches in one go
+func (ns *NamedStopwatch) AddMany(names []string) error {
+	if ns.stopwatches == nil {
+		ns.stopwatches = make(map[string](*Stopwatch))
+	}
+	for _, name := range names {
+		if _, ok := ns.stopwatches[name]; ok {
+			return fmt.Errorf("NamedStopwatch.AddMany()Stopwatch name %q already exists", name)
+		}
+		ns.stopwatches[name] = New(nil)
+	}
+	return nil
+}
+
+// Delete removes a Stopwatch with the given name (if it exists)
+func (ns *NamedStopwatch) Delete(name string) {
+	if ns.stopwatches == nil {
+		return
+	}
+
+	delete(ns.stopwatches, name) // check if it exists in case the user did the wrong thing
+}
+
+// Exists returns true if the NamedStopwatch exists
+func (ns *NamedStopwatch) Exists(name string) bool {
+	if ns == nil {
+		return false
+	}
+
+	_, found := ns.stopwatches[name]
+
+	return found
+}
+
+// Start starts a NamedStopwatch if it exists
+func (ns *NamedStopwatch) Start(name string) {
+	if ns == nil {
+		return
+	}
+	if s, ok := ns.stopwatches[name]; ok {
+		s.Start()
+	}
+}
+
+// StartMany allows you to start several stopwatches in one go
+func (ns *NamedStopwatch) StartMany(names []string) {
+	if ns == nil {
+		return
+	}
+	for _, name := range names {
+		ns.stopwatches[name].Start()
+	}
+}
+
+// Stop stops a NamedStopwatch if it exists
+func (ns *NamedStopwatch) Stop(name string) {
+	if ns == nil {
+		return
+	}
+	if s, ok := ns.stopwatches[name]; ok {
+		if s.IsRunning() {
+			s.Stop()
+		} else {
+			fmt.Printf("WARNING: NamedStopwatch.Stop(%q) IsRunning is false\n", name)
+		}
+	}
+}
+
+// StopMany allows you to stop several stopwatches in one go
+func (ns *NamedStopwatch) StopMany(names []string) {
+	if ns == nil {
+		return
+	}
+	for _, name := range names {
+		ns.stopwatches[name].Stop()
+	}
+}
+
+// Reset resets a NamedStopwatch if it exists
+func (ns *NamedStopwatch) Reset(name string) {
+	if ns == nil {
+		return
+	}
+	if s, ok := ns.stopwatches[name]; ok {
+		s.Reset()
+	}
+}
+
+// Keys returns the known names of Stopwatches
+func (ns *NamedStopwatch) Keys() []string {
+	if ns == nil {
+		return nil
+	}
+	keys := []string{}
+	for k := range ns.stopwatches {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Elapsed returns the elapsed time.Duration of the named stopwatch if it exists or 0
+func (ns *NamedStopwatch) Elapsed(name string) time.Duration {
+	if s, ok := ns.stopwatches[name]; ok {
+		return s.Elapsed()
+	}
+	return time.Duration(0)
+}
+
+// ElapsedSeconds returns the elapsed time in seconds of the named
+// stopwatch if it exists or 0.
+func (ns *NamedStopwatch) ElapsedSeconds(name string) float64 {
+	if s, ok := ns.stopwatches[name]; ok {
+		return s.ElapsedSeconds()
+	}
+	return float64(0)
+}
+
+// ElapsedMilliSeconds returns the elapsed time in milliseconds of
+// the named stopwatch if it exists or 0.
+func (ns *NamedStopwatch) ElapsedMilliSeconds(name string) float64 {
+	if s, ok := ns.stopwatches[name]; ok {
+		return s.ElapsedMilliSeconds()
+	}
+	return float64(0)
+}

--- a/vendor/github.com/sjmudd/stopwatch/named_stopwatch_test.go
+++ b/vendor/github.com/sjmudd/stopwatch/named_stopwatch_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2016, Simon J Mudd
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Package stopwatch implements simple stopwatch functionality
+package stopwatch
+
+import (
+	"testing"
+)
+
+// NewNamedStopwatch creates an empty Stopwatch list
+func TestNewNamedStopwatch(t *testing.T) {
+	n := NewNamedStopwatch()
+	if n == nil {
+		t.Error("TestNewNamedStopwatch() returns nil")
+	}
+	len := len(n.Keys())
+	if len != 0 {
+		t.Error("TestNewNamedStopwatch() len(n) = %d, expecting %d", len, 1)
+	}
+}
+
+var testNames []string
+
+func init() {
+	testNames = []string{"S1", "S2", "S3", "S4"}
+}
+
+// uses Add and Exists
+func TestAddNamedStopwatch(t *testing.T) {
+	n := NewNamedStopwatch()
+
+	for i, v := range testNames {
+		n.Add(v)
+		len := len(n.Keys())
+		if len != (i + 1) {
+			t.Errorf("TestAddNamedStopwatch(): len(n.Keys()) = %d after adding %q, expecting %d", len, v, 1+i)
+		}
+		if !n.Exists(v) {
+			t.Errorf("TestAddNamedStopwatch(): %q not exists after adding it.", v)
+		}
+	}
+}
+
+// checkAddMany behaves the same as Add
+func TestAddManyNamedStopwatch(t *testing.T) {
+	n1 := NewNamedStopwatch()
+	n2 := NewNamedStopwatch()
+
+	names := []string{}
+	for i := range testNames {
+		names = append(names, testNames[i])
+	}
+	n1.AddMany(names)
+	size := len(n1.Keys())
+	if size != len(testNames) {
+		t.Errorf("TestAddManyNamedStopwatch(): len(n1.Keys()) = %d, expecting %d", size, 1+i)
+	}
+
+	for i, v := range testNames {
+		if !n2.Exists(v) {
+			t.Errorf("TestAddManyNamedStopwatch(): name %q does not exist.", v)
+		}
+	}
+}

--- a/vendor/github.com/sjmudd/stopwatch/stopwatch.go
+++ b/vendor/github.com/sjmudd/stopwatch/stopwatch.go
@@ -1,0 +1,135 @@
+/*
+Copyright (c) 2016, Simon J Mudd
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Package stopwatch implements simple stopwatch functionality
+package stopwatch
+
+import (
+	"fmt"
+	"time"
+)
+
+// DefaultFormat allows the Stopwatch.String() function to be
+// configured differently to time.Duration if needed.  This is done
+// at the global package level to avoid having to do on each Stopwatch
+// instance.
+var DefaultFormat = func(t time.Duration) string { return t.String() }
+
+// Stopwatch is a structure to hold information about a stopwatch
+type Stopwatch struct {
+	format  func(time.Duration) string
+	elapsed time.Duration
+	refTime time.Time
+}
+
+// Start returns a pointer to a new Stopwatch struct and indicates
+// that the stopwatch has started.
+func Start(f func(time.Duration) string) *Stopwatch {
+	s := New(f)
+	s.Start()
+
+	return s
+}
+
+// New returns a pointer to a new Stopwatch struct.
+func New(f func(time.Duration) string) *Stopwatch {
+	s := new(Stopwatch)
+	s.format = f
+
+	return s
+}
+
+// Start records that we are now running. If called previously this
+// is a no-op.
+func (s *Stopwatch) Start() {
+	if s.IsRunning() {
+		fmt.Printf("WARNING: Stopwatch.Start() IsRunning is true\n")
+	} else {
+		s.refTime = time.Now()
+	}
+}
+
+// Stop collects the elapsed time if running and remembers we are
+// not running.
+func (s *Stopwatch) Stop() {
+	if s.IsRunning() {
+		s.elapsed += time.Since(s.refTime)
+		s.refTime = time.Time{}
+	} else {
+		fmt.Printf("WARNING: Stopwatch.Stop() IsRunning is false\n")
+	}
+}
+
+// Reset resets the counters.
+func (s *Stopwatch) Reset() {
+	if s.IsRunning() {
+		fmt.Printf("WARNING: Stopwatch.Reset() IsRunning is true\n")
+	}
+	s.refTime = time.Time{}
+	s.elapsed = 0
+}
+
+// String gives the string representation of the duration.
+func (s *Stopwatch) String() string {
+	// display using local formatting if possible
+	if s.format != nil {
+		return s.format(s.elapsed)
+	}
+	// display using package DefaultFormat
+	return DefaultFormat(s.elapsed)
+}
+
+// SetStringFormat allows the String() function to be configured
+// differently to time.Duration for the specific Stopwatch.
+func (s *Stopwatch) SetStringFormat(f func(time.Duration) string) {
+	s.format = f
+}
+
+// IsRunning is a helper function to indicate if in theory the
+// stopwatch is working.
+func (s *Stopwatch) IsRunning() bool {
+	return !s.refTime.IsZero()
+}
+
+// Elapsed returns the elapsed time since starting (in time.Duration).
+func (s *Stopwatch) Elapsed() time.Duration {
+	if s.IsRunning() {
+		return time.Since(s.refTime)
+	}
+	return s.elapsed
+}
+
+// ElapsedSeconds is a helper function returns the number of seconds
+// since starting.
+func (s *Stopwatch) ElapsedSeconds() float64 {
+	return s.Elapsed().Seconds()
+}
+
+// ElapsedMilliSeconds is a helper function returns the number of
+// milliseconds since starting.
+func (s *Stopwatch) ElapsedMilliSeconds() float64 {
+	return float64(s.Elapsed() / time.Millisecond)
+}

--- a/vendor/github.com/sjmudd/stopwatch/stopwatch_test.go
+++ b/vendor/github.com/sjmudd/stopwatch/stopwatch_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2016, Simon J Mudd
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Package stopwatch implements simple stopwatch functionality
+package stopwatch
+
+import (
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	s := New(nil)
+	if s == nil {
+		t.Error("TestNew(): New() returned %v, expecting non-nil value", s)
+	}
+}
+
+func TestStart(t *testing.T) {
+	s := Start(nil)
+	elapsed := s.ElapsedSeconds() // convert to seconds should be ok for now
+	if elapsed == 0 {
+		t.Error("TestStart(): s.Elapsed() returned %+v, expecting > 0", elapsed)
+	}
+}
+
+func TestStop(t *testing.T) {
+	s := Start(nil)
+	s.Stop()
+	elapsed1 := s.ElapsedSeconds() // convert to seconds should be ok for now
+	elapsed2 := s.ElapsedSeconds() // convert to seconds should be ok for now
+	if elapsed1 != elapsed2 {
+		t.Error("TestStop(): elapsed1 (%v) != elapsed2 (%v). Expecting them to be the same", elapsed1, elapsed2)
+	}
+}
+
+func TestReset(t *testing.T) {
+	s := New(nil)
+	s.Start()
+}
+
+func TestIsRunning(t *testing.T) {
+	s := New(nil)
+	if s.IsRunning() {
+		t.Error("TestIsRunning() returns %v after New(), expecting false", s.IsRunning())
+	}
+	s.Start()
+	if !s.IsRunning() {
+		t.Error("TestIsRunning() returns %v after Start(), expecting true", s.IsRunning())
+	}
+	s.Start()
+	if !s.IsRunning() {
+		t.Error("TestIsRunning() returns %v after 2nd Start(), expecting true", s.IsRunning())
+	}
+	s.Stop()
+	if s.IsRunning() {
+		t.Error("TestIsRunning() returns %v after 2nd Stop(), expecting false", s.IsRunning())
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -23,6 +23,12 @@
 			"path": "github.com/patrickmn/go-cache",
 			"revision": "1881a9bccb818787f68c52bfba648c6cf34c34fa",
 			"revisionTime": "2016-01-27T17:00:04Z"
+		},
+		{
+			"checksumSHA1": "/r6ySR3hhHOXoxpCvWdCMXQMZxw=",
+			"path": "github.com/sjmudd/stopwatch",
+			"revision": "637ef30077b7a4d31e70e7a2b9e1e690333be7be",
+			"revisionTime": "2017-01-03T08:58:48Z"
 		}
 	],
 	"rootPath": "github.com/github/orchestrator"


### PR DESCRIPTION
This rather large patch brings in code from booking.com which does the following:

Signal handling:
* handle SIGTERM

discoverInstance():
* Add timing metrics: talking to instance, backend timings and total
  time for each discovery using vendor/github.com/sjmudd/stopwatch
  for managing timing counters.

Add new api calls:
* /api/discovery-metrics-raw/:seconds
* /api/discovery-metrics-aggregated/:seconds
* /api/backend-query-metrics-raw/:seconds
* /api/backend-query-metrics-aggregated/:seconds

New configuration setting:
* DiscoveryCollectionRetentionSeconds which determines the amount of time
  individual discovery statistics are kept for.

checkMaxScale:
* move maxscale checks out of inst.ReadTopologyInstanceBufferable()

Basically the change adds more detailed metrics which can be seen in logging but also makes these metrics retrievable by API calls to orchestrator. Both raw and aggregated forms are provided to give the user to choose what works best.

These changes were added to our code to help us identify performance problems on our large setup and have been running for some time.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`