### PR TITLE
introducing SkipMaxScaleCheck config

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -82,6 +82,7 @@ type Configuration struct {
 	BufferInstanceWrites                         bool     // Set to 'true' for write-optimization on backend table (compromise: writes can be stale and overwrite non stale data)
 	InstanceFlushIntervalMilliseconds            int      // Max interval between instance write buffer flushes
 	ReadLongRunningQueries                       bool     // Whether orchestrator should read and record current long running executing queries.
+	SkipMaxScaleCheck                            bool     // If you don't ever have MaxScale BinlogServer in your topology (and most people don't), set this to 'true' to save some pointless queries
 	BinlogFileHistoryDays                        int      // When > 0, amount of days for which orchestrator records per-instance binlog files & sizes
 	UnseenInstanceForgetHours                    uint     // Number of hours after which an unseen instance is forgotten
 	SnapshotTopologiesIntervalHours              uint     // Interval in hour between snapshot-topologies invocation. Default: 0 (disabled)
@@ -253,6 +254,7 @@ func newConfiguration() *Configuration {
 		BufferInstanceWrites:                         false,
 		InstanceFlushIntervalMilliseconds:            100,
 		ReadLongRunningQueries:                       true,
+		SkipMaxScaleCheck:                            false,
 		BinlogFileHistoryDays:                        0,
 		UnseenInstanceForgetHours:                    240,
 		SnapshotTopologiesIntervalHours:              0,

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -150,12 +150,10 @@ func unrecoverableError(err error) bool {
 
 // Check if the instance is a MaxScale binlog server (a proxy not a real
 // MySQL server) and also update the resolved hostname
-func (instance *Instance) checkMaxScale(db *sql.DB, latency *stopwatch.NamedStopwatch) (bool, string, error) {
-	var (
-		err              error
-		isMaxScale       bool
-		resolvedHostname string
-	)
+func (instance *Instance) checkMaxScale(db *sql.DB, latency *stopwatch.NamedStopwatch) (isMaxScale bool, resolvedHostname string, err error) {
+	if config.Config.SkipMaxScaleCheck {
+		return isMaxScale, resolvedHostname, err
+	}
 
 	latency.Start("instance")
 	err = sqlutils.QueryRowsMap(db, "show variables like 'maxscale%'", func(m sqlutils.RowMap) error {


### PR DESCRIPTION
When `SkipMaxScaleCheck` is set to `true` (default is `false`), `orchestrator` skips any checks for `maxscale` servers.

People who never ever have any `maxscale` binlog server in their topology (not to be confused with maxscale load balancer, which is completely unrelated to this PR) should set this variable to `true`. 99.9999999% of people don't have `maxscale` binlog servers in their setups.

The reason for this flag: when connecting to a server, `orchestrator` first checks whether it is a `maxscale` server, because `maxscale` is very picky about the type of queries it can respond to. So first `orchestrator` needs to determine what is the type of queries valid to issue.

If a server is offline or down, what we get in our error logs is that the `maxscale` check has failed. I don't have `maxscale` and most people don't and this message actually bothers me.

But more importantly it is wasting a round trip. For remote servers with high latency saving a single round trip is a worthy change (and I will proceed to attempt to remove other round trips as well).

This PR is backwards compatible.

cc @github/database-infrastructure @sjmudd 