### PR TITLE
Fix issue #116: `precheck()` honours `-b`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,17 +31,18 @@ usage() {
 }
 
 function precheck() {
-  local target
+  local target build_only
   local ok=0 # return err. so shell exit code
   target="$1"
+  build_only="$2"
 
   if [[ "$target" == "linux" ]]; then
-    if [[ ! -x "$( which fpm )" ]]; then
+    if [[ $build_only -eq 0 ]] && [[ ! -x "$( which fpm )" ]]; then
       echo "Please install fpm and ensure it is in PATH (typically: 'gem install fpm')"
       ok=1
     fi
 
-    if [[ ! -x "$( which rpmbuild )" ]]; then
+    if [[ $build_only -eq 0 ]] && [[ ! -x "$( which rpmbuild )" ]]; then
       echo "rpmbuild not in PATH, rpm will not be built (OS/X: 'brew install rpm')"
     fi
   fi
@@ -162,7 +163,7 @@ function main() {
   fi
   RELEASE_VERSION="${RELEASE_VERSION}${RELEASE_SUBVERSION}"
 
-  precheck "$target"
+  precheck "$target" "$build_only"
   builddir=$( setuptree "$prefix" )
   oinstall "$builddir" "$prefix"
   build "$target" "$arch" "$builddir" "$prefix"


### PR DESCRIPTION
## Fix Issue #116 

The `precheck()` function in `build.sh` does not honor the `-b` option while checking prerequisites.

Related issue: https://github.com/github/orchestrator/issues/116

### Description

The `precheck()` function in `build.sh` does not honor the `-b` option while checking for prerequisites. This pull request augments `precheck()` with checks against the `build_only` flag.