### PR TITLE
Analysis: dead intermediate master and replicas

### DIFF
--- a/docs/topology-recovery.md
+++ b/docs/topology-recovery.md
@@ -20,6 +20,7 @@ At this time recovery requires either GTID, [Pseudo GTID](#pseudo-gtid) or Binlo
 * DeadIntermediateMasterWithSingleSlaveFailingToConnect
 * DeadIntermediateMasterWithSingleSlave
 * DeadIntermediateMasterAndSomeSlaves
+* DeadIntermediateMasterAndSlaves
 * AllIntermediateMasterSlavesFailingToConnectOrDead
 * AllIntermediateMasterSlavesNotReplicating
 * UnreachableIntermediateMaster

--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -45,6 +45,7 @@ const (
 	DeadIntermediateMasterWithSingleSlave                              = "DeadIntermediateMasterWithSingleSlave"
 	DeadIntermediateMasterWithSingleSlaveFailingToConnect              = "DeadIntermediateMasterWithSingleSlaveFailingToConnect"
 	DeadIntermediateMasterAndSomeSlaves                                = "DeadIntermediateMasterAndSomeSlaves"
+	DeadIntermediateMasterAndSlaves                                    = "DeadIntermediateMasterAndSlaves"
 	UnreachableIntermediateMaster                                      = "UnreachableIntermediateMaster"
 	AllIntermediateMasterSlavesFailingToConnectOrDead                  = "AllIntermediateMasterSlavesFailingToConnectOrDead"
 	AllIntermediateMasterSlavesNotReplicating                          = "AllIntermediateMasterSlavesNotReplicating"

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -318,6 +318,10 @@ func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnal
 			a.Analysis = DeadIntermediateMasterAndSomeSlaves
 			a.Description = "Intermediate master cannot be reached by orchestrator; some of its replicas are unreachable and none of its reachable replicas is replicating"
 			//
+		} else if !a.IsMaster && !a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicas == 0 {
+			a.Analysis = DeadIntermediateMasterAndSlaves
+			a.Description = "Intermediate master cannot be reached by orchestrator and all of its replicas are unreachable"
+			//
 		} else if !a.IsMaster && !a.LastCheckValid && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
 			a.Analysis = UnreachableIntermediateMaster
 			a.Description = "Intermediate master cannot be reached by orchestrator but it has replicating replicas; possibly a network/host issue"

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1185,6 +1185,8 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 		checkAndRecoverFunction = checkAndRecoverDeadIntermediateMaster
 	case inst.DeadIntermediateMasterWithSingleSlaveFailingToConnect:
 		checkAndRecoverFunction = checkAndRecoverDeadIntermediateMaster
+	case inst.DeadIntermediateMasterAndSlaves:
+		checkAndRecoverFunction = checkAndRecoverGenericProblem
 	case inst.AllIntermediateMasterSlavesFailingToConnectOrDead:
 		checkAndRecoverFunction = checkAndRecoverDeadIntermediateMaster
 	case inst.DeadCoMaster:

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1189,6 +1189,8 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 		checkAndRecoverFunction = checkAndRecoverGenericProblem
 	case inst.AllIntermediateMasterSlavesFailingToConnectOrDead:
 		checkAndRecoverFunction = checkAndRecoverDeadIntermediateMaster
+	case inst.AllIntermediateMasterSlavesNotReplicating:
+		checkAndRecoverFunction = checkAndRecoverGenericProblem
 	case inst.DeadCoMaster:
 		checkAndRecoverFunction = checkAndRecoverDeadCoMaster
 	case inst.DeadCoMasterAndSomeSlaves:

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1196,14 +1196,18 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 	case inst.DeadCoMasterAndSomeSlaves:
 		checkAndRecoverFunction = checkAndRecoverDeadCoMaster
 	case inst.DeadMasterAndSlaves:
+		checkAndRecoverFunction = checkAndRecoverGenericProblem
 		go emergentlyReadTopologyInstance(&analysisEntry.AnalyzedInstanceMasterKey, analysisEntry.Analysis)
 	case inst.UnreachableMaster:
+		checkAndRecoverFunction = checkAndRecoverGenericProblem
 		go emergentlyReadTopologyInstanceReplicas(&analysisEntry.AnalyzedInstanceKey, analysisEntry.Analysis)
 	case inst.AllMasterSlavesNotReplicating:
+		checkAndRecoverFunction = checkAndRecoverGenericProblem
 		go emergentlyReadTopologyInstance(&analysisEntry.AnalyzedInstanceKey, analysisEntry.Analysis)
 	case inst.FirstTierSlaveFailingToConnectToMaster:
 		go emergentlyReadTopologyInstance(&analysisEntry.AnalyzedInstanceMasterKey, analysisEntry.Analysis)
 	case inst.UnreachableMasterWithStaleSlaves:
+		checkAndRecoverFunction = checkAndRecoverGenericProblem
 		checkAndRecoverFunction = checkAndRecoverUnreachableMasterWithStaleSlaves
 	}
 	// Right now this is mostly causing noise with no clear action.

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1190,7 +1190,7 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 	case inst.AllIntermediateMasterSlavesFailingToConnectOrDead:
 		checkAndRecoverFunction = checkAndRecoverDeadIntermediateMaster
 	case inst.AllIntermediateMasterSlavesNotReplicating:
-		checkAndRecoverFunction = checkAndRecoverGenericProblem
+		checkAndRecoverFunction = nil
 	case inst.DeadCoMaster:
 		checkAndRecoverFunction = checkAndRecoverDeadCoMaster
 	case inst.DeadCoMasterAndSomeSlaves:

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1204,10 +1204,12 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 	case inst.AllMasterSlavesNotReplicating:
 		checkAndRecoverFunction = checkAndRecoverGenericProblem
 		go emergentlyReadTopologyInstance(&analysisEntry.AnalyzedInstanceKey, analysisEntry.Analysis)
+	case inst.AllMasterSlavesNotReplicatingOrDead:
+		checkAndRecoverFunction = checkAndRecoverGenericProblem
+		go emergentlyReadTopologyInstance(&analysisEntry.AnalyzedInstanceKey, analysisEntry.Analysis)
 	case inst.FirstTierSlaveFailingToConnectToMaster:
 		go emergentlyReadTopologyInstance(&analysisEntry.AnalyzedInstanceMasterKey, analysisEntry.Analysis)
 	case inst.UnreachableMasterWithStaleSlaves:
-		checkAndRecoverFunction = checkAndRecoverGenericProblem
 		checkAndRecoverFunction = checkAndRecoverUnreachableMasterWithStaleSlaves
 	}
 	// Right now this is mostly causing noise with no clear action.

--- a/resources/public/js/cluster-analysis-shared.js
+++ b/resources/public/js/cluster-analysis-shared.js
@@ -14,6 +14,7 @@ var interestingAnalysis = {
 	"DeadIntermediateMasterWithSingleSlaveFailingToConnect" : true,
 	"DeadIntermediateMasterWithSingleSlave" : true,
 	"DeadIntermediateMasterAndSomeSlaves" : true,
+	"DeadIntermediateMasterAndSlaves" : true,
 	"AllIntermediateMasterSlavesFailingToConnectOrDead" : true,
 	"AllIntermediateMasterSlavesNotReplicating" : true,
 	"UnreachableIntermediateMaster" : true,

--- a/tests/integration/analysis-dead-intermediate-master-and-replicas/create.sql
+++ b/tests/integration/analysis-dead-intermediate-master-and-replicas/create.sql
@@ -1,0 +1,3 @@
+-- 22295 replicates from 22294
+UPDATE database_instance SET last_seen=last_checked - interval 1 minute where master_port=22294;
+UPDATE database_instance SET last_seen=last_checked - interval 1 minute where port=22294;

--- a/tests/integration/analysis-dead-intermediate-master-and-replicas/expect_output
+++ b/tests/integration/analysis-dead-intermediate-master-and-replicas/expect_output
@@ -1,0 +1,1 @@
+testhost:22294 (cluster testhost:22293): DeadIntermediateMasterAndSlaves

--- a/tests/integration/analysis-dead-intermediate-master-and-replicas/extra_args
+++ b/tests/integration/analysis-dead-intermediate-master-and-replicas/extra_args
@@ -1,0 +1,1 @@
+-c replication-analysis


### PR DESCRIPTION
Surprisingly, `orchestrator` didn't analyze the case where an intermediate master and all of its replicas are dead.

There is no operation to take on such case (they're all dead, what can you do?)

But detection-wise this mustn't go under the radar. This PR adds this missing diagnostic.

- Added tests for expected behavior

cc @github/database-infrastructure 