### PR TITLE
Make executeCheckAndRecoverFunction show unhandled analysis entries.

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1209,8 +1209,10 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 
 	if checkAndRecoverFunction == nil {
 		// Unhandled problem type
-		log.Warningf("executeCheckAndRecoverFunction: Ignoring unhandled analysisEntry: %+v; key: %+v",
-			analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey)
+		if analysisEntry.Analysis != inst.NoProblem {
+			log.Warningf("executeCheckAndRecoverFunction: Ignoring unhandled analysisEntry: %+v; key: %+v",
+				analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey)
+		}
 
 		return false, nil, nil
 	}
@@ -1278,9 +1280,9 @@ func CheckAndRecover(specificInstance *inst.InstanceKey, candidateInstanceKey *i
 				promotedReplicaKey = topologyRecovery.SuccessorKey
 			}
 		} else if recoveryDisabledGlobally {
-			log.Infof("CheckAndRecover: InstanceKey: %+v, candidateInstanceKey: %+v, "+
+			log.Infof("CheckAndRecover: Analysis: %+v, InstanceKey: %+v, candidateInstanceKey: %+v, "+
 				"skipProcesses: %v: NOT Recovering host (disabled globally)",
-				analysisEntry.AnalyzedInstanceKey, candidateInstanceKey, skipProcesses)
+				analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey, candidateInstanceKey, skipProcesses)
 		} else {
 			go executeCheckAndRecoverFunction(analysisEntry, candidateInstanceKey, false, skipProcesses)
 		}

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1201,11 +1201,13 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 		go emergentlyReadTopologyInstance(&analysisEntry.AnalyzedInstanceMasterKey, analysisEntry.Analysis)
 	case inst.UnreachableMasterWithStaleSlaves:
 		checkAndRecoverFunction = checkAndRecoverUnreachableMasterWithStaleSlaves
-		// Right now this is mostly causing noise with no clear action.
-		// Will revisit this in the future.
-		// case inst.AllMasterSlavesStale:
-		// 	checkAndRecoverFunction = checkAndRecoverGenericProblem
-	default:
+	}
+	// Right now this is mostly causing noise with no clear action.
+	// Will revisit this in the future.
+	// case inst.AllMasterSlavesStale:
+	// 	checkAndRecoverFunction = checkAndRecoverGenericProblem
+
+	if checkAndRecoverFunction == nil {
 		// Unhandled problem type
 		log.Warningf("executeCheckAndRecoverFunction: Ignoring unhandled analysisEntry: %+v; key: %+v",
 			analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey)

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1201,14 +1201,15 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 		go emergentlyReadTopologyInstance(&analysisEntry.AnalyzedInstanceMasterKey, analysisEntry.Analysis)
 	case inst.UnreachableMasterWithStaleSlaves:
 		checkAndRecoverFunction = checkAndRecoverUnreachableMasterWithStaleSlaves
-	}
-	// Right now this is mostly causing noise with no clear action.
-	// Will revisit this in the future.
-	// case inst.AllMasterSlavesStale:
-	// 	checkAndRecoverFunction = checkAndRecoverGenericProblem
-
-	if checkAndRecoverFunction == nil {
+		// Right now this is mostly causing noise with no clear action.
+		// Will revisit this in the future.
+		// case inst.AllMasterSlavesStale:
+		// 	checkAndRecoverFunction = checkAndRecoverGenericProblem
+	default:
 		// Unhandled problem type
+		log.Warningf("executeCheckAndRecoverFunction: Ignoring unhandled analysisEntry: %+v; key: %+v",
+			analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey)
+
 		return false, nil, nil
 	}
 	// we have a recovery function; its execution still depends on filters if not disabled.


### PR DESCRIPTION
Current code does not make this very visible and the code path should not get here anyway. However, if it does it indicates that the analysis phase is not completely correct or we are not handling the situation correctly. Both situations probably need to be identified and resolved.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`
