### PR TITLE
Postponed functions: kick off immediatly concurrently

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -293,7 +293,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			lostReplicas, equalReplicas, aheadReplicas, cannotReplicateReplicas, promotedReplica, err := inst.RegroupReplicas(instanceKey, false, func(candidateReplica *inst.Instance) { fmt.Println(candidateReplica.Key.DisplayString()) }, postponedFunctionsContainer)
 			lostReplicas = append(lostReplicas, cannotReplicateReplicas...)
 
-			postponedFunctionsContainer.InvokePostponed()
+			postponedFunctionsContainer.Wait()
 			if promotedReplica == nil {
 				log.Fatalf("Could not regroup replicas of %+v; error: %+v", *instanceKey, err)
 			}
@@ -580,7 +580,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 
 			lostReplicas, equalReplicas, aheadReplicas, cannotReplicateReplicas, promotedReplica, err := inst.RegroupReplicasPseudoGTID(instanceKey, false, func(candidateReplica *inst.Instance) { fmt.Println(candidateReplica.Key.DisplayString()) }, postponedFunctionsContainer)
 			lostReplicas = append(lostReplicas, cannotReplicateReplicas...)
-			postponedFunctionsContainer.InvokePostponed()
+			postponedFunctionsContainer.Wait()
 			if promotedReplica == nil {
 				log.Fatalf("Could not regroup replicas of %+v; error: %+v", *instanceKey, err)
 			}
@@ -661,7 +661,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			instance := validateInstanceIsFound(instanceKey)
 
 			_, syncedReplicas, failedReplicas, postponedReplicas, err := remote.SyncReplicasRelayLogs(instance, remote.SyncRelaylogsChangeMasterToSourceReplicaFunc, nil, true, postponedFunctionsContainer)
-			postponedFunctionsContainer.InvokePostponed()
+			postponedFunctionsContainer.Wait()
 
 			log.Infof("synced: %d, failed: %d, postponed: %d", len(syncedReplicas), len(failedReplicas), len(postponedReplicas))
 			for _, replica := range syncedReplicas {
@@ -680,7 +680,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			instance := validateInstanceIsFound(instanceKey)
 
 			_, syncedReplicas, failedReplicas, postponedReplicas, err := remote.SyncReplicasRelayLogs(instance, remote.SyncRelaylogsChangeMasterToSharedMasterFunc, nil, false, postponedFunctionsContainer)
-			postponedFunctionsContainer.InvokePostponed()
+			postponedFunctionsContainer.Wait()
 
 			log.Infof("synced: %d, failed: %d, postponed: %d", len(syncedReplicas), len(failedReplicas), len(postponedReplicas))
 			for _, replica := range syncedReplicas {

--- a/go/inst/postponed_functions.go
+++ b/go/inst/postponed_functions.go
@@ -17,37 +17,37 @@
 package inst
 
 import (
+	"sync"
+	"sync/atomic"
+
 	"github.com/openark/golib/log"
 )
 
 type PostponedFunctionsContainer struct {
-	PostponedFunctions [](func() error)
+	waitGroup      sync.WaitGroup
+	countFunctions int64
 }
 
 func NewPostponedFunctionsContainer() *PostponedFunctionsContainer {
 	postponedFunctionsContainer := &PostponedFunctionsContainer{}
-	postponedFunctionsContainer.PostponedFunctions = [](func() error){}
 	return postponedFunctionsContainer
 }
 
-func (this *PostponedFunctionsContainer) AddPostponedFunction(f func() error) {
-	this.PostponedFunctions = append(this.PostponedFunctions, f)
+func (this *PostponedFunctionsContainer) AddPostponedFunction(postponedFunction func() error) {
+	atomic.AddInt64(&this.countFunctions, 1)
+	this.waitGroup.Add(1)
+	go func() {
+		defer this.waitGroup.Done()
+		postponedFunction()
+	}()
 }
 
-func (this *PostponedFunctionsContainer) InvokePostponed() (err error) {
-	if len(this.PostponedFunctions) == 0 {
-		return
-	}
-	log.Debugf("PostponedFunctionsContainer: invoking %+v postponed functions", len(this.PostponedFunctions))
-	for _, postponedFunction := range this.PostponedFunctions {
-		ferr := postponedFunction()
-		if err == nil {
-			err = ferr
-		}
-	}
-	return err
+func (this *PostponedFunctionsContainer) Wait() {
+	log.Debugf("PostponedFunctionsContainer: waiting on %+v postponed functions", this.Len())
+	this.waitGroup.Wait()
+	log.Debugf("PostponedFunctionsContainer: done waiting")
 }
 
-func (this *PostponedFunctionsContainer) Len() int {
-	return len(this.PostponedFunctions)
+func (this *PostponedFunctionsContainer) Len() int64 {
+	return atomic.LoadInt64(&this.countFunctions)
 }

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -63,7 +63,6 @@ type TopologyRecovery struct {
 	RecoveryEndTimestamp      string
 	ProcessingNodeHostname    string
 	ProcessingNodeToken       string
-	PostponedFunctions        [](func() error)
 	Acknowledged              bool
 	AcknowledgedAt            string
 	AcknowledgedBy            string
@@ -81,7 +80,6 @@ func NewTopologyRecovery(replicationAnalysis inst.ReplicationAnalysis) *Topology
 	topologyRecovery.LostReplicas = *inst.NewInstanceKeyMap()
 	topologyRecovery.ParticipatingInstanceKeys = *inst.NewInstanceKeyMap()
 	topologyRecovery.AllErrors = []string{}
-	topologyRecovery.PostponedFunctions = [](func() error){}
 	topologyRecovery.RecoveryType = NotMasterRecovery
 	return topologyRecovery
 }
@@ -1293,7 +1291,7 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 		}
 	}
 	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("Invoking %d postponed functions", topologyRecovery.PostponedFunctionsContainer.Len()))
-	topologyRecovery.InvokePostponed()
+	topologyRecovery.Wait()
 	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("Invoked %d postponed functions", topologyRecovery.PostponedFunctionsContainer.Len()))
 	return recoveryAttempted, topologyRecovery, err
 }

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1290,9 +1290,9 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 			executeProcesses(config.Config.PostFailoverProcesses, "PostFailoverProcesses", topologyRecovery, false)
 		}
 	}
-	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("Invoking %d postponed functions", topologyRecovery.PostponedFunctionsContainer.Len()))
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("Waiting for %d postponed functions", topologyRecovery.PostponedFunctionsContainer.Len()))
 	topologyRecovery.Wait()
-	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("Invoked %d postponed functions", topologyRecovery.PostponedFunctionsContainer.Len()))
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("Executed %d postponed functions", topologyRecovery.PostponedFunctionsContainer.Len()))
 	return recoveryAttempted, topologyRecovery, err
 }
 


### PR DESCRIPTION
With this PR postponed functions are kicked off immediately.

Until now, postponed functions were held back till operation (most notably a recovery operation) was mostly complete, and then were executed sequentially.

Instead, we run any new postponed function immediately, asynchronously. We then `Wait()` on them prior to ending the operation.

This should deliver quicker overall operation time, and in particular quicker recovery time in such case as there are postponed functions to run.