### PR TITLE
build.sh: fix missing assignment to target in `precheck()`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,7 @@ usage() {
 function precheck() {
   local target
   local ok=0 # return err. so shell exit code
+  target="$1"
 
   if [[ "$target" == "linux" ]]; then
     if [[ ! -x "$( which fpm )" ]]; then


### PR DESCRIPTION
## Fix for #99 

Related issue: https://github.com/github/orchestrator/issues/99

### Description

This PR corrects the missing assignment of the parameter in the `precheck()` function in `build.sh`