### PR TITLE
structured, audited recovery steps

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1460,7 +1460,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			}
 
-			replacement, err := logic.GetBestMasterReplacementFromAmongItsReplicas(clusterMaster, replicas, false)
+			replacement, err := logic.GetBestMasterReplacementFromAmongItsReplicas(nil, clusterMaster, replicas, false)
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/db/db.go
+++ b/go/db/db.go
@@ -774,6 +774,15 @@ var generateSQLBase = []string{
 			PRIMARY KEY (cluster_name)
 		) ENGINE=InnoDB DEFAULT CHARSET=ascii
 	`,
+	`
+		CREATE TABLE IF NOT EXISTS topology_recovery_steps (
+			recovery_step_id bigint unsigned not null auto_increment,
+			recovery_uid varchar(128) CHARACTER SET ascii NOT NULL,
+			audit_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			message text CHARACTER SET utf8 NOT NULL,
+			PRIMARY KEY (recovery_step_id)
+		) ENGINE=InnoDB DEFAULT CHARSET=ascii
+	`,
 }
 
 // generateSQLPatches contains DDLs for patching schema to the latest version.
@@ -1205,6 +1214,16 @@ var generateSQLPatches = []string{
 		ALTER TABLE
 			database_instance
 			ADD COLUMN binlog_row_image varchar(16) CHARACTER SET ascii NOT NULL
+	`,
+	`
+		ALTER TABLE topology_recovery
+			ADD COLUMN uid varchar(128) CHARACTER SET ascii NOT NULL
+	`,
+	`
+		CREATE INDEX uid_idx_topology_recovery ON topology_recovery(uid)
+	`,
+	`
+		CREATE INDEX recovery_uid_idx_topology_recovery_steps ON topology_recovery_steps(recovery_uid)
 	`,
 }
 

--- a/go/http/web.go
+++ b/go/http/web.go
@@ -276,6 +276,21 @@ func (this *HttpWeb) AuditFailureDetection(params martini.Params, r render.Rende
 	})
 }
 
+func (this *HttpWeb) AuditRecoverySteps(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+	recoveryUID := params["uid"]
+
+	r.HTML(200, "templates/audit_recovery_steps", map[string]interface{}{
+		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"title":               "audit-recovery-steps",
+		"activePage":          "audit",
+		"authorizedForAction": isAuthorizedForAction(req, user),
+		"userId":              getUserId(req, user),
+		"autoshow_problems":   false,
+		"recoveryUID":         recoveryUID,
+		"prefix":              this.URLPrefix,
+	})
+}
+
 func (this *HttpWeb) Agents(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	r.HTML(200, "templates/agents", map[string]interface{}{
 		"agentsHttpActive":    config.Config.ServeAgentsHttp,
@@ -423,6 +438,7 @@ func (this *HttpWeb) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get(this.URLPrefix+"/web/audit-failure-detection", this.AuditFailureDetection)
 	m.Get(this.URLPrefix+"/web/audit-failure-detection/:page", this.AuditFailureDetection)
 	m.Get(this.URLPrefix+"/web/audit-failure-detection/id/:id", this.AuditFailureDetection)
+	m.Get(this.URLPrefix+"/web/audit-recovery-steps/:uid", this.AuditRecoverySteps)
 	m.Get(this.URLPrefix+"/web/agents", this.Agents)
 	m.Get(this.URLPrefix+"/web/agent/:host", this.Agent)
 	m.Get(this.URLPrefix+"/web/seed-details/:seedId", this.AgentSeedDetails)

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -50,6 +50,7 @@ type TopologyRecovery struct {
 	inst.PostponedFunctionsContainer
 
 	Id                        int64
+	UID                       string
 	AnalysisEntry             inst.ReplicationAnalysis
 	SuccessorKey              *inst.InstanceKey
 	SuccessorAlias            string
@@ -74,6 +75,7 @@ type TopologyRecovery struct {
 
 func NewTopologyRecovery(replicationAnalysis inst.ReplicationAnalysis) *TopologyRecovery {
 	topologyRecovery := &TopologyRecovery{}
+	topologyRecovery.UID = fmt.Sprintf("%d:%s", time.Now().Nanosecond(), process.NewToken().Hash)
 	topologyRecovery.AnalysisEntry = replicationAnalysis
 	topologyRecovery.SuccessorKey = nil
 	topologyRecovery.LostReplicas = *inst.NewInstanceKeyMap()
@@ -95,6 +97,12 @@ func (this *TopologyRecovery) AddErrors(errs []error) {
 	for _, err := range errs {
 		this.AddError(err)
 	}
+}
+
+type TopologyRecoveryStep struct {
+	RecoveryUID string
+	AuditAt     string
+	Message     string
 }
 
 type MasterRecoveryType string
@@ -348,7 +356,7 @@ func recoverDeadMasterViaRelaylogSync(topologyRecovery *TopologyRecovery) (promo
 		var replacementErr error
 		once.Do(func() {
 			log.Debugf("recoverDeadMasterViaRelaylogSync: getting best replacement for %+v from among its %+v replicas", failedMaster.Key, len(replicas))
-			replacement, replacementErr = GetBestMasterReplacementFromAmongItsReplicas(failedMaster, replicas, false)
+			replacement, replacementErr = GetBestMasterReplacementFromAmongItsReplicas(topologyRecovery, failedMaster, replicas, false)
 			log.Debugf("recoverDeadMasterViaRelaylogSync: + got nil? %+v ; error: %+v", (replacement == nil), replacementErr)
 			if replacementErr != nil {
 				return
@@ -414,7 +422,7 @@ func RecoverDeadMaster(topologyRecovery *TopologyRecovery, skipProcesses bool) (
 		}
 	}
 
-	log.Infof("topology_recovery: RecoverDeadMaster: will recover %+v", *failedInstanceKey)
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: will recover %+v", *failedInstanceKey))
 
 	var masterRecoveryType MasterRecoveryType = MasterRecoveryPseudoGTID
 	if analysisEntry.OracleGTIDImmediateTopology || analysisEntry.MariaDBGTIDImmediateTopology {
@@ -425,7 +433,7 @@ func RecoverDeadMaster(topologyRecovery *TopologyRecovery, skipProcesses bool) (
 		masterRecoveryType = MasterRecoveryRemoteSSH
 	}
 	topologyRecovery.RecoveryType = masterRecoveryType
-	log.Infof("topology_recovery: RecoverDeadMaster: masterRecoveryType=%+v", masterRecoveryType)
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: masterRecoveryType=%+v", masterRecoveryType))
 
 	switch masterRecoveryType {
 	case MasterRecoveryGTID:
@@ -451,7 +459,7 @@ func RecoverDeadMaster(topologyRecovery *TopologyRecovery, skipProcesses bool) (
 
 	if promotedReplica != nil && len(lostReplicas) > 0 && config.Config.DetachLostReplicasAfterMasterFailover {
 		postponedFunction := func() error {
-			log.Infof("topology_recovery: - RecoverDeadMaster: lost %+v replicas during recovery process; detaching them", len(lostReplicas))
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: lost %+v replicas during recovery process; detaching them", len(lostReplicas)))
 			for _, replica := range lostReplicas {
 				replica := replica
 				inst.DetachReplicaOperation(&replica.Key)
@@ -483,7 +491,7 @@ func RecoverDeadMaster(topologyRecovery *TopologyRecovery, skipProcesses bool) (
 // But, is there an even better replica to promote?
 // if candidateInstanceKey is given, then it is forced to be promoted over the promotedReplica
 // Otherwise, search for the best to promote!
-func replacePromotedReplicaWithCandidate(deadInstanceKey *inst.InstanceKey, promotedReplica *inst.Instance, candidateInstanceKey *inst.InstanceKey) (*inst.Instance, error) {
+func replacePromotedReplicaWithCandidate(topologyRecovery *TopologyRecovery, deadInstanceKey *inst.InstanceKey, promotedReplica *inst.Instance, candidateInstanceKey *inst.InstanceKey) (*inst.Instance, error) {
 	candidateReplicas, _ := inst.ReadClusterCandidateInstances(promotedReplica.ClusterName)
 	// So we've already promoted a replica.
 	// However, can we improve on our choice? Are there any replicas marked with "is_candidate"?
@@ -492,7 +500,7 @@ func replacePromotedReplicaWithCandidate(deadInstanceKey *inst.InstanceKey, prom
 	// - 1. we prefer to promote a "is_candidate" which is in the same DC & env as the dead intermediate master (or do nothing if the promtoed replica is such one)
 	// - 2. we prefer to promote a "is_candidate" which is in the same DC & env as the promoted replica (or do nothing if the promtoed replica is such one)
 	// - 3. keep to current choice
-	log.Infof("topology_recovery: checking if should replace promoted replica with a better candidate")
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("checking if should replace promoted replica with a better candidate"))
 	if candidateInstanceKey == nil {
 		if deadInstance, _, err := inst.ReadInstance(deadInstanceKey); err == nil && deadInstance != nil {
 			for _, candidateReplica := range candidateReplicas {
@@ -500,7 +508,7 @@ func replacePromotedReplicaWithCandidate(deadInstanceKey *inst.InstanceKey, prom
 					promotedReplica.DataCenter == deadInstance.DataCenter &&
 					promotedReplica.PhysicalEnvironment == deadInstance.PhysicalEnvironment {
 					// Seems like we promoted a candidate in the same DC & ENV as dead IM! Ideal! We're happy!
-					log.Infof("topology_recovery: promoted replica %+v is the ideal candidate", promotedReplica.Key)
+					AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("promoted replica %+v is the ideal candidate", promotedReplica.Key))
 					return promotedReplica, nil
 				}
 			}
@@ -516,7 +524,7 @@ func replacePromotedReplicaWithCandidate(deadInstanceKey *inst.InstanceKey, prom
 					candidateReplica.MasterKey.Equals(&promotedReplica.Key) {
 					// This would make a great candidate
 					candidateInstanceKey = &candidateReplica.Key
-					log.Infof("topology_recovery: no candidate was offered for %+v but orchestrator picks %+v as candidate replacement, based on being in same DC & env as failed instance", promotedReplica.Key, candidateReplica.Key)
+					AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("no candidate was offered for %+v but orchestrator picks %+v as candidate replacement, based on being in same DC & env as failed instance", promotedReplica.Key, candidateReplica.Key))
 				}
 			}
 		}
@@ -527,7 +535,7 @@ func replacePromotedReplicaWithCandidate(deadInstanceKey *inst.InstanceKey, prom
 			if promotedReplica.Key.Equals(&candidateReplica.Key) {
 				// Seems like we promoted a candidate replica (though not in same DC and ENV as dead master). Good enough.
 				// No further action required.
-				log.Infof("topology_recovery: promoted replica %+v is a good candidate", promotedReplica.Key)
+				AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("promoted replica %+v is a good candidate", promotedReplica.Key))
 				return promotedReplica, nil
 			}
 		}
@@ -541,7 +549,7 @@ func replacePromotedReplicaWithCandidate(deadInstanceKey *inst.InstanceKey, prom
 				candidateReplica.MasterKey.Equals(&promotedReplica.Key) {
 				// OK, better than nothing
 				candidateInstanceKey = &candidateReplica.Key
-				log.Infof("topology_recovery: no candidate was offered for %+v but orchestrator picks %+v as candidate replacement, based on being in same DC & env as promoted instance", promotedReplica.Key, candidateReplica.Key)
+				AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("no candidate was offered for %+v but orchestrator picks %+v as candidate replacement, based on being in same DC & env as promoted instance", promotedReplica.Key, candidateReplica.Key))
 			}
 		}
 	}
@@ -557,7 +565,7 @@ func replacePromotedReplicaWithCandidate(deadInstanceKey *inst.InstanceKey, prom
 	}
 
 	// Try and promote suggested candidate, if applicable and possible
-	log.Infof("topology_recovery: promoted instance %+v is not the suggested candidate %+v. Will see what can be done", promotedReplica.Key, *candidateInstanceKey)
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("promoted instance %+v is not the suggested candidate %+v. Will see what can be done", promotedReplica.Key, *candidateInstanceKey))
 
 	candidateInstance, _, err := inst.ReadInstance(candidateInstanceKey)
 	if err != nil {
@@ -565,16 +573,16 @@ func replacePromotedReplicaWithCandidate(deadInstanceKey *inst.InstanceKey, prom
 	}
 
 	if candidateInstance.MasterKey.Equals(&promotedReplica.Key) {
-		log.Infof("topology_recovery: suggested candidate %+v is replica of promoted instance %+v. Will try and take its master", *candidateInstanceKey, promotedReplica.Key)
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("suggested candidate %+v is replica of promoted instance %+v. Will try and take its master", *candidateInstanceKey, promotedReplica.Key))
 		candidateInstance, err = inst.TakeMaster(&candidateInstance.Key)
 		if err != nil {
 			return promotedReplica, log.Errore(err)
 		}
-		log.Infof("topology_recovery: success promoting %+v over %+v", *candidateInstanceKey, promotedReplica.Key)
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("success promoting %+v over %+v", *candidateInstanceKey, promotedReplica.Key))
 		return candidateInstance, nil
 	}
 
-	log.Infof("topology_recovery: could not manage to promoted suggested candidate %+v", *candidateInstanceKey)
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("could not manage to promoted suggested candidate %+v", *candidateInstanceKey))
 	return promotedReplica, nil
 }
 
@@ -586,18 +594,18 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 	}
 	topologyRecovery, err := AttemptRecoveryRegistration(&analysisEntry, !forceInstanceRecovery, !forceInstanceRecovery)
 	if topologyRecovery == nil {
-		log.Infof("topology_recovery: found an active or recent recovery on %+v. Will not issue another RecoverDeadMaster.", analysisEntry.AnalyzedInstanceKey)
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another RecoverDeadMaster.", analysisEntry.AnalyzedInstanceKey))
 		return false, nil, err
 	}
 
 	// That's it! We must do recovery!
-	log.Infof("topology_recovery: will handle DeadMaster event on %+v", analysisEntry.ClusterDetails.ClusterName)
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("will handle DeadMaster event on %+v", analysisEntry.ClusterDetails.ClusterName))
 	recoverDeadMasterCounter.Inc(1)
 	promotedReplica, lostReplicas, err := RecoverDeadMaster(topologyRecovery, skipProcesses)
 	topologyRecovery.LostReplicas.AddInstances(lostReplicas)
 
 	if promotedReplica != nil {
-		promotedReplica, err = replacePromotedReplicaWithCandidate(&analysisEntry.AnalyzedInstanceKey, promotedReplica, candidateInstanceKey)
+		promotedReplica, err = replacePromotedReplicaWithCandidate(topologyRecovery, &analysisEntry.AnalyzedInstanceKey, promotedReplica, candidateInstanceKey)
 		topologyRecovery.AddError(err)
 	}
 	// And this is the end; whether successful or not, we're done.
@@ -611,7 +619,7 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 		recoverDeadMasterSuccessCounter.Inc(1)
 
 		if config.Config.ApplyMySQLPromotionAfterMasterFailover {
-			log.Infof("topology_recovery: - RecoverDeadMaster: will apply MySQL changes to promoted master")
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadMaster: will apply MySQL changes to promoted master"))
 			inst.ResetSlaveOperation(&promotedReplica.Key)
 			inst.SetReadOnly(&promotedReplica.Key, false)
 		}
@@ -622,14 +630,14 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 
 		if config.Config.MasterFailoverDetachReplicaMasterHost {
 			postponedFunction := func() error {
-				log.Infof("topology_recovery: - RecoverDeadMaster: detaching master host on promoted master")
+				AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadMaster: detaching master host on promoted master"))
 				inst.DetachReplicaMasterHost(&promotedReplica.Key)
 				return nil
 			}
 			topologyRecovery.AddPostponedFunction(postponedFunction)
 		}
 		func() error {
-			log.Infof("topology_recovery: - RecoverDeadMaster: updating cluster_alias")
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadMaster: updating cluster_alias"))
 			inst.ReplaceAliasClusterName(analysisEntry.AnalyzedInstanceKey.StringCode(), promotedReplica.Key.StringCode())
 			return nil
 		}()
@@ -703,7 +711,7 @@ func isGenerallyValidAsWouldBeMaster(replica *inst.Instance, requireLogSlaveUpda
 	return true
 }
 
-func GetBestMasterReplacementFromAmongItsReplicas(master *inst.Instance, replicas [](*inst.Instance), requireLogSlaveUpdates bool) (replacement *inst.Instance, err error) {
+func GetBestMasterReplacementFromAmongItsReplicas(topologyRecovery *TopologyRecovery, master *inst.Instance, replicas [](*inst.Instance), requireLogSlaveUpdates bool) (replacement *inst.Instance, err error) {
 	// Sanity:
 	for _, replica := range replicas {
 		if !replica.MasterKey.Equals(&master.Key) {
@@ -721,38 +729,38 @@ func GetBestMasterReplacementFromAmongItsReplicas(master *inst.Instance, replica
 		if replica.IsCandidate &&
 			replica.DataCenter == master.DataCenter &&
 			replica.PhysicalEnvironment == master.PhysicalEnvironment {
-			log.Infof("GetBestMasterReplacementFromAmongItsReplicas: found %+v as the ideal candidate", replica.Key)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("GetBestMasterReplacementFromAmongItsReplicas: found %+v as the ideal candidate", replica.Key))
 			return replica, nil
 		}
 	}
 	for _, replica := range validReplicas {
 		if replica.IsCandidate &&
 			replica.DataCenter == master.DataCenter {
-			log.Infof("GetBestMasterReplacementFromAmongItsReplicas: found %+v as candidate in same dc", replica.Key)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("GetBestMasterReplacementFromAmongItsReplicas: found %+v as candidate in same dc", replica.Key))
 			return replica, nil
 		}
 	}
 	for _, replica := range validReplicas {
 		if replica.DataCenter == master.DataCenter &&
 			replica.PhysicalEnvironment == master.PhysicalEnvironment {
-			log.Infof("GetBestMasterReplacementFromAmongItsReplicas: found %+v as valid replacement in same dc & environment", replica.Key)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("GetBestMasterReplacementFromAmongItsReplicas: found %+v as valid replacement in same dc & environment", replica.Key))
 			return replica, nil
 		}
 	}
 	for _, replica := range validReplicas {
 		if replica.DataCenter == master.DataCenter {
-			log.Infof("GetBestMasterReplacementFromAmongItsReplicas: found %+v as valid replacement in same dc", replica.Key)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("GetBestMasterReplacementFromAmongItsReplicas: found %+v as valid replacement in same dc", replica.Key))
 			return replica, nil
 		}
 	}
 	for _, replica := range validReplicas {
 		if replica.IsCandidate {
-			log.Infof("GetBestMasterReplacementFromAmongItsReplicas: found %+v as candidate in different dc", replica.Key)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("GetBestMasterReplacementFromAmongItsReplicas: found %+v as candidate in different dc", replica.Key))
 			return replica, nil
 		}
 	}
 	for _, replica := range validReplicas {
-		log.Infof("GetBestMasterReplacementFromAmongItsReplicas: found %+v as valid replacement in different dc", replica.Key)
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("GetBestMasterReplacementFromAmongItsReplicas: found %+v as valid replacement in different dc", replica.Key))
 		return replica, nil
 	}
 	return nil, fmt.Errorf("GetBestMasterReplacementFromAmongItsReplicas: cannot find replacement")
@@ -760,7 +768,7 @@ func GetBestMasterReplacementFromAmongItsReplicas(master *inst.Instance, replica
 
 // GetCandidateSiblingOfIntermediateMaster chooses the best sibling of a dead intermediate master
 // to whom the IM's replicas can be moved.
-func GetCandidateSiblingOfIntermediateMaster(intermediateMasterInstance *inst.Instance) (*inst.Instance, error) {
+func GetCandidateSiblingOfIntermediateMaster(topologyRecovery *TopologyRecovery, intermediateMasterInstance *inst.Instance) (*inst.Instance, error) {
 
 	siblings, err := inst.ReadReplicaInstances(&intermediateMasterInstance.MasterKey)
 	if err != nil {
@@ -777,14 +785,14 @@ func GetCandidateSiblingOfIntermediateMaster(intermediateMasterInstance *inst.In
 	// this has small likelihood in the general case, and, well, it's an attempt. It's a Plan A, but we have Plan B & C if this fails.
 
 	// At first, we try to return an "is_candidate" server in same dc & env
-	log.Infof("topology_recovery: searching for the best candidate sibling of dead intermediate master %+v", intermediateMasterInstance.Key)
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("searching for the best candidate sibling of dead intermediate master %+v", intermediateMasterInstance.Key))
 	for _, sibling := range siblings {
 		sibling := sibling
 		if isValidAsCandidateSiblingOfIntermediateMaster(intermediateMasterInstance, sibling) &&
 			sibling.IsCandidate &&
 			sibling.DataCenter == intermediateMasterInstance.DataCenter &&
 			sibling.PhysicalEnvironment == intermediateMasterInstance.PhysicalEnvironment {
-			log.Infof("topology_recovery: found %+v as the ideal candidate", sibling.Key)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found %+v as the ideal candidate", sibling.Key))
 			return sibling, nil
 		}
 	}
@@ -794,7 +802,7 @@ func GetCandidateSiblingOfIntermediateMaster(intermediateMasterInstance *inst.In
 		if isValidAsCandidateSiblingOfIntermediateMaster(intermediateMasterInstance, sibling) &&
 			sibling.DataCenter == intermediateMasterInstance.DataCenter &&
 			sibling.PhysicalEnvironment == intermediateMasterInstance.PhysicalEnvironment {
-			log.Infof("topology_recovery: found %+v as a replacement for %+v [same dc & environment]", sibling.Key, intermediateMasterInstance.Key)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found %+v as a replacement for %+v [same dc & environment]", sibling.Key, intermediateMasterInstance.Key))
 			return sibling, nil
 		}
 	}
@@ -802,7 +810,7 @@ func GetCandidateSiblingOfIntermediateMaster(intermediateMasterInstance *inst.In
 	for _, sibling := range siblings {
 		sibling := sibling
 		if isValidAsCandidateSiblingOfIntermediateMaster(intermediateMasterInstance, sibling) && sibling.IsCandidate {
-			log.Infof("topology_recovery: found %+v as a replacement for %+v [candidate sibling]", sibling.Key, intermediateMasterInstance.Key)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found %+v as a replacement for %+v [candidate sibling]", sibling.Key, intermediateMasterInstance.Key))
 			return sibling, nil
 		}
 	}
@@ -810,7 +818,7 @@ func GetCandidateSiblingOfIntermediateMaster(intermediateMasterInstance *inst.In
 	for _, sibling := range siblings {
 		sibling := sibling
 		if isValidAsCandidateSiblingOfIntermediateMaster(intermediateMasterInstance, sibling) {
-			log.Infof("topology_recovery: found %+v as a replacement for %+v [any sibling]", sibling.Key, intermediateMasterInstance.Key)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found %+v as a replacement for %+v [any sibling]", sibling.Key, intermediateMasterInstance.Key))
 			return sibling, nil
 		}
 	}
@@ -835,23 +843,23 @@ func RecoverDeadIntermediateMaster(topologyRecovery *TopologyRecovery, skipProce
 		return nil, topologyRecovery.AddError(err)
 	}
 	// Find possible candidate
-	candidateSiblingOfIntermediateMaster, err := GetCandidateSiblingOfIntermediateMaster(intermediateMasterInstance)
+	candidateSiblingOfIntermediateMaster, err := GetCandidateSiblingOfIntermediateMaster(topologyRecovery, intermediateMasterInstance)
 	relocateReplicasToCandidateSibling := func() {
 		if candidateSiblingOfIntermediateMaster == nil {
 			return
 		}
 		// We have a candidate
-		log.Infof("topology_recovery: - RecoverDeadIntermediateMaster: will attempt a candidate intermediate master: %+v", candidateSiblingOfIntermediateMaster.Key)
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: will attempt a candidate intermediate master: %+v", candidateSiblingOfIntermediateMaster.Key))
 		relocatedReplicas, candidateSibling, err, errs := inst.RelocateReplicas(failedInstanceKey, &candidateSiblingOfIntermediateMaster.Key, "")
 		topologyRecovery.AddErrors(errs)
 		topologyRecovery.ParticipatingInstanceKeys.AddKey(candidateSiblingOfIntermediateMaster.Key)
 
 		if len(relocatedReplicas) == 0 {
-			log.Infof("topology_recovery: - RecoverDeadIntermediateMaster: failed to move any replica to candidate intermediate master (%+v)", candidateSibling.Key)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: failed to move any replica to candidate intermediate master (%+v)", candidateSibling.Key))
 			return
 		}
 		if err != nil || len(errs) > 0 {
-			log.Infof("topology_recovery: - RecoverDeadIntermediateMaster: move to candidate intermediate master (%+v) did not complete: %+v", candidateSibling.Key, err)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: move to candidate intermediate master (%+v) did not complete: %+v", candidateSibling.Key, err))
 			return
 		}
 		if err == nil {
@@ -866,12 +874,12 @@ func RecoverDeadIntermediateMaster(topologyRecovery *TopologyRecovery, skipProce
 		relocateReplicasToCandidateSibling()
 	}
 	if !recoveryResolved {
-		log.Infof("topology_recovery: - RecoverDeadIntermediateMaster: will next attempt regrouping of replicas")
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: will next attempt regrouping of replicas"))
 		// Plan B: regroup (we wish to reduce cross-DC replication streams)
 		lostReplicas, _, _, _, regroupPromotedReplica, regroupError := inst.RegroupReplicas(failedInstanceKey, true, nil, nil)
 		if regroupError != nil {
 			topologyRecovery.AddError(regroupError)
-			log.Infof("topology_recovery: - RecoverDeadIntermediateMaster: regroup failed on: %+v", regroupError)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: regroup failed on: %+v", regroupError))
 		}
 		if regroupPromotedReplica != nil {
 			topologyRecovery.ParticipatingInstanceKeys.AddKey(regroupPromotedReplica.Key)
@@ -883,7 +891,7 @@ func RecoverDeadIntermediateMaster(topologyRecovery *TopologyRecovery, skipProce
 		}
 		// Plan C: try replacement intermediate master in other DC...
 		if candidateSiblingOfIntermediateMaster != nil && candidateSiblingOfIntermediateMaster.DataCenter != intermediateMasterInstance.DataCenter {
-			log.Infof("topology_recovery: - RecoverDeadIntermediateMaster: will next attempt relocating to another DC server")
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: will next attempt relocating to another DC server"))
 			relocateReplicasToCandidateSibling()
 		}
 	}
@@ -894,7 +902,7 @@ func RecoverDeadIntermediateMaster(topologyRecovery *TopologyRecovery, skipProce
 		// one replica, but the operation is still valid if regroup partially/completely failed. We just promote anything
 		// not regrouped.
 		// So, match up all that's left, plan D
-		log.Infof("topology_recovery: - RecoverDeadIntermediateMaster: will next attempt to relocate up from %+v", *failedInstanceKey)
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: will next attempt to relocate up from %+v", *failedInstanceKey))
 
 		relocatedReplicas, masterInstance, err, errs := inst.RelocateReplicas(failedInstanceKey, &analysisEntry.AnalyzedInstanceMasterKey, "")
 		topologyRecovery.AddErrors(errs)
@@ -927,7 +935,7 @@ func checkAndRecoverDeadIntermediateMaster(analysisEntry inst.ReplicationAnalysi
 	}
 	topologyRecovery, err := AttemptRecoveryRegistration(&analysisEntry, !forceInstanceRecovery, !forceInstanceRecovery)
 	if topologyRecovery == nil {
-		log.Infof("topology_recovery: found an active or recent recovery on %+v. Will not issue another RecoverDeadIntermediateMaster.", analysisEntry.AnalyzedInstanceKey)
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: found an active or recent recovery on %+v. Will not issue another RecoverDeadIntermediateMaster.", analysisEntry.AnalyzedInstanceKey))
 		return false, nil, err
 	}
 
@@ -966,14 +974,14 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 		}
 	}
 
-	log.Infof("topology_recovery: RecoverDeadCoMaster: will recover %+v", *failedInstanceKey)
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: will recover %+v", *failedInstanceKey))
 
 	var coMasterRecoveryType MasterRecoveryType = MasterRecoveryPseudoGTID
 	if analysisEntry.OracleGTIDImmediateTopology || analysisEntry.MariaDBGTIDImmediateTopology {
 		coMasterRecoveryType = MasterRecoveryGTID
 	}
 
-	log.Infof("topology_recovery: RecoverDeadCoMaster: coMasterRecoveryType=%+v", coMasterRecoveryType)
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: coMasterRecoveryType=%+v", coMasterRecoveryType))
 
 	var cannotReplicateReplicas [](*inst.Instance)
 	switch coMasterRecoveryType {
@@ -991,24 +999,24 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 
 	mustPromoteOtherCoMaster := config.Config.CoMasterRecoveryMustPromoteOtherCoMaster
 	if !otherCoMaster.ReadOnly {
-		log.Infof("topology_recovery: RecoverDeadCoMaster: other co-master %+v is writeable hence has to be promoted", otherCoMaster.Key)
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: other co-master %+v is writeable hence has to be promoted", otherCoMaster.Key))
 		mustPromoteOtherCoMaster = true
 	}
-	log.Infof("topology_recovery: RecoverDeadCoMaster: mustPromoteOtherCoMaster? %+v", mustPromoteOtherCoMaster)
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: mustPromoteOtherCoMaster? %+v", mustPromoteOtherCoMaster))
 
 	if promotedReplica != nil {
 		topologyRecovery.ParticipatingInstanceKeys.AddKey(promotedReplica.Key)
 		if mustPromoteOtherCoMaster {
-			log.Infof("topology_recovery: mustPromoteOtherCoMaster. Verifying that %+v is/can be promoted", *otherCoMasterKey)
-			promotedReplica, err = replacePromotedReplicaWithCandidate(failedInstanceKey, promotedReplica, otherCoMasterKey)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: mustPromoteOtherCoMaster. Verifying that %+v is/can be promoted", *otherCoMasterKey))
+			promotedReplica, err = replacePromotedReplicaWithCandidate(topologyRecovery, failedInstanceKey, promotedReplica, otherCoMasterKey)
 		} else {
 			// We are allowed to promote any server
-			promotedReplica, err = replacePromotedReplicaWithCandidate(failedInstanceKey, promotedReplica, nil)
+			promotedReplica, err = replacePromotedReplicaWithCandidate(topologyRecovery, failedInstanceKey, promotedReplica, nil)
 
 			if promotedReplica.DataCenter == otherCoMaster.DataCenter &&
 				promotedReplica.PhysicalEnvironment == otherCoMaster.PhysicalEnvironment && false {
 				// and _still_ we prefer to promote the co-master! They're in same env & DC so no worries about geo issues!
-				promotedReplica, err = replacePromotedReplicaWithCandidate(failedInstanceKey, promotedReplica, otherCoMasterKey)
+				promotedReplica, err = replacePromotedReplicaWithCandidate(topologyRecovery, failedInstanceKey, promotedReplica, otherCoMasterKey)
 			}
 		}
 		topologyRecovery.AddError(err)
@@ -1044,7 +1052,7 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 
 	if promotedReplica != nil && len(lostReplicas) > 0 && config.Config.DetachLostReplicasAfterMasterFailover {
 		postponedFunction := func() error {
-			log.Infof("topology_recovery: - RecoverDeadCoMaster: lost %+v replicas during recovery process; detaching them", len(lostReplicas))
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadCoMaster: lost %+v replicas during recovery process; detaching them", len(lostReplicas)))
 			for _, replica := range lostReplicas {
 				replica := replica
 				inst.DetachReplicaOperation(&replica.Key)
@@ -1076,7 +1084,7 @@ func checkAndRecoverDeadCoMaster(analysisEntry inst.ReplicationAnalysis, candida
 	}
 	topologyRecovery, err := AttemptRecoveryRegistration(&analysisEntry, !forceInstanceRecovery, !forceInstanceRecovery)
 	if topologyRecovery == nil {
-		log.Infof("topology_recovery: found an active or recent recovery on %+v. Will not issue another RecoverDeadCoMaster.", analysisEntry.AnalyzedInstanceKey)
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another RecoverDeadCoMaster.", analysisEntry.AnalyzedInstanceKey))
 		return false, nil, err
 	}
 
@@ -1095,7 +1103,7 @@ func checkAndRecoverDeadCoMaster(analysisEntry inst.ReplicationAnalysis, candida
 		recoverDeadCoMasterSuccessCounter.Inc(1)
 
 		if config.Config.ApplyMySQLPromotionAfterMasterFailover {
-			log.Infof("topology_recovery: - RecoverDeadMaster: will apply MySQL changes to promoted master")
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadMaster: will apply MySQL changes to promoted master"))
 			inst.SetReadOnly(&promotedReplica.Key, false)
 		}
 		if !skipProcesses {
@@ -1115,7 +1123,7 @@ func checkAndRecoverDeadCoMaster(analysisEntry inst.ReplicationAnalysis, candida
 func checkAndRecoverUnreachableMasterWithStaleSlaves(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (bool, *TopologyRecovery, error) {
 	topologyRecovery, err := AttemptRecoveryRegistration(&analysisEntry, !forceInstanceRecovery, !forceInstanceRecovery)
 	if topologyRecovery == nil {
-		log.Infof("topology_recovery: found an active or recent recovery on %+v. Will not issue another UnreachableMasterWithStaleSlaves.", analysisEntry.AnalyzedInstanceKey)
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another UnreachableMasterWithStaleSlaves.", analysisEntry.AnalyzedInstanceKey))
 	} else {
 		recoverUnreachableMasterWithStaleSlavesCounter.Inc(1)
 		if !skipProcesses {

--- a/go/logic/topology_recovery_dao.go
+++ b/go/logic/topology_recovery_dao.go
@@ -133,9 +133,11 @@ func AttemptRecoveryRegistration(analysisEntry *inst.ReplicationAnalysis, failIf
 		// trying to recover the same instance at the same time
 	}
 
+	topologyRecovery := NewTopologyRecovery(*analysisEntry)
 	sqlResult, err := db.ExecOrchestrator(`
 			insert ignore
 				into topology_recovery (
+					uid,
 					hostname,
 					port,
 					in_active_period,
@@ -152,6 +154,7 @@ func AttemptRecoveryRegistration(analysisEntry *inst.ReplicationAnalysis, failIf
 				) values (
 					?,
 					?,
+					?,
 					1,
 					NOW(),
 					0,
@@ -164,7 +167,7 @@ func AttemptRecoveryRegistration(analysisEntry *inst.ReplicationAnalysis, failIf
 					?,
 					(select ifnull(max(detection_id), 0) from topology_failure_detection where hostname=? and port=?)
 				)
-			`, analysisEntry.AnalyzedInstanceKey.Hostname, analysisEntry.AnalyzedInstanceKey.Port, process.ThisHostname, process.ProcessToken.Hash,
+			`, topologyRecovery.UID, analysisEntry.AnalyzedInstanceKey.Hostname, analysisEntry.AnalyzedInstanceKey.Port, process.ThisHostname, process.ProcessToken.Hash,
 		string(analysisEntry.Analysis), analysisEntry.ClusterDetails.ClusterName, analysisEntry.ClusterDetails.ClusterAlias, analysisEntry.CountReplicas, analysisEntry.SlaveHosts.ToCommaDelimitedList(),
 		analysisEntry.AnalyzedInstanceKey.Hostname, analysisEntry.AnalyzedInstanceKey.Port,
 	)
@@ -179,7 +182,6 @@ func AttemptRecoveryRegistration(analysisEntry *inst.ReplicationAnalysis, failIf
 		return nil, nil
 	}
 	// Success
-	topologyRecovery := NewTopologyRecovery(*analysisEntry)
 	topologyRecovery.Id, _ = sqlResult.LastInsertId()
 	return topologyRecovery, nil
 }
@@ -290,10 +292,7 @@ func ExpireBlockedRecoveries() error {
 					last_blocked_timestamp < NOW() - interval ? second
 			`, (config.Config.RecoveryPollSeconds * 2),
 	)
-	if err != nil {
-		return log.Errore(err)
-	}
-	return nil
+	return log.Errore(err)
 }
 
 // acknowledgeRecoveries sets acknowledged* details and clears the in_active_period flags from a set of entries
@@ -421,6 +420,7 @@ func readRecoveries(whereCondition string, limit string, args []interface{}) ([]
 	query := fmt.Sprintf(`
 		select
             recovery_id,
+						uid,
             hostname,
             port,
             (IFNULL(end_active_period_unixtime, 0) = 0) as is_active,
@@ -456,6 +456,7 @@ func readRecoveries(whereCondition string, limit string, args []interface{}) ([]
 	err := db.QueryOrchestrator(query, args, func(m sqlutils.RowMap) error {
 		topologyRecovery := *NewTopologyRecovery(inst.ReplicationAnalysis{})
 		topologyRecovery.Id = m.GetInt64("recovery_id")
+		topologyRecovery.UID = m.GetString("uid")
 
 		topologyRecovery.IsActive = m.GetBool("is_active")
 		topologyRecovery.RecoveryStartTimestamp = m.GetString("start_active_period")
@@ -494,10 +495,7 @@ func readRecoveries(whereCondition string, limit string, args []interface{}) ([]
 		return nil
 	})
 
-	if err != nil {
-		log.Errore(err)
-	}
-	return res, err
+	return res, log.Errore(err)
 }
 
 // ReadActiveRecoveries reads active recovery entry/audit entires from topology_recovery
@@ -573,6 +571,12 @@ func ReadRecovery(recoveryId int64) ([]TopologyRecovery, error) {
 	return readRecoveries(whereClause, ``, sqlutils.Args(recoveryId))
 }
 
+// ReadRecoveryByUID reads completed recovery entry/audit entires from topology_recovery
+func ReadRecoveryByUID(recoveryUID string) ([]TopologyRecovery, error) {
+	whereClause := `where uid = ?`
+	return readRecoveries(whereClause, ``, sqlutils.Args(recoveryUID))
+}
+
 // ReadCRecoveries reads latest recovery entries from topology_recovery
 func ReadRecentRecoveries(clusterName string, unacknowledgedOnly bool, page int) ([]TopologyRecovery, error) {
 	whereConditions := []string{}
@@ -646,10 +650,7 @@ func readFailureDetections(whereCondition string, limit string, args []interface
 		return nil
 	})
 
-	if err != nil {
-		log.Errore(err)
-	}
-	return res, err
+	return res, log.Errore(err)
 }
 
 // ReadRecentFailureDetections
@@ -702,8 +703,46 @@ func ReadBlockedRecoveries(clusterName string) ([]BlockedTopologyRecovery, error
 		return nil
 	})
 
-	if err != nil {
-		log.Errore(err)
+	return res, log.Errore(err)
+}
+
+// AuditTopologyRecovery audits a single step in a topology recovery process.
+func AuditTopologyRecovery(topologyRecovery *TopologyRecovery, message string) error {
+	log.Infof("topology_recovery: %s", message)
+	if topologyRecovery == nil {
+		return nil
 	}
-	return res, err
+	_, err := db.ExecOrchestrator(`
+			insert
+				into topology_recovery_steps (
+					recovery_uid, audit_at, message
+				) values (?, now(), ?)
+			`, topologyRecovery.UID, message,
+	)
+	return log.Errore(err)
+}
+
+// ReadTopologyRecoverySteps reads recovery steps for a given recovery
+func ReadTopologyRecoverySteps(recoveryUID string) ([]TopologyRecoveryStep, error) {
+	res := []TopologyRecoveryStep{}
+	query := `
+		select
+			recovery_uid, audit_at, message
+		from
+			topology_recovery_steps
+		where
+			recovery_uid=?
+		order by
+			recovery_step_id asc
+		`
+	err := db.QueryOrchestrator(query, sqlutils.Args(recoveryUID), func(m sqlutils.RowMap) error {
+		recoveryStep := TopologyRecoveryStep{}
+		recoveryStep.RecoveryUID = recoveryUID
+		recoveryStep.AuditAt = m.GetString("audit_at")
+		recoveryStep.Message = m.GetString("message")
+
+		res = append(res, recoveryStep)
+		return nil
+	})
+	return res, log.Errore(err)
 }

--- a/resources/public/js/audit-recovery-steps.js
+++ b/resources/public/js/audit-recovery-steps.js
@@ -1,0 +1,61 @@
+$(document).ready(function() {
+  showLoader();
+
+  var recoveryUri = "/api/audit-recovery/uid/" + recoveryUID();
+  var uri = "/api/audit-recovery-steps/" + recoveryUID();
+
+  $.get(appUrl(uri), function(steps) {
+    $.get(appUrl(recoveryUri), function(recoveryAudits) {
+      displayAudit(steps, recoveryAudits);
+    }, "json");
+  }, "json");
+
+  function displayAudit(steps, recoveryAudits) {
+    hideLoader();
+
+    recoveryAudits.forEach(function(audit) {
+      // There's really just the one audit.
+      var analyzedInstanceDisplay = audit.AnalysisEntry.AnalyzedInstanceKey.Hostname + ":" + audit.AnalysisEntry.AnalyzedInstanceKey.Port;
+      var row = jQuery('<tr/>');
+      var moreInfoElement = $('<span class="more-detection-info pull-right glyphicon glyphicon-info-sign text-primary" title="More info"></span>');
+      moreInfoElement.attr("data-detection-id", audit.Id);
+
+      $('<td/>', {
+        text: audit.AnalysisEntry.Analysis
+      }).prepend(moreInfoElement).appendTo(row);
+      $('<a/>', {
+        text: analyzedInstanceDisplay,
+        href: appUrl("/web/search/" + analyzedInstanceDisplay)
+      }).wrap($("<td/>")).parent().appendTo(row);
+      $('<td/>', {
+        text: audit.AnalysisEntry.CountReplicas
+      }).appendTo(row);
+      $('<a/>', {
+        text: audit.AnalysisEntry.ClusterDetails.ClusterName,
+        href: appUrl("/web/cluster/" + audit.AnalysisEntry.ClusterDetails.ClusterName)
+      }).wrap($("<td/>")).parent().appendTo(row);
+      $('<a/>', {
+        text: audit.AnalysisEntry.ClusterDetails.ClusterAlias,
+        href: appUrl("/web/cluster/alias/" + audit.AnalysisEntry.ClusterDetails.ClusterAlias)
+      }).wrap($("<td/>")).parent().appendTo(row);
+      $('<td/>', {
+        text: audit.RecoveryStartTimestamp
+      }).appendTo(row);
+      row.appendTo('#audit_recovery_table tbody');
+    });
+
+    steps.forEach(function(step) {
+      console.log(step);
+
+      var row = $('<tr/>');
+      $('<td/>', {
+        text: step.AuditAt
+      }).appendTo(row);
+      $('<td/>', {
+        text: step.Message
+      }).appendTo(row);
+
+      row.appendTo('#audit_recovery_steps tbody');
+    });
+  }
+});

--- a/resources/public/js/audit-recovery.js
+++ b/resources/public/js/audit-recovery.js
@@ -111,6 +111,7 @@ $(document).ready(function() {
       }
       moreInfo += '<div><a href="' + appUrl('/web/audit-failure-detection/id/' + audit.LastDetectionId) + '">Related detection</a></div>';
       moreInfo += '<div>Proccessed by <code>' + audit.ProcessingNodeHostname + '</code></div>';
+      moreInfo += '<div><a href="' + appUrl('/web/audit-recovery-steps/' + audit.UID) + '">Recovery steps</a></div>';
       row.appendTo('#audit tbody');
 
       var row = $('<tr/>');

--- a/resources/templates/audit_recovery_steps.tmpl
+++ b/resources/templates/audit_recovery_steps.tmpl
@@ -1,0 +1,38 @@
+<div class="container" id="audit">
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <table id="audit_recovery_table" class="table table-striped table-bordered table-condensed">
+        <thead>
+          <tr>
+            <th>Analysis</th>
+            <th>Failed instance</th>
+            <th>Affected</th>
+            <th>Cluster name</th>
+            <th>Cluster alias</th>
+            <th>Detect time</th>
+          </tr>
+        </thead>
+        <tbody>
+        </tbody>
+      </table>
+      <table id="audit_recovery_steps" class="table table-striped table-bordered table-condensed">
+        <thead>
+          <tr>
+            <th>Audit at</th>
+            <th>Message</th>
+          </tr>
+        </thead>
+        <tbody>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+
+<script>
+  function recoveryUID() {
+    return "{{.recoveryUID}}";
+  }
+</script>
+<script src="{{.prefix}}/js/audit-recovery-steps.js"></script>


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/120

Recovery steps are now audited in the `topology_recovery_steps` table. A new `UID` field in `topology_recovery` indicates a uniquely identified recovery (there's the `auto_increment` id, but that's generated only after the recovery is written; there's a bit of a chicken and an egg here; this isn't the best solution but good enough).

The steps are visible via:

- api: `/api/audit-recovery-steps/:uid`, where `uid` relates to `topology_recovery.uid` column, or to `UID` field in `/api/audit-recovery/...` response
- web: `Audit`->`Recovery`->`Recovery steps`

cc @sjmudd 