### PR TITLE
end-downtime does not produce error when instance not downtimed

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1326,7 +1326,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	case registerCliCommand("end-maintenance", "Instance management", `Remove maintenance lock from an instance`):
 		{
 			instanceKey = deduceInstanceKeyIfNeeded(instance, instanceKey, true)
-			err := inst.EndMaintenanceByInstanceKey(instanceKey)
+			_, err := inst.EndMaintenanceByInstanceKey(instanceKey)
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1359,7 +1359,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	case registerCliCommand("end-downtime", "Instance management", `Indicate an instance is no longer downtimed`):
 		{
 			instanceKey = deduceInstanceKeyIfNeeded(instance, instanceKey, true)
-			err := inst.EndDowntime(instanceKey)
+			_, err := inst.EndDowntime(instanceKey)
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -342,7 +342,7 @@ func (this *HttpAPI) EndDowntime(params martini.Params, r render.Render, req *ht
 		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	err = inst.EndDowntime(&instanceKey)
+	_, err = inst.EndDowntime(&instanceKey)
 	if err != nil {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
 		return

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -253,7 +253,7 @@ func (this *HttpAPI) EndMaintenance(params martini.Params, r render.Render, req 
 		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	err = inst.EndMaintenance(maintenanceKey)
+	_, err = inst.EndMaintenance(maintenanceKey)
 	if err != nil {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
@@ -274,7 +274,7 @@ func (this *HttpAPI) EndMaintenanceByInstanceKey(params martini.Params, r render
 		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	err = inst.EndMaintenanceByInstanceKey(&instanceKey)
+	_, err = inst.EndMaintenanceByInstanceKey(&instanceKey)
 	if err != nil {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
 		return

--- a/go/inst/maintenance_dao.go
+++ b/go/inst/maintenance_dao.go
@@ -113,7 +113,7 @@ func BeginMaintenance(instanceKey *InstanceKey, owner string, reason string) (in
 }
 
 // EndMaintenanceByInstanceKey will terminate an active maintenance using given instanceKey as hint
-func EndMaintenanceByInstanceKey(instanceKey *InstanceKey) error {
+func EndMaintenanceByInstanceKey(instanceKey *InstanceKey) (wasMaintenance bool, err error) {
 	res, err := db.ExecOrchestrator(`
 			update
 				database_instance_maintenance
@@ -129,16 +129,15 @@ func EndMaintenanceByInstanceKey(instanceKey *InstanceKey) error {
 		instanceKey.Port,
 	)
 	if err != nil {
-		return log.Errore(err)
+		return wasMaintenance, log.Errore(err)
 	}
 
-	if affected, _ := res.RowsAffected(); affected == 0 {
-		err = fmt.Errorf("Instance is not in maintenance mode: %+v", instanceKey)
-	} else {
+	if affected, _ := res.RowsAffected(); affected > 0 {
 		// success
+		wasMaintenance = true
 		AuditOperation("end-maintenance", instanceKey, "")
 	}
-	return err
+	return wasMaintenance, err
 }
 
 // ReadMaintenanceInstanceKey will return the instanceKey for active maintenance by maintenanceToken
@@ -170,7 +169,7 @@ func ReadMaintenanceInstanceKey(maintenanceToken int64) (*InstanceKey, error) {
 }
 
 // EndMaintenance will terminate an active maintenance via maintenanceToken
-func EndMaintenance(maintenanceToken int64) error {
+func EndMaintenance(maintenanceToken int64) (wasMaintenance bool, err error) {
 	res, err := db.ExecOrchestrator(`
 			update
 				database_instance_maintenance
@@ -183,16 +182,15 @@ func EndMaintenance(maintenanceToken int64) error {
 		maintenanceToken,
 	)
 	if err != nil {
-		return log.Errore(err)
+		return wasMaintenance, log.Errore(err)
 	}
-	if affected, _ := res.RowsAffected(); affected == 0 {
-		err = fmt.Errorf("Instance is not in maintenance mode; token = %+v", maintenanceToken)
-	} else {
+	if affected, _ := res.RowsAffected(); affected > 0 {
 		// success
+		wasMaintenance = true
 		instanceKey, _ := ReadMaintenanceInstanceKey(maintenanceToken)
 		AuditOperation("end-maintenance", instanceKey, fmt.Sprintf("maintenanceToken: %d", maintenanceToken))
 	}
-	return err
+	return wasMaintenance, err
 }
 
 // ExpireMaintenance will remove the maintenance flag on old maintenances and on bounded maintenances


### PR DESCRIPTION
It makes sense to silently say "ok, instance is not downtimed anymore".

