### PR TITLE
Make cluster alias name change explicit in audit logging

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -661,8 +661,10 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 			topologyRecovery.AddPostponedFunction(postponedFunction, fmt.Sprintf("RecoverDeadMaster, detaching promoted master host %+v", promotedReplica.Key))
 		}
 		func() error {
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadMaster: updating cluster_alias"))
-			inst.ReplaceAliasClusterName(analysisEntry.AnalyzedInstanceKey.StringCode(), promotedReplica.Key.StringCode())
+			before := analysisEntry.AnalyzedInstanceKey.StringCode()
+			after := promotedReplica.Key.StringCode()
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadMaster: updating cluster_alias: %v -> %v", before, after))
+			inst.ReplaceAliasClusterName(before, after)
 			return nil
 		}()
 


### PR DESCRIPTION
Current auditing is not very verbose and says: 

```
- RecoverDeadMaster: updating cluster_alias
```

which is fine but I think it would be good to be explicit and say something like:

```
- RecoverDeadMaster: updating cluster_alias: somehost.example.com:3306 -> newhost.example.com:3306
```

This patch just makes the names used more explicit.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
