### PR TITLE
make the configuration race detector safe.

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -208,7 +208,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	}
 
 	if instance != "" && !strings.Contains(instance, ":") {
-		instance = fmt.Sprintf("%s:%d", instance, config.Config.DefaultInstancePort)
+		instance = fmt.Sprintf("%s:%d", instance, config.Config().DefaultInstancePort)
 	}
 
 	instanceKey, err := inst.ParseInstanceKey(instance)
@@ -222,7 +222,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	}
 
 	if destination != "" && !strings.Contains(destination, ":") {
-		destination = fmt.Sprintf("%s:%d", destination, config.Config.DefaultInstancePort)
+		destination = fmt.Sprintf("%s:%d", destination, config.Config().DefaultInstancePort)
 	}
 	destinationKey, err := inst.ParseInstanceKey(destination)
 	if err != nil {
@@ -232,7 +232,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 		destinationKey = inst.ReadFuzzyInstanceKeyIfPossible(destinationKey)
 	}
 	if hostname, err := os.Hostname(); err == nil {
-		thisInstanceKey = &inst.InstanceKey{Hostname: hostname, Port: int(config.Config.DefaultInstancePort)}
+		thisInstanceKey = &inst.InstanceKey{Hostname: hostname, Port: int(config.Config().DefaultInstancePort)}
 	}
 	postponedFunctionsContainer := inst.NewPostponedFunctionsContainer()
 
@@ -1567,7 +1567,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 		}
 	case registerCliCommand("dump-config", "Meta", `Print out configuration in JSON format`):
 		{
-			jsonString := config.Config.ToJSONString()
+			jsonString := config.Config().ToJSONString()
 			fmt.Println(jsonString)
 		}
 	case registerCliCommand("show-resolve-hosts", "Meta", `Show the content of the hostname_resolve table. Generally used for debugging`):

--- a/go/app/cli_test.go
+++ b/go/app/cli_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	config.Config.HostnameResolveMethod = "none"
+	config.Config().HostnameResolveMethod = "none"
 	config.MarkConfigurationLoaded()
 	log.SetLevel(log.ERROR)
 }

--- a/go/cmd/orchestrator/main.go
+++ b/go/cmd/orchestrator/main.go
@@ -113,20 +113,20 @@ func main() {
 		config.Read("/etc/orchestrator.conf.json", "conf/orchestrator.conf.json", "orchestrator.conf.json")
 	}
 	if *config.RuntimeCLIFlags.Databaseless {
-		config.Config.DatabaselessMode__experimental = true
+		config.SetDatabaselessMode__experimental()
 	}
-	if config.Config.Debug {
+	if config.Config().Debug {
 		log.SetLevel(log.DEBUG)
 	}
 	if *quiet {
 		// Override!!
 		log.SetLevel(log.ERROR)
 	}
-	if config.Config.EnableSyslog {
+	if config.Config().EnableSyslog {
 		log.EnableSyslogWriter("orchestrator")
 		log.SetSyslogLevel(log.INFO)
 	}
-	if config.Config.AuditToSyslog {
+	if config.Config().AuditToSyslog {
 		inst.EnableAuditSyslog()
 	}
 	config.RuntimeCLIFlags.ConfiguredVersion = AppVersion

--- a/go/collection/collection.go
+++ b/go/collection/collection.go
@@ -120,7 +120,7 @@ func CreateOrReturnCollection(name string) *Collection {
 		collection: nil,
 		done:       make(chan struct{}),
 		// WARNING: use a different configuration name
-		expirePeriod: time.Duration(config.Config.DiscoveryCollectionRetentionSeconds) * time.Second,
+		expirePeriod: time.Duration(config.Config().DiscoveryCollectionRetentionSeconds) * time.Second,
 	}
 	go qmc.StartAutoExpiration()
 

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -599,3 +599,10 @@ func SetDatabaselessMode__experimental() {
 
 	config.DatabaselessMode__experimental = true
 }
+
+func SetStatusOUVerify(value bool) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	config.StatusOUVerify = value
+}

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 
 	"gopkg.in/gcfg.v1"
 
@@ -222,11 +223,27 @@ func (this *Configuration) GetDiscoveryPollSeconds() uint {
 	return 1
 }
 
-// Config is *the* configuration instance, used globally to get configuration data
-var Config = newConfiguration()
-var readFileNames []string
+// config is a private copy of the global configuration
+var config = defaultConfiguration()
 
-func newConfiguration() *Configuration {
+// records a copy of the file names read at startup.
+var readFileNames []string
+var lock sync.RWMutex
+
+// Config() returns a copy of the pointer to the configuration to
+// avoid it being overwritten while the configuration is being read
+// or reloaded.
+func Config() *Configuration {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	c := config
+
+	return c
+}
+
+// defaultConfiguration returns the orchestrator default configuration settings
+func defaultConfiguration() *Configuration {
 	return &Configuration{
 		Debug:                                        false,
 		EnableSyslog:                                 false,
@@ -376,6 +393,10 @@ func newConfiguration() *Configuration {
 }
 
 func (this *Configuration) postReadAdjustments() error {
+	// lock the configuration before potentially changing it
+	lock.Lock()
+	defer lock.Unlock()
+
 	if this.MySQLOrchestratorCredentialsConfigFile != "" {
 		mySQLConfig := struct {
 			Client struct {
@@ -493,51 +514,71 @@ func (this *Configuration) IsMySQL() bool {
 	return this.BackendDB == "mysql" || this.BackendDB == ""
 }
 
-// read reads configuration from given file, or silently skips if the file does not exist.
-// If the file does exist, then it is expected to be in valid JSON format or the function bails out.
-func read(fileName string) (*Configuration, error) {
+// read reads configuration from given file, or silently skips if
+// the file does not exist.  If the file does exist, then it is
+// expected to be in valid JSON format or the function bails out.
+// - a current configuration is provided and changes are applied to
+//   that.
+func read(fileName string, c *Configuration) error {
 	file, err := os.Open(fileName)
 	if err == nil {
 		decoder := json.NewDecoder(file)
-		err := decoder.Decode(Config)
+		err := decoder.Decode(c) // modify provided config
 		if err == nil {
 			log.Infof("Read config: %s", fileName)
 		} else {
 			log.Fatal("Cannot read config file:", fileName, err)
 		}
-		if err := Config.postReadAdjustments(); err != nil {
+		if err := c.postReadAdjustments(); err != nil {
 			log.Fatale(err)
 		}
 	}
-	return Config, err
+	return err
 }
 
-// Read reads configuration from zero, either, some or all given files, in order of input.
-// A file can override configuration provided in previous file.
-func Read(fileNames ...string) *Configuration {
+// Read reads configuration information from zero or more files
+// after first applying the default configuration.  Each file can
+// override configuration provided in the previous file.
+// - the final configuration can be read by calling Config()
+func Read(fileNames ...string) {
+	c := defaultConfiguration()
+
 	for _, fileName := range fileNames {
-		read(fileName)
+		read(fileName, c) // ignore errors!
 	}
 	readFileNames = fileNames
-	return Config
+
+	lock.Lock()
+	config = c // modify global config
+	lock.Unlock()
 }
 
 // ForceRead reads configuration from given file name or bails out if it fails
-func ForceRead(fileName string) *Configuration {
-	_, err := read(fileName)
+func ForceRead(fileName string) {
+	c := defaultConfiguration()
+
+	err := read(fileName, c)
 	if err != nil {
 		log.Fatal("Cannot read config file:", fileName, err)
 	}
 	readFileNames = []string{fileName}
-	return Config
+
+	lock.Lock()
+	config = c // modify global config
+	lock.Unlock()
 }
 
 // Reload re-reads configuration from last used files
-func Reload() *Configuration {
+func Reload() {
+	c := defaultConfiguration()
+
 	for _, fileName := range readFileNames {
-		read(fileName)
+		read(fileName, c) // ignore errors!
 	}
-	return Config
+
+	lock.Lock()
+	config = c // modify global config
+	lock.Unlock()
 }
 
 // MarkConfigurationLoaded is called once configuration has first been loaded.
@@ -550,4 +591,11 @@ func MarkConfigurationLoaded() {
 	}()
 	// wait for it
 	<-ConfigurationLoaded
+}
+
+func SetDatabaselessMode__experimental() {
+	lock.Lock()
+	defer lock.Unlock()
+
+	config.DatabaselessMode__experimental = true
 }

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -8,27 +8,27 @@ import (
 )
 
 func init() {
-	Config.HostnameResolveMethod = "none"
+	Config().HostnameResolveMethod = "none"
 	log.SetLevel(log.ERROR)
 }
 
 func TestReplicationLagQuery(t *testing.T) {
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.SlaveLagQuery = "select 3"
 		c.ReplicationLagQuery = "select 4"
 		err := c.postReadAdjustments()
 		test.S(t).ExpectNotNil(err)
 	}
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.SlaveLagQuery = "select 3"
 		c.ReplicationLagQuery = "select 3"
 		err := c.postReadAdjustments()
 		test.S(t).ExpectNil(err)
 	}
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.SlaveLagQuery = "select 3"
 		c.ReplicationLagQuery = ""
 		err := c.postReadAdjustments()
@@ -39,21 +39,21 @@ func TestReplicationLagQuery(t *testing.T) {
 
 func TestPostponeReplicaRecoveryOnLagMinutes(t *testing.T) {
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.PostponeSlaveRecoveryOnLagMinutes = 3
 		c.PostponeReplicaRecoveryOnLagMinutes = 5
 		err := c.postReadAdjustments()
 		test.S(t).ExpectNotNil(err)
 	}
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.PostponeSlaveRecoveryOnLagMinutes = 3
 		c.PostponeReplicaRecoveryOnLagMinutes = 3
 		err := c.postReadAdjustments()
 		test.S(t).ExpectNil(err)
 	}
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.PostponeSlaveRecoveryOnLagMinutes = 3
 		c.PostponeReplicaRecoveryOnLagMinutes = 0
 		err := c.postReadAdjustments()
@@ -64,7 +64,7 @@ func TestPostponeReplicaRecoveryOnLagMinutes(t *testing.T) {
 
 func TestMasterFailoverDetachReplicaMasterHost(t *testing.T) {
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.MasterFailoverDetachSlaveMasterHost = false
 		c.MasterFailoverDetachReplicaMasterHost = false
 		err := c.postReadAdjustments()
@@ -72,7 +72,7 @@ func TestMasterFailoverDetachReplicaMasterHost(t *testing.T) {
 		test.S(t).ExpectFalse(c.MasterFailoverDetachReplicaMasterHost)
 	}
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.MasterFailoverDetachSlaveMasterHost = false
 		c.MasterFailoverDetachReplicaMasterHost = true
 		err := c.postReadAdjustments()
@@ -80,7 +80,7 @@ func TestMasterFailoverDetachReplicaMasterHost(t *testing.T) {
 		test.S(t).ExpectTrue(c.MasterFailoverDetachReplicaMasterHost)
 	}
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.MasterFailoverDetachSlaveMasterHost = true
 		c.MasterFailoverDetachReplicaMasterHost = false
 		err := c.postReadAdjustments()
@@ -91,7 +91,7 @@ func TestMasterFailoverDetachReplicaMasterHost(t *testing.T) {
 
 func TestMasterFailoverDetachDetachLostReplicasAfterMasterFailover(t *testing.T) {
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.DetachLostSlavesAfterMasterFailover = false
 		c.DetachLostReplicasAfterMasterFailover = false
 		err := c.postReadAdjustments()
@@ -99,7 +99,7 @@ func TestMasterFailoverDetachDetachLostReplicasAfterMasterFailover(t *testing.T)
 		test.S(t).ExpectFalse(c.DetachLostReplicasAfterMasterFailover)
 	}
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.DetachLostSlavesAfterMasterFailover = false
 		c.DetachLostReplicasAfterMasterFailover = true
 		err := c.postReadAdjustments()
@@ -107,7 +107,7 @@ func TestMasterFailoverDetachDetachLostReplicasAfterMasterFailover(t *testing.T)
 		test.S(t).ExpectTrue(c.DetachLostReplicasAfterMasterFailover)
 	}
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.DetachLostSlavesAfterMasterFailover = true
 		c.DetachLostReplicasAfterMasterFailover = false
 		err := c.postReadAdjustments()
@@ -118,7 +118,7 @@ func TestMasterFailoverDetachDetachLostReplicasAfterMasterFailover(t *testing.T)
 
 func TestRecoveryPeriodBlock(t *testing.T) {
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.RecoveryPeriodBlockSeconds = 0
 		c.RecoveryPeriodBlockMinutes = 0
 		err := c.postReadAdjustments()
@@ -126,7 +126,7 @@ func TestRecoveryPeriodBlock(t *testing.T) {
 		test.S(t).ExpectEquals(c.RecoveryPeriodBlockSeconds, 0)
 	}
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.RecoveryPeriodBlockSeconds = 30
 		c.RecoveryPeriodBlockMinutes = 1
 		err := c.postReadAdjustments()
@@ -134,7 +134,7 @@ func TestRecoveryPeriodBlock(t *testing.T) {
 		test.S(t).ExpectEquals(c.RecoveryPeriodBlockSeconds, 30)
 	}
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.RecoveryPeriodBlockSeconds = 0
 		c.RecoveryPeriodBlockMinutes = 2
 		err := c.postReadAdjustments()
@@ -142,7 +142,7 @@ func TestRecoveryPeriodBlock(t *testing.T) {
 		test.S(t).ExpectEquals(c.RecoveryPeriodBlockSeconds, 120)
 	}
 	{
-		c := newConfiguration()
+		c := defaultConfiguration()
 		c.RecoveryPeriodBlockSeconds = 15
 		c.RecoveryPeriodBlockMinutes = 0
 		err := c.postReadAdjustments()

--- a/go/discovery/queue.go
+++ b/go/discovery/queue.go
@@ -82,7 +82,7 @@ func CreateOrReturnQueue(name string) *Queue {
 		name:         name,
 		queuedKeys:   make(map[inst.InstanceKey]time.Time),
 		consumedKeys: make(map[inst.InstanceKey]time.Time),
-		queue:        make(chan inst.InstanceKey, config.Config.DiscoveryQueueCapacity),
+		queue:        make(chan inst.InstanceKey, config.Config().DiscoveryQueueCapacity),
 	}
 	go q.startMonitoring()
 
@@ -119,8 +119,8 @@ func (q *Queue) collectStatistics() {
 	q.metrics = append(q.metrics, QueueMetric{Queued: len(q.queuedKeys), Active: len(q.consumedKeys)})
 
 	// remove old entries if we get too big
-	if len(q.metrics) > config.Config.DiscoveryQueueMaxStatisticsSize {
-		q.metrics = q.metrics[len(q.metrics)-config.Config.DiscoveryQueueMaxStatisticsSize:]
+	if len(q.metrics) > config.Config().DiscoveryQueueMaxStatisticsSize {
+		q.metrics = q.metrics[len(q.metrics)-config.Config().DiscoveryQueueMaxStatisticsSize:]
 	}
 }
 
@@ -166,7 +166,7 @@ func (q *Queue) Consume() inst.InstanceKey {
 
 	// alarm if have been waiting for too long
 	timeOnQueue := time.Since(q.queuedKeys[key])
-	if timeOnQueue > time.Duration(config.Config.InstancePollSeconds)*time.Second {
+	if timeOnQueue > time.Duration(config.Config().InstancePollSeconds)*time.Second {
 		log.Warningf("key %v spent %.4fs waiting on a discoveryQueue", key, timeOnQueue.Seconds())
 	}
 

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1711,7 +1711,7 @@ func (this *HttpAPI) Agents(params martini.Params, r render.Render, req *http.Re
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1732,7 +1732,7 @@ func (this *HttpAPI) Agent(params martini.Params, r render.Render, req *http.Req
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1753,7 +1753,7 @@ func (this *HttpAPI) AgentUnmount(params martini.Params, r render.Render, req *h
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1774,7 +1774,7 @@ func (this *HttpAPI) AgentMountLV(params martini.Params, r render.Render, req *h
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1795,7 +1795,7 @@ func (this *HttpAPI) AgentCreateSnapshot(params martini.Params, r render.Render,
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1816,7 +1816,7 @@ func (this *HttpAPI) AgentRemoveLV(params martini.Params, r render.Render, req *
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1837,7 +1837,7 @@ func (this *HttpAPI) AgentMySQLStop(params martini.Params, r render.Render, req 
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1858,7 +1858,7 @@ func (this *HttpAPI) AgentMySQLStart(params martini.Params, r render.Render, req
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1878,7 +1878,7 @@ func (this *HttpAPI) AgentCustomCommand(params martini.Params, r render.Render, 
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1900,7 +1900,7 @@ func (this *HttpAPI) AgentSeed(params martini.Params, r render.Render, req *http
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1921,7 +1921,7 @@ func (this *HttpAPI) AgentActiveSeeds(params martini.Params, r render.Render, re
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1942,7 +1942,7 @@ func (this *HttpAPI) AgentRecentSeeds(params martini.Params, r render.Render, re
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1963,7 +1963,7 @@ func (this *HttpAPI) AgentSeedDetails(params martini.Params, r render.Render, re
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -1985,7 +1985,7 @@ func (this *HttpAPI) AgentSeedStates(params martini.Params, r render.Render, req
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -2007,7 +2007,7 @@ func (this *HttpAPI) Seeds(params martini.Params, r render.Render, req *http.Req
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -2028,7 +2028,7 @@ func (this *HttpAPI) AbortSeed(params martini.Params, r render.Render, req *http
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	if !config.Config.ServeAgentsHttp {
+	if !config.Config().ServeAgentsHttp {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
 		return
 	}
@@ -2075,7 +2075,7 @@ func (this *HttpAPI) StatusCheck(params martini.Params, r render.Render, req *ht
 	// SimpleHealthTest just checks to see if we can connect to the database.  Lighter weight if you intend to call it a lot
 	var health *process.HealthStatus
 	var err error
-	if config.Config.StatusSimpleHealth {
+	if config.Config().StatusSimpleHealth {
 		health, err = process.SimpleHealthTest()
 	} else {
 		health, err = process.HealthTest()
@@ -2207,9 +2207,9 @@ func (this *HttpAPI) RegisterCandidate(params martini.Params, r render.Render, r
 // AutomatedRecoveryFilters retuens list of clusters which are configured with automated recovery
 func (this *HttpAPI) AutomatedRecoveryFilters(params martini.Params, r render.Render, req *http.Request) {
 	automatedRecoveryMap := make(map[string]interface{})
-	automatedRecoveryMap["RecoverMasterClusterFilters"] = config.Config.RecoverMasterClusterFilters
-	automatedRecoveryMap["RecoverIntermediateMasterClusterFilters"] = config.Config.RecoverIntermediateMasterClusterFilters
-	automatedRecoveryMap["RecoveryIgnoreHostnameFilters"] = config.Config.RecoveryIgnoreHostnameFilters
+	automatedRecoveryMap["RecoverMasterClusterFilters"] = config.Config().RecoverMasterClusterFilters
+	automatedRecoveryMap["RecoverIntermediateMasterClusterFilters"] = config.Config().RecoverIntermediateMasterClusterFilters
+	automatedRecoveryMap["RecoveryIgnoreHostnameFilters"] = config.Config().RecoveryIgnoreHostnameFilters
 
 	r.JSON(200, &APIResponse{Code: OK, Message: fmt.Sprintf("Automated recovery configuration details"), Details: automatedRecoveryMap})
 }
@@ -2643,5 +2643,5 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerRequest(m, "seeds", this.Seeds)
 
 	// Configurable status check endpoint
-	m.Get(config.Config.StatusEndpoint, this.StatusCheck)
+	m.Get(config.Config().StatusEndpoint, this.StatusCheck)
 }

--- a/go/http/api_test.go
+++ b/go/http/api_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	config.Config.HostnameResolveMethod = "none"
+	config.Config().HostnameResolveMethod = "none"
 	config.MarkConfigurationLoaded()
 	log.SetLevel(log.ERROR)
 }

--- a/go/http/httpbase.go
+++ b/go/http/httpbase.go
@@ -28,7 +28,7 @@ import (
 )
 
 func getProxyAuthUser(req *http.Request) string {
-	for _, user := range req.Header[config.Config.AuthUserHeader] {
+	for _, user := range req.Header[config.Config().AuthUserHeader] {
 		return user
 	}
 	return ""
@@ -37,11 +37,11 @@ func getProxyAuthUser(req *http.Request) string {
 // isAuthorizedForAction checks req to see whether authenticated user has write-privileges.
 // This depends on configured authentication method.
 func isAuthorizedForAction(req *http.Request, user auth.User) bool {
-	if config.Config.ReadOnly {
+	if config.Config().ReadOnly {
 		return false
 	}
 
-	switch strings.ToLower(config.Config.AuthenticationMethod) {
+	switch strings.ToLower(config.Config().AuthenticationMethod) {
 	case "basic":
 		{
 			// The mere fact we're here means the user has passed authentication
@@ -59,7 +59,7 @@ func isAuthorizedForAction(req *http.Request, user auth.User) bool {
 	case "proxy":
 		{
 			authUser := getProxyAuthUser(req)
-			for _, configPowerAuthUser := range config.Config.PowerAuthUsers {
+			for _, configPowerAuthUser := range config.Config().PowerAuthUsers {
 				if configPowerAuthUser == "*" || configPowerAuthUser == authUser {
 					return true
 				}
@@ -103,11 +103,11 @@ func authenticateToken(publicToken string, resp http.ResponseWriter) error {
 
 // getUserId returns the authenticated user id, if available, depending on authertication method.
 func getUserId(req *http.Request, user auth.User) string {
-	if config.Config.ReadOnly {
+	if config.Config().ReadOnly {
 		return ""
 	}
 
-	switch strings.ToLower(config.Config.AuthenticationMethod) {
+	switch strings.ToLower(config.Config().AuthenticationMethod) {
 	case "basic":
 		{
 			return string(user)

--- a/go/http/web.go
+++ b/go/http/web.go
@@ -69,42 +69,42 @@ func (this *HttpWeb) Index(params martini.Params, r render.Render, req *http.Req
 
 func (this *HttpWeb) Clusters(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	r.HTML(200, "templates/clusters", map[string]interface{}{
-		"agentsHttpActive":              config.Config.ServeAgentsHttp,
+		"agentsHttpActive":              config.Config().ServeAgentsHttp,
 		"title":                         "clusters",
 		"activePage":                    "cluster",
 		"autoshow_problems":             false,
 		"authorizedForAction":           isAuthorizedForAction(req, user),
 		"userId":                        getUserId(req, user),
-		"removeTextFromHostnameDisplay": config.Config.RemoveTextFromHostnameDisplay,
+		"removeTextFromHostnameDisplay": config.Config().RemoveTextFromHostnameDisplay,
 		"prefix":                        this.URLPrefix,
 	})
 }
 
 func (this *HttpWeb) ClustersAnalysis(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	r.HTML(200, "templates/clusters_analysis", map[string]interface{}{
-		"agentsHttpActive":              config.Config.ServeAgentsHttp,
+		"agentsHttpActive":              config.Config().ServeAgentsHttp,
 		"title":                         "clusters",
 		"activePage":                    "cluster",
 		"autoshow_problems":             false,
 		"authorizedForAction":           isAuthorizedForAction(req, user),
 		"userId":                        getUserId(req, user),
-		"removeTextFromHostnameDisplay": config.Config.RemoveTextFromHostnameDisplay,
+		"removeTextFromHostnameDisplay": config.Config().RemoveTextFromHostnameDisplay,
 		"prefix":                        this.URLPrefix,
 	})
 }
 
 func (this *HttpWeb) Cluster(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	r.HTML(200, "templates/cluster", map[string]interface{}{
-		"agentsHttpActive":              config.Config.ServeAgentsHttp,
+		"agentsHttpActive":              config.Config().ServeAgentsHttp,
 		"title":                         "cluster",
 		"activePage":                    "cluster",
 		"clusterName":                   params["clusterName"],
 		"autoshow_problems":             true,
 		"contextMenuVisible":            true,
-		"pseudoGTIDModeEnabled":         (config.Config.PseudoGTIDPattern != ""),
+		"pseudoGTIDModeEnabled":         (config.Config().PseudoGTIDPattern != ""),
 		"authorizedForAction":           isAuthorizedForAction(req, user),
 		"userId":                        getUserId(req, user),
-		"removeTextFromHostnameDisplay": config.Config.RemoveTextFromHostnameDisplay,
+		"removeTextFromHostnameDisplay": config.Config().RemoveTextFromHostnameDisplay,
 		"compactDisplay":                req.URL.Query().Get("compact"),
 		"prefix":                        this.URLPrefix,
 	})
@@ -146,16 +146,16 @@ func (this *HttpWeb) ClusterByInstance(params martini.Params, r render.Render, r
 
 func (this *HttpWeb) ClusterPools(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	r.HTML(200, "templates/cluster_pools", map[string]interface{}{
-		"agentsHttpActive":              config.Config.ServeAgentsHttp,
+		"agentsHttpActive":              config.Config().ServeAgentsHttp,
 		"title":                         "cluster pools",
 		"activePage":                    "cluster_pools",
 		"clusterName":                   params["clusterName"],
 		"autoshow_problems":             false, // because pool screen by default expands all hosts
 		"contextMenuVisible":            true,
-		"pseudoGTIDModeEnabled":         (config.Config.PseudoGTIDPattern != ""),
+		"pseudoGTIDModeEnabled":         (config.Config().PseudoGTIDPattern != ""),
 		"authorizedForAction":           isAuthorizedForAction(req, user),
 		"userId":                        getUserId(req, user),
-		"removeTextFromHostnameDisplay": config.Config.RemoveTextFromHostnameDisplay,
+		"removeTextFromHostnameDisplay": config.Config().RemoveTextFromHostnameDisplay,
 		"compactDisplay":                req.URL.Query().Get("compact"),
 		"prefix":                        this.URLPrefix,
 	})
@@ -167,7 +167,7 @@ func (this *HttpWeb) Search(params martini.Params, r render.Render, req *http.Re
 		searchString = req.URL.Query().Get("s")
 	}
 	r.HTML(200, "templates/search", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "search",
 		"activePage":          "search",
 		"searchString":        searchString,
@@ -181,7 +181,7 @@ func (this *HttpWeb) Search(params martini.Params, r render.Render, req *http.Re
 func (this *HttpWeb) Discover(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 
 	r.HTML(200, "templates/discover", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "discover",
 		"activePage":          "discover",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -198,7 +198,7 @@ func (this *HttpWeb) LongQueries(params martini.Params, r render.Render, req *ht
 	}
 
 	r.HTML(200, "templates/long_queries", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "long queries",
 		"activePage":          "queries",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -216,7 +216,7 @@ func (this *HttpWeb) Audit(params martini.Params, r render.Render, req *http.Req
 	}
 
 	r.HTML(200, "templates/audit", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "audit",
 		"activePage":          "audit",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -240,7 +240,7 @@ func (this *HttpWeb) AuditRecovery(params martini.Params, r render.Render, req *
 	}
 
 	r.HTML(200, "templates/audit_recovery", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "audit-recovery",
 		"activePage":          "audit",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -264,7 +264,7 @@ func (this *HttpWeb) AuditFailureDetection(params martini.Params, r render.Rende
 	}
 
 	r.HTML(200, "templates/audit_failure_detection", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "audit-failure-detection",
 		"activePage":          "audit",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -280,7 +280,7 @@ func (this *HttpWeb) AuditRecoverySteps(params martini.Params, r render.Render, 
 	recoveryUID := params["uid"]
 
 	r.HTML(200, "templates/audit_recovery_steps", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "audit-recovery-steps",
 		"activePage":          "audit",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -293,7 +293,7 @@ func (this *HttpWeb) AuditRecoverySteps(params martini.Params, r render.Render, 
 
 func (this *HttpWeb) Agents(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	r.HTML(200, "templates/agents", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "agents",
 		"activePage":          "agents",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -305,7 +305,7 @@ func (this *HttpWeb) Agents(params martini.Params, r render.Render, req *http.Re
 
 func (this *HttpWeb) Agent(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	r.HTML(200, "templates/agent", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "agent",
 		"activePage":          "agents",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -318,7 +318,7 @@ func (this *HttpWeb) Agent(params martini.Params, r render.Render, req *http.Req
 
 func (this *HttpWeb) AgentSeedDetails(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	r.HTML(200, "templates/agent_seed_details", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "agent seed details",
 		"activePage":          "agents",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -331,7 +331,7 @@ func (this *HttpWeb) AgentSeedDetails(params martini.Params, r render.Render, re
 
 func (this *HttpWeb) Seeds(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	r.HTML(200, "templates/seeds", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "seeds",
 		"activePage":          "agents",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -344,7 +344,7 @@ func (this *HttpWeb) Seeds(params martini.Params, r render.Render, req *http.Req
 func (this *HttpWeb) Home(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 
 	r.HTML(200, "templates/home", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "home",
 		"activePage":          "home",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -357,7 +357,7 @@ func (this *HttpWeb) Home(params martini.Params, r render.Render, req *http.Requ
 func (this *HttpWeb) About(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 
 	r.HTML(200, "templates/about", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "about",
 		"activePage":          "home",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -370,7 +370,7 @@ func (this *HttpWeb) About(params martini.Params, r render.Render, req *http.Req
 func (this *HttpWeb) KeepCalm(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 
 	r.HTML(200, "templates/keep-calm", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "Keep Calm",
 		"activePage":          "home",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -383,7 +383,7 @@ func (this *HttpWeb) KeepCalm(params martini.Params, r render.Render, req *http.
 func (this *HttpWeb) FAQ(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 
 	r.HTML(200, "templates/faq", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "FAQ",
 		"activePage":          "home",
 		"authorizedForAction": isAuthorizedForAction(req, user),
@@ -396,7 +396,7 @@ func (this *HttpWeb) FAQ(params martini.Params, r render.Render, req *http.Reque
 func (this *HttpWeb) Status(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 
 	r.HTML(200, "templates/status", map[string]interface{}{
-		"agentsHttpActive":    config.Config.ServeAgentsHttp,
+		"agentsHttpActive":    config.Config().ServeAgentsHttp,
 		"title":               "status",
 		"activePage":          "home",
 		"authorizedForAction": isAuthorizedForAction(req, user),

--- a/go/inst/audit_dao.go
+++ b/go/inst/audit_dao.go
@@ -57,9 +57,9 @@ func AuditOperation(auditType string, instanceKey *InstanceKey, message string) 
 		clusterName, _ = GetClusterName(instanceKey)
 	}
 
-	if config.Config.AuditLogFile != "" {
+	if config.Config().AuditLogFile != "" {
 		go func() error {
-			f, err := os.OpenFile(config.Config.AuditLogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
+			f, err := os.OpenFile(config.Config().AuditLogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
 			if err != nil {
 				return log.Errore(err)
 			}
@@ -126,7 +126,7 @@ func ReadRecentAudit(instanceKey *InstanceKey, page int) ([]Audit, error) {
 		limit ?
 		offset ?
 		`, whereCondition)
-	args = append(args, config.Config.AuditPageSize, page*config.Config.AuditPageSize)
+	args = append(args, config.Config().AuditPageSize, page*config.Config().AuditPageSize)
 	err := db.QueryOrchestrator(query, args, func(m sqlutils.RowMap) error {
 		audit := Audit{}
 		audit.AuditId = m.GetInt64("audit_id")
@@ -156,7 +156,7 @@ func ExpireAudit() error {
 			where
 				audit_timestamp < NOW() - INTERVAL ? DAY 
 			`,
-			config.Config.AuditPurgeDays,
+			config.Config().AuditPurgeDays,
 		)
 		return err
 	}

--- a/go/inst/candidate_database_instance.go
+++ b/go/inst/candidate_database_instance.go
@@ -50,7 +50,7 @@ root@myorchestrator [orchestrator]> select * from candidate_database_instance;
 2 rows in set (0.00 sec)
 */
 func BulkReadCandidateDatabaseInstance() ([]CandidateDatabaseInstance, error) {
-	if config.Config.DatabaselessMode__experimental {
+	if config.Config().DatabaselessMode__experimental {
 		return nil, nil // no data to return if not using a database
 	}
 

--- a/go/inst/cluster.go
+++ b/go/inst/cluster.go
@@ -35,8 +35,8 @@ type ClusterInfo struct {
 
 // ReadRecoveryInfo
 func (this *ClusterInfo) ReadRecoveryInfo() {
-	this.HasAutomatedMasterRecovery = this.filtersMatchCluster(config.Config.RecoverMasterClusterFilters)
-	this.HasAutomatedIntermediateMasterRecovery = this.filtersMatchCluster(config.Config.RecoverIntermediateMasterClusterFilters)
+	this.HasAutomatedMasterRecovery = this.filtersMatchCluster(config.Config().RecoverMasterClusterFilters)
+	this.HasAutomatedIntermediateMasterRecovery = this.filtersMatchCluster(config.Config().RecoverIntermediateMasterClusterFilters)
 }
 
 // filtersMatchCluster will see whether the given filters match the given cluster details
@@ -76,9 +76,9 @@ func (this *ClusterInfo) ApplyClusterAlias() {
 		return
 	}
 	// Try out the hard-wired config:
-	for pattern := range config.Config.ClusterNameToAlias {
+	for pattern := range config.Config().ClusterNameToAlias {
 		if matched, _ := regexp.MatchString(pattern, this.ClusterName); matched {
-			this.ClusterAlias = config.Config.ClusterNameToAlias[pattern]
+			this.ClusterAlias = config.Config().ClusterNameToAlias[pattern]
 		}
 	}
 }

--- a/go/inst/cluster_domain_dao.go
+++ b/go/inst/cluster_domain_dao.go
@@ -46,7 +46,7 @@ func ExpireClusterDomainName() error {
 		_, err := db.ExecOrchestrator(`
     	delete from cluster_domain_name
 				where last_registered < NOW() - INTERVAL ? MINUTE
-				`, config.Config.ExpiryHostnameResolvesMinutes,
+				`, config.Config().ExpiryHostnameResolvesMinutes,
 		)
 		return log.Errore(err)
 	}

--- a/go/inst/downtime_dao.go
+++ b/go/inst/downtime_dao.go
@@ -26,7 +26,7 @@ import (
 // BeginDowntime will make mark an instance as downtimed (or override existing downtime period)
 func BeginDowntime(instanceKey *InstanceKey, owner string, reason string, durationSeconds uint) error {
 	if durationSeconds == 0 {
-		durationSeconds = config.Config.MaintenanceExpireMinutes * 60
+		durationSeconds = config.Config().MaintenanceExpireMinutes * 60
 	}
 	_, err := db.ExecOrchestrator(`
 			insert
@@ -94,7 +94,7 @@ func ExpireDowntime() error {
 				downtime_active is null
 				and end_timestamp < NOW() - INTERVAL ? DAY
 			`,
-			config.Config.MaintenancePurgeDays,
+			config.Config().MaintenancePurgeDays,
 		)
 		if err != nil {
 			return log.Errore(err)

--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -346,7 +346,7 @@ func (this *Instance) CanReplicateFrom(other *Instance) (bool, error) {
 			return false, fmt.Errorf("Cannot replicate from %+v binlog format on %+v to %+v on %+v", other.Binlog_format, other.Key, this.Binlog_format, this.Key)
 		}
 	}
-	if config.Config.VerifyReplicationFilters {
+	if config.Config().VerifyReplicationFilters {
 		if other.HasReplicationFilters && !this.HasReplicationFilters {
 			return false, fmt.Errorf("%+v has replication filters", other.Key)
 		}
@@ -361,9 +361,9 @@ func (this *Instance) CanReplicateFrom(other *Instance) (bool, error) {
 func (this *Instance) HasReasonableMaintenanceReplicationLag() bool {
 	// replicas with SQLDelay are a special case
 	if this.SQLDelay > 0 {
-		return math.AbsInt64(this.SecondsBehindMaster.Int64-int64(this.SQLDelay)) <= int64(config.Config.ReasonableMaintenanceReplicationLagSeconds)
+		return math.AbsInt64(this.SecondsBehindMaster.Int64-int64(this.SQLDelay)) <= int64(config.Config().ReasonableMaintenanceReplicationLagSeconds)
 	}
-	return this.SecondsBehindMaster.Int64 <= int64(config.Config.ReasonableMaintenanceReplicationLagSeconds)
+	return this.SecondsBehindMaster.Int64 <= int64(config.Config().ReasonableMaintenanceReplicationLagSeconds)
 }
 
 // CanMove returns true if this instance's state allows it to be repositioned. For example,
@@ -446,7 +446,7 @@ func (this *Instance) LagStatusString() string {
 	if this.IsReplica() && !this.SecondsBehindMaster.Valid {
 		return "null"
 	}
-	if this.IsReplica() && this.SlaveLagSeconds.Int64 > int64(config.Config.ReasonableMaintenanceReplicationLagSeconds) {
+	if this.IsReplica() && this.SlaveLagSeconds.Int64 > int64(config.Config().ReasonableMaintenanceReplicationLagSeconds) {
 		return fmt.Sprintf("%+vs", this.SlaveLagSeconds.Int64)
 	}
 	return fmt.Sprintf("%+vs", this.SlaveLagSeconds.Int64)

--- a/go/inst/instance_binlog.go
+++ b/go/inst/instance_binlog.go
@@ -168,7 +168,7 @@ func (this *BinlogEventCursor) nextRealEvent(recursionLevel int) (*BinlogEvent, 
 		// but we really don't expect a huge sequence of those.
 		return this.nextRealEvent(recursionLevel + 1)
 	}
-	for _, skipSubstring := range config.Config.SkipBinlogEventsContaining {
+	for _, skipSubstring := range config.Config().SkipBinlogEventsContaining {
 		if strings.Index(event.Info, skipSubstring) >= 0 {
 			// Recursion might go deeper here.
 			return this.nextRealEvent(recursionLevel + 1)

--- a/go/inst/instance_binlog_dao.go
+++ b/go/inst/instance_binlog_dao.go
@@ -46,18 +46,18 @@ func initializeBinlogDaoPostConfiguration() {
 }
 
 func compilePseudoGTIDPattern() (pseudoGTIDRegexp *regexp.Regexp, err error) {
-	log.Debugf("PseudoGTIDPatternIsFixedSubstring: %+v", config.Config.PseudoGTIDPatternIsFixedSubstring)
-	if config.Config.PseudoGTIDPatternIsFixedSubstring {
+	log.Debugf("PseudoGTIDPatternIsFixedSubstring: %+v", config.Config().PseudoGTIDPatternIsFixedSubstring)
+	if config.Config().PseudoGTIDPatternIsFixedSubstring {
 		return nil, nil
 	}
-	log.Debugf("Compiling PseudoGTIDPattern: %q", config.Config.PseudoGTIDPattern)
-	return regexp.Compile(config.Config.PseudoGTIDPattern)
+	log.Debugf("Compiling PseudoGTIDPattern: %q", config.Config().PseudoGTIDPattern)
+	return regexp.Compile(config.Config().PseudoGTIDPattern)
 }
 
 // pseudoGTIDMatches attempts to match given string with pseudo GTID pattern/text.
 func pseudoGTIDMatches(pseudoGTIDRegexp *regexp.Regexp, binlogEntryInfo string) (found bool) {
-	if config.Config.PseudoGTIDPatternIsFixedSubstring {
-		return strings.Contains(binlogEntryInfo, config.Config.PseudoGTIDPattern)
+	if config.Config().PseudoGTIDPatternIsFixedSubstring {
+		return strings.Contains(binlogEntryInfo, config.Config().PseudoGTIDPattern)
 	}
 	return pseudoGTIDRegexp.MatchString(binlogEntryInfo)
 }
@@ -95,14 +95,14 @@ func getLastPseudoGTIDEntryInBinlog(pseudoGTIDRegexp *regexp.Regexp, instanceKey
 	for moreRowsExpected {
 		query := ""
 		if binlogCoordinates.Type == BinaryLog {
-			query = fmt.Sprintf("show binlog events in '%s' FROM %d LIMIT %d", binlog, nextPos, config.Config.BinlogEventsChunkSize)
+			query = fmt.Sprintf("show binlog events in '%s' FROM %d LIMIT %d", binlog, nextPos, config.Config().BinlogEventsChunkSize)
 		} else {
-			query = fmt.Sprintf("show relaylog events in '%s' FROM %d LIMIT %d,%d", binlog, relyLogMinPos, (step * config.Config.BinlogEventsChunkSize), config.Config.BinlogEventsChunkSize)
+			query = fmt.Sprintf("show relaylog events in '%s' FROM %d LIMIT %d,%d", binlog, relyLogMinPos, (step * config.Config().BinlogEventsChunkSize), config.Config().BinlogEventsChunkSize)
 		}
 
 		moreRowsExpected = false
 		queryRowsFunc := sqlutils.QueryRowsMap
-		if config.Config.BufferBinlogEvents {
+		if config.Config().BufferBinlogEvents {
 			queryRowsFunc = sqlutils.QueryRowsMapBuffered
 		}
 		err = queryRowsFunc(db, query, func(m sqlutils.RowMap) error {
@@ -231,7 +231,7 @@ func ReadBinlogEventAtRelayLogCoordinates(instanceKey *InstanceKey, relaylogCoor
 		return nil, err
 	}
 	queryRowsFunc := sqlutils.QueryRowsMap
-	if config.Config.BufferBinlogEvents {
+	if config.Config().BufferBinlogEvents {
 		queryRowsFunc = sqlutils.QueryRowsMapBuffered
 	}
 	query := fmt.Sprintf("show relaylog events in '%s' FROM %d LIMIT 1", relaylogCoordinates.LogFile, relaylogCoordinates.LogPos)
@@ -269,12 +269,12 @@ func getLastExecutedEntryInRelaylog(instanceKey *InstanceKey, binlog string, min
 	}
 
 	queryRowsFunc := sqlutils.QueryRowsMap
-	if config.Config.BufferBinlogEvents {
+	if config.Config().BufferBinlogEvents {
 		queryRowsFunc = sqlutils.QueryRowsMapBuffered
 	}
 	step := 0
 	for moreRowsExpected {
-		query := fmt.Sprintf("show relaylog events in '%s' FROM %d LIMIT %d,%d", binlog, relyLogMinPos, (step * config.Config.BinlogEventsChunkSize), config.Config.BinlogEventsChunkSize)
+		query := fmt.Sprintf("show relaylog events in '%s' FROM %d LIMIT %d,%d", binlog, relyLogMinPos, (step * config.Config().BinlogEventsChunkSize), config.Config().BinlogEventsChunkSize)
 
 		moreRowsExpected = false
 		err = queryRowsFunc(db, query, func(m sqlutils.RowMap) error {
@@ -345,14 +345,14 @@ func searchEventInRelaylog(instanceKey *InstanceKey, binlog string, searchEvent 
 	}
 
 	queryRowsFunc := sqlutils.QueryRowsMap
-	if config.Config.BufferBinlogEvents {
+	if config.Config().BufferBinlogEvents {
 		queryRowsFunc = sqlutils.QueryRowsMapBuffered
 	}
 	skipRestOfBinlog := false
 
 	step := 0
 	for moreRowsExpected {
-		query := fmt.Sprintf("show relaylog events in '%s' FROM %d LIMIT %d,%d", binlog, relyLogMinPos, (step * config.Config.BinlogEventsChunkSize), config.Config.BinlogEventsChunkSize)
+		query := fmt.Sprintf("show relaylog events in '%s' FROM %d LIMIT %d,%d", binlog, relyLogMinPos, (step * config.Config().BinlogEventsChunkSize), config.Config().BinlogEventsChunkSize)
 
 		// We don't know in advance when we will hit the end of the binlog. We will implicitly understand it when our
 		// `show binlog events` query does not return any row.
@@ -442,13 +442,13 @@ func SearchEntryInBinlog(pseudoGTIDRegexp *regexp.Regexp, instanceKey *InstanceK
 	}
 
 	for moreRowsExpected {
-		query := fmt.Sprintf("show binlog events in '%s' FROM %d LIMIT %d", binlog, nextPos, config.Config.BinlogEventsChunkSize)
+		query := fmt.Sprintf("show binlog events in '%s' FROM %d LIMIT %d", binlog, nextPos, config.Config().BinlogEventsChunkSize)
 
 		// We don't know in advance when we will hit the end of the binlog. We will implicitly understand it when our
 		// `show binlog events` query does not return any row.
 		moreRowsExpected = false
 		queryRowsFunc := sqlutils.QueryRowsMap
-		if config.Config.BufferBinlogEvents {
+		if config.Config().BufferBinlogEvents {
 			queryRowsFunc = sqlutils.QueryRowsMapBuffered
 		}
 		err = queryRowsFunc(db, query, func(m sqlutils.RowMap) error {
@@ -534,7 +534,7 @@ func SearchEntryInInstanceBinlogs(instance *Instance, entryText string, monotoni
 					break
 				}
 				log.Debugf("lag is too high on %+v. Throttling the search for pseudo gtid entry", instance.Key)
-				time.Sleep(time.Duration(config.Config.ReasonableMaintenanceReplicationLagSeconds) * time.Second)
+				time.Sleep(time.Duration(config.Config().ReasonableMaintenanceReplicationLagSeconds) * time.Second)
 			}
 		}
 		var resultCoordinates BinlogCoordinates
@@ -575,7 +575,7 @@ func readBinlogEventsChunk(instanceKey *InstanceKey, startingCoordinates BinlogC
 	if startingCoordinates.LogFile == "" {
 		return events, log.Errorf("readBinlogEventsChunk: empty binlog file name for %+v.", *instanceKey)
 	}
-	query := fmt.Sprintf("show %s events in '%s' FROM %d LIMIT %d", commandToken, startingCoordinates.LogFile, startingCoordinates.LogPos, config.Config.BinlogEventsChunkSize)
+	query := fmt.Sprintf("show %s events in '%s' FROM %d LIMIT %d", commandToken, startingCoordinates.LogFile, startingCoordinates.LogPos, config.Config().BinlogEventsChunkSize)
 	err = sqlutils.QueryRowsMap(db, query, func(m sqlutils.RowMap) error {
 		binlogEvent := BinlogEvent{}
 		binlogEvent.Coordinates.LogFile = m.GetString("Log_name")

--- a/go/inst/instance_key.go
+++ b/go/inst/instance_key.go
@@ -50,7 +50,7 @@ func NewRawInstanceKey(hostPort string) (*InstanceKey, error) {
 // The port part is optional; there will be no name resolve
 func ParseRawInstanceKeyLoose(hostPort string) (*InstanceKey, error) {
 	if !strings.Contains(hostPort, ":") {
-		return &InstanceKey{Hostname: hostPort, Port: config.Config.DefaultInstancePort}, nil
+		return &InstanceKey{Hostname: hostPort, Port: config.Config().DefaultInstancePort}, nil
 	}
 	return NewRawInstanceKey(hostPort)
 }
@@ -88,7 +88,7 @@ func ParseInstanceKey(hostPort string) (*InstanceKey, error) {
 // The port part is optional
 func ParseInstanceKeyLoose(hostPort string) (*InstanceKey, error) {
 	if !strings.Contains(hostPort, ":") {
-		return &InstanceKey{Hostname: hostPort, Port: config.Config.DefaultInstancePort}, nil
+		return &InstanceKey{Hostname: hostPort, Port: config.Config().DefaultInstancePort}, nil
 	}
 	return ParseInstanceKey(hostPort)
 }

--- a/go/inst/instance_test.go
+++ b/go/inst/instance_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	config.Config.HostnameResolveMethod = "none"
+	config.Config().HostnameResolveMethod = "none"
 	config.MarkConfigurationLoaded()
 	log.SetLevel(log.ERROR)
 }

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1265,7 +1265,7 @@ Cleanup:
 // and return found coordinates as well as entry text
 func FindLastPseudoGTIDEntry(instance *Instance, recordedInstanceRelayLogCoordinates BinlogCoordinates, maxBinlogCoordinates *BinlogCoordinates, exhaustiveSearch bool, expectedBinlogFormat *string) (instancePseudoGtidCoordinates *BinlogCoordinates, instancePseudoGtidText string, err error) {
 
-	if config.Config.PseudoGTIDPattern == "" {
+	if config.Config().PseudoGTIDPattern == "" {
 		return instancePseudoGtidCoordinates, instancePseudoGtidText, fmt.Errorf("PseudoGTIDPattern not configured; cannot use Pseudo-GTID")
 	}
 
@@ -1303,7 +1303,7 @@ func CorrelateBinlogCoordinates(instance *Instance, binlogCoordinates *BinlogCoo
 	if err != nil {
 		return nil, 0, err
 	}
-	entriesMonotonic := (config.Config.PseudoGTIDMonotonicHint != "") && strings.Contains(instancePseudoGtidText, config.Config.PseudoGTIDMonotonicHint)
+	entriesMonotonic := (config.Config().PseudoGTIDMonotonicHint != "") && strings.Contains(instancePseudoGtidText, config.Config().PseudoGTIDMonotonicHint)
 	minBinlogCoordinates, _, err := GetHeuristiclyRecentCoordinatesForInstance(&otherInstance.Key)
 	otherInstancePseudoGtidCoordinates, err := SearchEntryInInstanceBinlogs(otherInstance, instancePseudoGtidText, entriesMonotonic, minBinlogCoordinates)
 	if err != nil {
@@ -1373,7 +1373,7 @@ func MatchBelow(instanceKey, otherKey *InstanceKey, requireInstanceMaintenance b
 	if err != nil {
 		return instance, nil, err
 	}
-	if config.Config.PseudoGTIDPattern == "" {
+	if config.Config().PseudoGTIDPattern == "" {
 		return instance, nil, fmt.Errorf("PseudoGTIDPattern not configured; cannot use Pseudo-GTID")
 	}
 	if instanceKey.Equals(otherKey) {
@@ -1672,7 +1672,7 @@ func sortedReplicas(replicas [](*Instance), stopReplicationMethod StopReplicatio
 	if len(replicas) == 0 {
 		return replicas
 	}
-	replicas = StopSlaves(replicas, stopReplicationMethod, time.Duration(config.Config.InstanceBulkOperationsWaitTimeoutSeconds)*time.Second)
+	replicas = StopSlaves(replicas, stopReplicationMethod, time.Duration(config.Config().InstanceBulkOperationsWaitTimeoutSeconds)*time.Second)
 	replicas = RemoveNilInstances(replicas)
 
 	sortInstances(replicas)
@@ -1748,14 +1748,14 @@ func MultiMatchBelowIndependently(replicas [](*Instance), belowKey *InstanceKey,
 // MultiMatchBelow will efficiently match multiple replicas below a given instance.
 // It is assumed that all given replicas are siblings
 func MultiMatchBelow(replicas [](*Instance), belowKey *InstanceKey, replicasAlreadyStopped bool, postponedFunctionsContainer *PostponedFunctionsContainer) ([](*Instance), *Instance, error, []error) {
-	if config.Config.PseudoGTIDPreferIndependentMultiMatch {
+	if config.Config().PseudoGTIDPreferIndependentMultiMatch {
 		return MultiMatchBelowIndependently(replicas, belowKey, postponedFunctionsContainer)
 	}
 	res := [](*Instance){}
 	errs := []error{}
 	replicaMutex := make(chan bool, 1)
 
-	if config.Config.PseudoGTIDPattern == "" {
+	if config.Config().PseudoGTIDPattern == "" {
 		return res, nil, fmt.Errorf("PseudoGTIDPattern not configured; cannot use Pseudo-GTID"), errs
 	}
 
@@ -1790,7 +1790,7 @@ func MultiMatchBelow(replicas [](*Instance), belowKey *InstanceKey, replicasAlre
 		log.Debugf("MultiMatchBelow: stopping %d replicas nicely", len(replicas))
 		// We want the replicas to have SQL thread up to date with IO thread.
 		// We will wait for them (up to a timeout) to do so.
-		replicas = StopSlavesNicely(replicas, time.Duration(config.Config.InstanceBulkOperationsWaitTimeoutSeconds)*time.Second)
+		replicas = StopSlavesNicely(replicas, time.Duration(config.Config().InstanceBulkOperationsWaitTimeoutSeconds)*time.Second)
 	}
 	replicas = RemoveNilInstances(replicas)
 	sort.Sort(sort.Reverse(InstancesByExecBinlogCoordinates(replicas)))
@@ -1834,8 +1834,8 @@ func MultiMatchBelow(replicas [](*Instance), belowKey *InstanceKey, replicasAlre
 						return nil
 					}
 					if postponedFunctionsContainer != nil &&
-						config.Config.PostponeReplicaRecoveryOnLagMinutes > 0 &&
-						replica.SQLDelay > config.Config.PostponeReplicaRecoveryOnLagMinutes*60 &&
+						config.Config().PostponeReplicaRecoveryOnLagMinutes > 0 &&
+						replica.SQLDelay > config.Config().PostponeReplicaRecoveryOnLagMinutes*60 &&
 						len(bucketReplicas) == 1 {
 						// This replica is the only one in the bucket, AND it's lagging very much, AND
 						// we're configured to postpone operation on this replica so as not to delay everyone else.
@@ -2078,7 +2078,7 @@ func IsBannedFromBeingCandidateReplica(replica *Instance) bool {
 		log.Debugf("instance %+v is banned because of promotion rule", replica.Key)
 		return true
 	}
-	for _, filter := range config.Config.PromotionIgnoreHostnameFilters {
+	for _, filter := range config.Config().PromotionIgnoreHostnameFilters {
 		if matched, _ := regexp.MatchString(filter, replica.Key.Hostname); matched {
 			return true
 		}
@@ -2264,7 +2264,7 @@ func RegroupReplicasPseudoGTID(masterKey *InstanceKey, returnReplicaEvenOnFailur
 		return aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, candidateReplica, err
 	}
 
-	if config.Config.PseudoGTIDPattern == "" {
+	if config.Config().PseudoGTIDPattern == "" {
 		return aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, candidateReplica, fmt.Errorf("PseudoGTIDPattern not configured; cannot use Pseudo-GTID")
 	}
 

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -385,8 +385,8 @@ func StartSlave(instanceKey *InstanceKey) (*Instance, error) {
 		return instance, log.Errore(err)
 	}
 	log.Infof("Started slave on %+v", instanceKey)
-	if config.Config.SlaveStartPostWaitMilliseconds > 0 {
-		time.Sleep(time.Duration(config.Config.SlaveStartPostWaitMilliseconds) * time.Millisecond)
+	if config.Config().SlaveStartPostWaitMilliseconds > 0 {
+		time.Sleep(time.Duration(config.Config().SlaveStartPostWaitMilliseconds) * time.Millisecond)
 	}
 
 	instance, err = ReadTopologyInstance(instanceKey)

--- a/go/inst/instance_topology_test.go
+++ b/go/inst/instance_topology_test.go
@@ -17,7 +17,7 @@ var (
 )
 
 func init() {
-	config.Config.HostnameResolveMethod = "none"
+	config.Config().HostnameResolveMethod = "none"
 	config.MarkConfigurationLoaded()
 	log.SetLevel(log.ERROR)
 }

--- a/go/inst/maintenance.go
+++ b/go/inst/maintenance.go
@@ -37,7 +37,7 @@ func GetMaintenanceOwner() string {
 	if maintenanceOwner != "" {
 		return maintenanceOwner
 	}
-	return config.Config.MaintenanceOwner
+	return config.Config().MaintenanceOwner
 }
 
 func SetMaintenanceOwner(owner string) {

--- a/go/inst/maintenance_dao.go
+++ b/go/inst/maintenance_dao.go
@@ -72,7 +72,7 @@ func ReadActiveMaintenance() ([]Maintenance, error) {
 func BeginBoundedMaintenance(instanceKey *InstanceKey, owner string, reason string, durationSeconds uint, explicitlyBounded bool) (int64, error) {
 	var maintenanceToken int64 = 0
 	if durationSeconds == 0 {
-		durationSeconds = config.Config.MaintenanceExpireMinutes * 60
+		durationSeconds = config.Config().MaintenanceExpireMinutes * 60
 	}
 	res, err := db.ExecOrchestrator(`
 			insert ignore
@@ -203,7 +203,7 @@ func ExpireMaintenance() error {
 				maintenance_active is null
 				and end_timestamp < NOW() - INTERVAL ? DAY
 			`,
-			config.Config.MaintenancePurgeDays,
+			config.Config().MaintenancePurgeDays,
 		)
 		if err != nil {
 			return log.Errore(err)

--- a/go/inst/master_equivalence_dao.go
+++ b/go/inst/master_equivalence_dao.go
@@ -122,7 +122,7 @@ func ExpireMasterPositionEquivalence() error {
 		_, err := db.ExecOrchestrator(`
         	delete from master_position_equivalence 
 				where last_suggested < NOW() - INTERVAL ? HOUR
-				`, config.Config.UnseenInstanceForgetHours,
+				`, config.Config().UnseenInstanceForgetHours,
 		)
 		return log.Errore(err)
 	}

--- a/go/inst/pool.go
+++ b/go/inst/pool.go
@@ -43,7 +43,7 @@ func ApplyPoolInstances(pool string, instancesList string) error {
 		for _, instanceString := range instancesStrings {
 
 			instanceKey, err := ParseInstanceKeyLoose(instanceString)
-			if config.Config.SupportFuzzyPoolHostnames {
+			if config.Config().SupportFuzzyPoolHostnames {
 				instanceKey = ReadFuzzyInstanceKeyIfPossible(instanceKey)
 			}
 			log.Debugf("%+v", instanceKey)

--- a/go/inst/pool_dao.go
+++ b/go/inst/pool_dao.go
@@ -133,7 +133,7 @@ func ExpirePoolInstances() error {
 			where
 				registered_at < now() - interval ? minute
 			`,
-		config.Config.InstancePoolExpiryMinutes,
+		config.Config().InstancePoolExpiryMinutes,
 	)
 	return log.Errore(err)
 }

--- a/go/inst/resolve_dao.go
+++ b/go/inst/resolve_dao.go
@@ -247,7 +247,7 @@ func ExpireHostnameUnresolve() error {
 		_, err := db.ExecOrchestrator(`
       	delete from hostname_unresolve
 				where last_registered < NOW() - INTERVAL ? MINUTE
-				`, config.Config.ExpiryHostnameResolvesMinutes,
+				`, config.Config().ExpiryHostnameResolvesMinutes,
 		)
 		return log.Errore(err)
 	}
@@ -261,7 +261,7 @@ func ForgetExpiredHostnameResolves() error {
 				from hostname_resolve
 			where
 				resolved_timestamp < NOW() - interval ? minute`,
-		2*config.Config.ExpiryHostnameResolvesMinutes,
+		2*config.Config().ExpiryHostnameResolvesMinutes,
 	)
 	return err
 }

--- a/go/logic/async_request_dao.go
+++ b/go/logic/async_request_dao.go
@@ -133,7 +133,7 @@ func ExpireAsyncRequests() error {
 			where
 				end_timestamp IS NULL
 				and begin_timestamp < NOW() - INTERVAL ? MINUTE
-			`, config.Config.MaintenanceExpireMinutes,
+			`, config.Config().MaintenanceExpireMinutes,
 	)
 	if err != nil {
 		log.Errore(err)
@@ -144,7 +144,7 @@ func ExpireAsyncRequests() error {
 			where
 				end_timestamp IS NOT NULL
 				and begin_timestamp < NOW() - INTERVAL ? DAY
-			`, config.Config.MaintenancePurgeDays,
+			`, config.Config().MaintenancePurgeDays,
 	)
 	return log.Errore(err)
 }

--- a/go/logic/topology_recovery_dao.go
+++ b/go/logic/topology_recovery_dao.go
@@ -80,7 +80,7 @@ func ClearActiveFailureDetections() error {
 				in_active_period = 1
 				AND start_active_period < NOW() - INTERVAL ? MINUTE
 			`,
-		config.Config.FailureDetectionPeriodBlockMinutes,
+		config.Config().FailureDetectionPeriodBlockMinutes,
 	)
 	return log.Errore(err)
 }
@@ -197,7 +197,7 @@ func ClearActiveRecoveries() error {
 				in_active_period = 1
 				AND start_active_period < NOW() - INTERVAL ? SECOND
 			`,
-		config.Config.RecoveryPeriodBlockSeconds,
+		config.Config().RecoveryPeriodBlockSeconds,
 	)
 	return log.Errore(err)
 }
@@ -290,7 +290,7 @@ func ExpireBlockedRecoveries() error {
 				from blocked_topology_recovery
 				where
 					last_blocked_timestamp < NOW() - interval ? second
-			`, (config.Config.RecoveryPollSeconds * 2),
+			`, (config.Config().RecoveryPollSeconds * 2),
 	)
 	return log.Errore(err)
 }
@@ -562,7 +562,7 @@ func ReadCompletedRecoveries(page int) ([]TopologyRecovery, error) {
 	limit := `
 		limit ?
 		offset ?`
-	return readRecoveries(`where end_recovery is not null`, limit, sqlutils.Args(config.Config.AuditPageSize, page*config.Config.AuditPageSize))
+	return readRecoveries(`where end_recovery is not null`, limit, sqlutils.Args(config.Config().AuditPageSize, page*config.Config().AuditPageSize))
 }
 
 // ReadRecovery reads completed recovery entry/audit entires from topology_recovery
@@ -595,7 +595,7 @@ func ReadRecentRecoveries(clusterName string, unacknowledgedOnly bool, page int)
 	limit := `
 		limit ?
 		offset ?`
-	args = append(args, config.Config.AuditPageSize, page*config.Config.AuditPageSize)
+	args = append(args, config.Config().AuditPageSize, page*config.Config().AuditPageSize)
 	return readRecoveries(whereClause, limit, args)
 }
 
@@ -658,7 +658,7 @@ func ReadRecentFailureDetections(page int) ([]TopologyRecovery, error) {
 	limit := `
 		limit ?
 		offset ?`
-	return readFailureDetections(``, limit, sqlutils.Args(config.Config.AuditPageSize, page*config.Config.AuditPageSize))
+	return readFailureDetections(``, limit, sqlutils.Args(config.Config().AuditPageSize, page*config.Config().AuditPageSize))
 }
 
 // ReadFailureDetection

--- a/go/metrics/graphite.go
+++ b/go/metrics/graphite.go
@@ -31,29 +31,29 @@ var graphiteTickCallbacks [](func())
 
 // InitGraphiteMetrics is called once in the lifetime of the app, after config has been loaded
 func InitGraphiteMetrics() error {
-	if config.Config.GraphiteAddr == "" {
+	if config.Config().GraphiteAddr == "" {
 		return nil
 	}
-	if config.Config.GraphitePollSeconds <= 0 {
+	if config.Config().GraphitePollSeconds <= 0 {
 		return nil
 	}
-	if config.Config.GraphitePath == "" {
+	if config.Config().GraphitePath == "" {
 		return log.Errorf("No graphite path provided (see GraphitePath config variable). Will not log to graphite")
 	}
-	addr, err := net.ResolveTCPAddr("tcp", config.Config.GraphiteAddr)
+	addr, err := net.ResolveTCPAddr("tcp", config.Config().GraphiteAddr)
 	if err != nil {
 		return log.Errore(err)
 	}
 	graphitePathHostname := process.ThisHostname
-	if config.Config.GraphiteConvertHostnameDotsToUnderscores {
+	if config.Config().GraphiteConvertHostnameDotsToUnderscores {
 		graphitePathHostname = strings.Replace(graphitePathHostname, ".", "_", -1)
 	}
-	graphitePath := config.Config.GraphitePath
+	graphitePath := config.Config().GraphitePath
 	graphitePath = strings.Replace(graphitePath, "{hostname}", graphitePathHostname, -1)
 
-	log.Debugf("Will log to graphite on %+v, %+v", config.Config.GraphiteAddr, graphitePath)
+	log.Debugf("Will log to graphite on %+v, %+v", config.Config().GraphiteAddr, graphitePath)
 
-	graphiteCallbackTick := time.Tick(time.Duration(config.Config.GraphitePollSeconds) * time.Second)
+	graphiteCallbackTick := time.Tick(time.Duration(config.Config().GraphitePollSeconds) * time.Second)
 	go func() {
 		go graphite.Graphite(metrics.DefaultRegistry, 1*time.Minute, graphitePath, addr)
 		for range graphiteCallbackTick {

--- a/go/os/process.go
+++ b/go/os/process.go
@@ -76,7 +76,7 @@ func CommandRun(commandText string, env []string, arguments ...string) error {
 // file and returns the exec.Command which can be executed together
 // with the script name that was created.
 func generateShellScript(commandText string, env []string, arguments ...string) (*exec.Cmd, string, error) {
-	shell := config.Config.ProcessesShellCommand
+	shell := config.Config().ProcessesShellCommand
 
 	commandBytes := []byte(commandText)
 	tmpFile, err := ioutil.TempFile("", "orchestrator-process-cmd-")

--- a/go/process/access_token_dao.go
+++ b/go/process/access_token_dao.go
@@ -63,7 +63,7 @@ func AcquireAccessToken(publicToken string) (secretToken string, err error) {
 						or is_reentrant=1
 					)
 			`,
-		publicToken, config.Config.AccessTokenUseExpirySeconds,
+		publicToken, config.Config().AccessTokenUseExpirySeconds,
 	)
 	if err != nil {
 		return secretToken, log.Errore(err)
@@ -101,7 +101,7 @@ func TokenIsValid(publicToken string, secretToken string) (result bool, err erro
 					or is_reentrant = 1
 				)
 		`
-	err = db.QueryOrchestrator(query, sqlutils.Args(publicToken, secretToken, config.Config.AccessTokenExpiryMinutes), func(m sqlutils.RowMap) error {
+	err = db.QueryOrchestrator(query, sqlutils.Args(publicToken, secretToken, config.Config().AccessTokenExpiryMinutes), func(m sqlutils.RowMap) error {
 		result = m.GetInt("valid_token") > 0
 		return nil
 	})
@@ -117,7 +117,7 @@ func ExpireAccessTokens() error {
 				generated_at < now() - interval ? minute
 				and is_reentrant = 0
 			`,
-		config.Config.AccessTokenExpiryMinutes,
+		config.Config().AccessTokenExpiryMinutes,
 	)
 	return log.Errore(err)
 }

--- a/go/process/election_dao.go
+++ b/go/process/election_dao.go
@@ -59,7 +59,7 @@ func AttemptElection() (bool, error) {
 				anchor = 1
 			  and last_seen_active < (now() - interval ? second)
 		`,
-			ThisHostname, ProcessToken.Hash, config.Config.ActiveNodeExpireSeconds,
+			ThisHostname, ProcessToken.Hash, config.Config().ActiveNodeExpireSeconds,
 		)
 		if err != nil {
 			return false, log.Errore(err)

--- a/go/process/health_dao.go
+++ b/go/process/health_dao.go
@@ -191,7 +191,7 @@ func ExpireNodesHistory() error {
 			where
 				first_seen_active < now() - interval ? hour
 			`,
-		config.Config.UnseenInstanceForgetHours,
+		config.Config().UnseenInstanceForgetHours,
 	)
 	return log.Errore(err)
 }

--- a/go/ssl/ssl.go
+++ b/go/ssl/ssl.go
@@ -72,7 +72,7 @@ func NewTLSConfig(caFile string, mutualTLS bool) (*tls.Config, error) {
 // Verify that the OU of the presented client certificate matches the list
 // of Valid OUs
 func Verify(r *nethttp.Request, validOUs []string) error {
-	if strings.Contains(r.URL.String(), config.Config.StatusEndpoint) && !config.Config.StatusOUVerify {
+	if strings.Contains(r.URL.String(), config.Config().StatusEndpoint) && !config.Config().StatusOUVerify {
 		return nil
 	}
 	if r.TLS == nil {

--- a/go/ssl/ssl_test.go
+++ b/go/ssl/ssl_test.go
@@ -60,17 +60,17 @@ func TestNewTLSConfig(t *testing.T) {
 
 func TestStatus(t *testing.T) {
 	var validOUs []string
-	url := fmt.Sprintf("http://example.com%s", config.Config.StatusEndpoint)
+	url := fmt.Sprintf("http://example.com%s", config.Config().StatusEndpoint)
 
 	req, err := nethttp.NewRequest("GET", url, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	config.Config.StatusOUVerify = false
+	config.SetStatusOUVerify(false)
 	if err := ssl.Verify(req, validOUs); err != nil {
 		t.Errorf("Failed even with verification off")
 	}
-	config.Config.StatusOUVerify = true
+	config.SetStatusOUVerify(true)
 	if err := ssl.Verify(req, validOUs); err == nil {
 		t.Errorf("Did not fail on with bad verification")
 	}


### PR DESCRIPTION
The go race detector notices that we may overwrite the configuration
while reading it as there are no locks to prevent this.  This is
most likely to happen when you send SIGHUP to the running process
as it is quite busy.

So replace config.Config with config.Config() and return a copy of
the pointer to the configuration.

Load() Reload() and ForceReload() have been adjusted to use locking
and to also create a new copy of the configuration rather than
modify the existing one. The new copy then replaces the original
configuration and this process is surrounded by locking.  Configuration
modifications by the application are now done via calls which also
lock.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`
