### PR TITLE
fixing Config-dependant constructs

### DIFF
--- a/go/app/cli_test.go
+++ b/go/app/cli_test.go
@@ -9,6 +9,7 @@ import (
 
 func init() {
 	config.Config.HostnameResolveMethod = "none"
+	config.MarkConfigurationLoaded()
 	log.SetLevel(log.ERROR)
 }
 

--- a/go/cmd/orchestrator/main.go
+++ b/go/cmd/orchestrator/main.go
@@ -130,8 +130,7 @@ func main() {
 		inst.EnableAuditSyslog()
 	}
 	config.RuntimeCLIFlags.ConfiguredVersion = AppVersion
-
-	inst.InitializeInstanceDao()
+	config.MarkConfigurationLoaded()
 
 	if len(flag.Args()) == 0 && *command == "" {
 		// No command, no argument: just prompt

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -32,6 +32,8 @@ var (
 	envVariableRegexp = regexp.MustCompile("[$][{](.*)[}]")
 )
 
+var ConfigurationLoaded chan bool = make(chan bool)
+
 // Configuration makes for orchestrator configuration input, which can be provided by user via JSON formatted file.
 // Some of the parameteres have reasonable default values, and some (like database credentials) are
 // strictly expected from user.
@@ -536,4 +538,14 @@ func Reload() *Configuration {
 		read(fileName)
 	}
 	return Config
+}
+
+// MarkConfigurationLoaded is called once configuration has first been loaded.
+// Listeners on ConfigurationLoaded will get a notification
+func MarkConfigurationLoaded() {
+	go func() {
+		for {
+			ConfigurationLoaded <- true
+		}
+	}()
 }

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -548,4 +548,6 @@ func MarkConfigurationLoaded() {
 			ConfigurationLoaded <- true
 		}
 	}()
+	// wait for it
+	<-ConfigurationLoaded
 }

--- a/go/http/api_test.go
+++ b/go/http/api_test.go
@@ -13,6 +13,7 @@ import (
 
 func init() {
 	config.Config.HostnameResolveMethod = "none"
+	config.MarkConfigurationLoaded()
 	log.SetLevel(log.ERROR)
 }
 

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -31,12 +31,20 @@ import (
 var analysisChangeWriteAttemptCounter = metrics.NewCounter()
 var analysisChangeWriteCounter = metrics.NewCounter()
 
+var recentInstantAnalysis *cache.Cache
+
 func init() {
 	metrics.Register("analysis.change.write.attempt", analysisChangeWriteAttemptCounter)
 	metrics.Register("analysis.change.write", analysisChangeWriteCounter)
+
+	go initializeAnalysisDaoPostConfiguration()
 }
 
-var recentInstantAnalysis = cache.New(time.Duration(config.Config.RecoveryPollSeconds*2)*time.Second, time.Second)
+func initializeAnalysisDaoPostConfiguration() {
+	<-config.ConfigurationLoaded
+
+	recentInstantAnalysis = cache.New(time.Duration(config.Config.RecoveryPollSeconds*2)*time.Second, time.Second)
+}
 
 // GetReplicationAnalysis will check for replication problems (dead master; unreachable master; etc)
 func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnalysis bool) ([]ReplicationAnalysis, error) {

--- a/go/inst/instance_binlog_dao.go
+++ b/go/inst/instance_binlog_dao.go
@@ -33,7 +33,17 @@ import (
 const maxEmptyBinlogFiles int = 10
 const maxEventInfoDisplayLength int = 200
 
-var instanceBinlogEntryCache = cache.New(time.Duration(10)*time.Minute, time.Minute)
+var instanceBinlogEntryCache *cache.Cache
+
+func init() {
+	go initializeBinlogDaoPostConfiguration()
+}
+
+func initializeBinlogDaoPostConfiguration() {
+	<-config.ConfigurationLoaded
+
+	instanceBinlogEntryCache = cache.New(time.Duration(10)*time.Minute, time.Minute)
+}
 
 func compilePseudoGTIDPattern() (pseudoGTIDRegexp *regexp.Regexp, err error) {
 	log.Debugf("PseudoGTIDPatternIsFixedSubstring: %+v", config.Config.PseudoGTIDPatternIsFixedSubstring)

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -68,9 +68,12 @@ func init() {
 	metrics.Register("instance.read_topology", readTopologyInstanceCounter)
 	metrics.Register("instance.read", readInstanceCounter)
 	metrics.Register("instance.write", writeInstanceCounter)
+
+	go initializeInstanceDao()
 }
 
-func InitializeInstanceDao() {
+func initializeInstanceDao() {
+	<-config.ConfigurationLoaded
 	instanceWriteBuffer = make(chan instanceUpdateObject, config.Config.InstanceWriteBufferSize)
 	instanceKeyInformativeClusterName = cache.New(time.Duration(config.Config.InstancePollSeconds/2)*time.Second, time.Second)
 

--- a/go/inst/instance_test.go
+++ b/go/inst/instance_test.go
@@ -25,6 +25,7 @@ import (
 
 func init() {
 	config.Config.HostnameResolveMethod = "none"
+	config.MarkConfigurationLoaded()
 	log.SetLevel(log.ERROR)
 }
 

--- a/go/inst/instance_topology_test.go
+++ b/go/inst/instance_topology_test.go
@@ -18,6 +18,7 @@ var (
 
 func init() {
 	config.Config.HostnameResolveMethod = "none"
+	config.MarkConfigurationLoaded()
 	log.SetLevel(log.ERROR)
 }
 

--- a/go/inst/resolve.go
+++ b/go/inst/resolve.go
@@ -46,14 +46,22 @@ func (this HostnameUnresolve) String() string {
 	return fmt.Sprintf("%s %s", this.hostname, this.unresolvedHostname)
 }
 
+var hostnameResolvesLightweightCache *cache.Cache
+var hostnameResolvesLightweightCacheLoadedOnceFromDB bool = false
+
 func init() {
 	if config.Config.ExpiryHostnameResolvesMinutes < 1 {
 		config.Config.ExpiryHostnameResolvesMinutes = 1
 	}
+
+	go initializeResolvePostConfiguration()
 }
 
-var hostnameResolvesLightweightCache = cache.New(time.Duration(config.Config.ExpiryHostnameResolvesMinutes)*time.Minute, time.Minute)
-var hostnameResolvesLightweightCacheLoadedOnceFromDB bool = false
+func initializeResolvePostConfiguration() {
+	<-config.ConfigurationLoaded
+
+	hostnameResolvesLightweightCache = cache.New(time.Duration(config.Config.ExpiryHostnameResolvesMinutes)*time.Minute, time.Minute)
+}
 
 func HostnameResolveMethodIsNone() bool {
 	return strings.ToLower(config.Config.HostnameResolveMethod) == "none"

--- a/go/inst/resolve.go
+++ b/go/inst/resolve.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -47,19 +48,22 @@ func (this HostnameUnresolve) String() string {
 }
 
 var hostnameResolvesLightweightCache *cache.Cache
+var hostnameResolvesLightweightCacheInit = &sync.Mutex{}
 var hostnameResolvesLightweightCacheLoadedOnceFromDB bool = false
 
 func init() {
 	if config.Config.ExpiryHostnameResolvesMinutes < 1 {
 		config.Config.ExpiryHostnameResolvesMinutes = 1
 	}
-	go initializeResolvePostConfiguration()
 }
 
-func initializeResolvePostConfiguration() {
-	<-config.ConfigurationLoaded
-
-	hostnameResolvesLightweightCache = cache.New(time.Duration(config.Config.ExpiryHostnameResolvesMinutes)*time.Minute, time.Minute)
+func getHostnameResolvesLightweightCache() *cache.Cache {
+	hostnameResolvesLightweightCacheInit.Lock()
+	defer hostnameResolvesLightweightCacheInit.Unlock()
+	if hostnameResolvesLightweightCache == nil {
+		hostnameResolvesLightweightCache = cache.New(time.Duration(config.Config.ExpiryHostnameResolvesMinutes)*time.Minute, time.Minute)
+	}
+	return hostnameResolvesLightweightCache
 }
 
 func HostnameResolveMethodIsNone() bool {
@@ -105,7 +109,7 @@ func ResolveHostname(hostname string) (string, error) {
 	}
 
 	// First go to lightweight cache
-	if resolvedHostname, found := hostnameResolvesLightweightCache.Get(hostname); found {
+	if resolvedHostname, found := getHostnameResolvesLightweightCache().Get(hostname); found {
 		return resolvedHostname.(string), nil
 	}
 
@@ -116,7 +120,7 @@ func ResolveHostname(hostname string) (string, error) {
 		// let's try and get the resolved hostname from database.
 		if !HostnameResolveMethodIsNone() {
 			if resolvedHostname, err := ReadResolvedHostname(hostname); err == nil && resolvedHostname != "" {
-				hostnameResolvesLightweightCache.Set(hostname, resolvedHostname, 0)
+				getHostnameResolvesLightweightCache().Set(hostname, resolvedHostname, 0)
 				return resolvedHostname, nil
 			}
 		}
@@ -136,7 +140,7 @@ func ResolveHostname(hostname string) (string, error) {
 	if err != nil {
 		// Problem. What we'll do is cache the hostname for just one minute, so as to avoid flooding requests
 		// on one hand, yet make it refresh shortly on the other hand. Anyway do not write to database.
-		hostnameResolvesLightweightCache.Set(hostname, resolvedHostname, time.Minute)
+		getHostnameResolvesLightweightCache().Set(hostname, resolvedHostname, time.Minute)
 		return hostname, err
 	}
 	// Good result! Cache it, also to DB
@@ -152,10 +156,10 @@ func UpdateResolvedHostname(hostname string, resolvedHostname string) bool {
 	if resolvedHostname == "" {
 		return false
 	}
-	if existingResolvedHostname, found := hostnameResolvesLightweightCache.Get(hostname); found && (existingResolvedHostname == resolvedHostname) {
+	if existingResolvedHostname, found := getHostnameResolvesLightweightCache().Get(hostname); found && (existingResolvedHostname == resolvedHostname) {
 		return false
 	}
-	hostnameResolvesLightweightCache.Set(hostname, resolvedHostname, 0)
+	getHostnameResolvesLightweightCache().Set(hostname, resolvedHostname, 0)
 	if !HostnameResolveMethodIsNone() {
 		WriteResolvedHostname(hostname, resolvedHostname)
 	}
@@ -175,7 +179,7 @@ func loadHostnameResolveCacheFromDatabase() error {
 		return err
 	}
 	for _, hostnameResolve := range allHostnamesResolves {
-		hostnameResolvesLightweightCache.Set(hostnameResolve.hostname, hostnameResolve.resolvedHostname, 0)
+		getHostnameResolvesLightweightCache().Set(hostnameResolve.hostname, hostnameResolve.resolvedHostname, 0)
 	}
 	hostnameResolvesLightweightCacheLoadedOnceFromDB = true
 	return nil
@@ -187,7 +191,7 @@ func FlushNontrivialResolveCacheToDatabase() error {
 	}
 	items, _ := HostnameResolveCache()
 	for hostname := range items {
-		resolvedHostname, found := hostnameResolvesLightweightCache.Get(hostname)
+		resolvedHostname, found := getHostnameResolvesLightweightCache().Get(hostname)
 		if found && (resolvedHostname.(string) != hostname) {
 			WriteResolvedHostname(hostname, resolvedHostname.(string))
 		}
@@ -197,13 +201,13 @@ func FlushNontrivialResolveCacheToDatabase() error {
 
 func ResetHostnameResolveCache() error {
 	err := deleteHostnameResolves()
-	hostnameResolvesLightweightCache.Flush()
+	getHostnameResolvesLightweightCache().Flush()
 	hostnameResolvesLightweightCacheLoadedOnceFromDB = false
 	return err
 }
 
 func HostnameResolveCache() (map[string]cache.Item, error) {
-	return hostnameResolvesLightweightCache.Items(), nil
+	return getHostnameResolvesLightweightCache().Items(), nil
 }
 
 func UnresolveHostname(instanceKey *InstanceKey) (InstanceKey, bool, error) {

--- a/go/inst/resolve.go
+++ b/go/inst/resolve.go
@@ -53,7 +53,6 @@ func init() {
 	if config.Config.ExpiryHostnameResolvesMinutes < 1 {
 		config.Config.ExpiryHostnameResolvesMinutes = 1
 	}
-
 	go initializeResolvePostConfiguration()
 }
 

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -107,7 +107,7 @@ const (
 	MasterRecoveryRemoteSSH                       = "MasterRecoveryRemoteSSH"
 )
 
-var emergencyReadTopologyInstanceMap = cache.New(time.Duration(config.Config.InstancePollSeconds)*time.Second, time.Second)
+var emergencyReadTopologyInstanceMap *cache.Cache
 
 // InstancesByCountReplicas sorts instances by umber of replicas, descending
 type InstancesByCountReplicas [](*inst.Instance)
@@ -148,6 +148,14 @@ func init() {
 	metrics.Register("recover.unreach_master_stale_slaves.start", recoverUnreachableMasterWithStaleSlavesCounter)
 	metrics.Register("recover.unreach_master_stale_slaves.success", recoverUnreachableMasterWithStaleSlavesSuccessCounter)
 	metrics.Register("recover.unreach_master_stale_slaves.fail", recoverUnreachableMasterWithStaleSlavesFailureCounter)
+
+	go initializeTopologyRecoveryPostConfiguration()
+}
+
+func initializeTopologyRecoveryPostConfiguration() {
+	<-config.ConfigurationLoaded
+
+	emergencyReadTopologyInstanceMap = cache.New(time.Second, time.Second)
 }
 
 // replaceCommandPlaceholders replaces agreed-upon placeholders with analysis data


### PR DESCRIPTION
Some constructs were depending on `config.Config` variables even before these would be populated. Such constructs were just assuming `var someCache = ...` within general scope.

With this PR it is possible to listen on a global `ConfigurationLoaded` channel, which produces endless "I have loaded" tokens right after loading.
