### PR TITLE
Fix typo in go/logic/orchestrator.go

### DIFF
--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -314,7 +314,7 @@ func ContinuousDiscovery() {
 			}()
 		case <-instancePollTick:
 			go func() {
-				// This tick does NOT do instance poll (these are handled by the oversmapling discoveryTick)
+				// This tick does NOT do instance poll (these are handled by the oversampling discoveryTick)
 				// But rather should invoke such routinely operations that need to be as (or roughly as) frequent
 				// as instance poll
 				if atomic.LoadInt64(&isElectedNode) == 1 {


### PR DESCRIPTION
Fix tiny typo in comment.
