### PR TITLE
NodeHealthExpiry: if false ensure the expiry happens on the active node

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -87,7 +87,6 @@ type Configuration struct {
 	DiscoveryCollectionRetentionSeconds          uint     // Number of seconds to retain the discovery collection information
 	InstanceBulkOperationsWaitTimeoutSeconds     uint     // Time to wait on a single instance when doing bulk (many instances) operation
 	ActiveNodeExpireSeconds                      uint     // Maximum time to wait for active node to send keepalive before attempting to take over as active node.
-	NodeHealthExpiry                             bool     // Do we expire the node_health table on every cli/http run? By default this is true, but if we have many systems involved it's better to delegate this exclusively to the active node.
 	HostnameResolveMethod                        string   // Method by which to "normalize" hostname ("none"/"default"/"cname")
 	MySQLHostnameResolveMethod                   string   // Method by which to "normalize" hostname via MySQL server. ("none"/"@@hostname"/"@@report_host"; default "@@hostname")
 	SkipBinlogServerUnresolveCheck               bool     // Skip the double-check that an unresolved hostname resolves back to same hostname for binlog servers
@@ -255,7 +254,6 @@ func newConfiguration() *Configuration {
 		DiscoveryCollectionRetentionSeconds:          120,
 		InstanceBulkOperationsWaitTimeoutSeconds:     10,
 		ActiveNodeExpireSeconds:                      5,
-		NodeHealthExpiry:                             true,
 		HostnameResolveMethod:                        "default",
 		MySQLHostnameResolveMethod:                   "@@hostname",
 		SkipBinlogServerUnresolveCheck:               true,

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -87,7 +87,7 @@ type Configuration struct {
 	DiscoveryCollectionRetentionSeconds          uint     // Number of seconds to retain the discovery collection information
 	InstanceBulkOperationsWaitTimeoutSeconds     uint     // Time to wait on a single instance when doing bulk (many instances) operation
 	ActiveNodeExpireSeconds                      uint     // Maximum time to wait for active node to send keepalive before attempting to take over as active node.
-	NodeHealthExpiry                             bool     // Do we expire the node_health table? Usually this is true but it might be disabled on command line tools if an orchestrator daemon is running.
+	NodeHealthExpiry                             bool     // Do we expire the node_health table on every cli/http run? By default this is true, but if we have many systems involved it's better to delegate this exclusively to the active node.
 	HostnameResolveMethod                        string   // Method by which to "normalize" hostname ("none"/"default"/"cname")
 	MySQLHostnameResolveMethod                   string   // Method by which to "normalize" hostname via MySQL server. ("none"/"@@hostname"/"@@report_host"; default "@@hostname")
 	SkipBinlogServerUnresolveCheck               bool     // Skip the double-check that an unresolved hostname resolves back to same hostname for binlog servers

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -291,6 +291,7 @@ func ContinuousDiscovery() {
 	inst.LoadHostnameResolveCache()
 	go handleDiscoveryRequests()
 
+	nodeHealthExpiryTick := time.Tick(time.Duration(process.RegistrationPollSeconds) * time.Second)
 	discoveryTick := time.Tick(time.Duration(config.Config.GetDiscoveryPollSeconds()) * time.Second)
 	instancePollTick := time.Tick(time.Duration(config.Config.InstancePollSeconds) * time.Second)
 	caretakingTick := time.Tick(time.Minute)
@@ -308,6 +309,18 @@ func ContinuousDiscovery() {
 	}
 	for {
 		select {
+		case <-nodeHealthExpiryTick:
+			// If we do not explicitly expire health
+			// details on every node (NodeHealthExpiry =
+			// true) then this will be done by the
+			// active node only.
+			if !config.Config.NodeHealthExpiry && atomic.LoadInt64(&isElectedNode) == 1 {
+				go func() {
+					if err := process.ExpireAvailableNodes(); err != nil {
+						log.Errorf("ContinuousDiscovery: process.ExpireAvailableNodes failed: %+v", err)
+					}
+				}()
+			}
 		case <-discoveryTick:
 			go func() {
 				onDiscoveryTick()

--- a/go/process/health_dao.go
+++ b/go/process/health_dao.go
@@ -18,7 +18,6 @@ package process
 
 import (
 	"database/sql"
-	"sync"
 	"time"
 
 	"github.com/github/orchestrator/go/config"


### PR DESCRIPTION
All nodes, "cli clients" or active "http" nodes, insert into the node_health table, and keep it up to date while they are running. By default they also try to clean up old entries in this table. If
a large number of http or cli nodes are running then this clean up may trigger unwanted contention on the table, so it has been possible for some time to disable the expiry.  However, this requires a clean up, and the best node to do this is the active orchestrator node.

This patch thus checks if NodeHealthExpiry is false and if so the active node will carry out this task.