### PR TITLE
some postponed functions to work immediately

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -461,15 +461,14 @@ func RecoverDeadMaster(topologyRecovery *TopologyRecovery, skipProcesses bool) (
 		topologyRecovery.AddPostponedFunction(postponedFunction)
 	}
 	if config.Config.MasterFailoverLostInstancesDowntimeMinutes > 0 {
-		postponedFunction := func() error {
+		func() error {
 			inst.BeginDowntime(failedInstanceKey, inst.GetMaintenanceOwner(), inst.DowntimeLostInRecoveryMessage, config.Config.MasterFailoverLostInstancesDowntimeMinutes*60)
 			for _, replica := range lostReplicas {
 				replica := replica
 				inst.BeginDowntime(&replica.Key, inst.GetMaintenanceOwner(), inst.DowntimeLostInRecoveryMessage, config.Config.MasterFailoverLostInstancesDowntimeMinutes*60)
 			}
 			return nil
-		}
-		topologyRecovery.AddPostponedFunction(postponedFunction)
+		}()
 	}
 
 	if promotedReplica == nil {
@@ -629,12 +628,11 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 			}
 			topologyRecovery.AddPostponedFunction(postponedFunction)
 		}
-		postponedFunction := func() error {
+		func() error {
 			log.Infof("topology_recovery: - RecoverDeadMaster: updating cluster_alias")
 			inst.ReplaceAliasClusterName(analysisEntry.AnalyzedInstanceKey.StringCode(), promotedReplica.Key.StringCode())
 			return nil
-		}
-		topologyRecovery.AddPostponedFunction(postponedFunction)
+		}()
 
 		attributes.SetGeneralAttribute(analysisEntry.ClusterDetails.ClusterDomain, promotedReplica.Key.StringCode())
 	} else {
@@ -1056,15 +1054,14 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 		topologyRecovery.AddPostponedFunction(postponedFunction)
 	}
 	if config.Config.MasterFailoverLostInstancesDowntimeMinutes > 0 {
-		postponedFunction := func() error {
+		func() error {
 			inst.BeginDowntime(failedInstanceKey, inst.GetMaintenanceOwner(), inst.DowntimeLostInRecoveryMessage, config.Config.MasterFailoverLostInstancesDowntimeMinutes*60)
 			for _, replica := range lostReplicas {
 				replica := replica
 				inst.BeginDowntime(&replica.Key, inst.GetMaintenanceOwner(), inst.DowntimeLostInRecoveryMessage, config.Config.MasterFailoverLostInstancesDowntimeMinutes*60)
 			}
 			return nil
-		}
-		topologyRecovery.AddPostponedFunction(postponedFunction)
+		}()
 	}
 
 	return promotedReplica, lostReplicas, err


### PR DESCRIPTION
Some operations were executed as _postponed_, i.e. after failover was done with critical changes.

However some of these operations are purely internal (e.g. `BeginDowntime`) and there was no sense in making them postponed.
