### PR TITLE
Log at Info level as It's important to know when we receive signals

### DIFF
--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -81,12 +81,12 @@ func acceptSignals() {
 		for sig := range c {
 			switch sig {
 			case syscall.SIGHUP:
-				log.Debugf("Received SIGHUP. Reloading configuration")
+				log.Infof("Received SIGHUP. Reloading configuration")
 				inst.AuditOperation("reload-configuration", nil, "Triggered via SIGHUP")
 				config.Reload()
 				discoveryMetrics.SetExpirePeriod(time.Duration(config.Config.DiscoveryCollectionRetentionSeconds) * time.Second)
 			case syscall.SIGTERM:
-				log.Debugf("Received SIGTERM. Shutting down orchestrator")
+				log.Infof("Received SIGTERM. Shutting down orchestrator")
 				discoveryMetrics.StopAutoExpiration()
 				// probably should poke other go routines to stop cleanly here ...
 				inst.AuditOperation("shutdown", nil, "Triggered via SIGTERM")


### PR DESCRIPTION
Minor change.

Current logging of signal handling is at the debug level.
* It's good to log this as it's infrequent and even if the debug is not set.
* SIGHUP takes configuration changes so this should be visible.