### PR TITLE
Global recovery-disable lock still runs detection

### DIFF
--- a/go/logic/disable_recovery.go
+++ b/go/logic/disable_recovery.go
@@ -36,11 +36,7 @@ import (
 )
 
 // IsRecoveryDisabled returns true if Recoveries are disabled globally
-func IsRecoveryDisabled() (bool, error) {
-	var (
-		disabled bool // default is false!
-		err      error
-	)
+func IsRecoveryDisabled() (disabled bool, err error) {
 	query := `
 		SELECT
 			COUNT(*) as mycount

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1268,10 +1268,29 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 	// we have a recovery function; its execution still depends on filters if not disabled.
 	log.Debugf("executeCheckAndRecoverFunction: proceeeding with %+v; skipProcesses: %+v", analysisEntry.AnalyzedInstanceKey, skipProcesses)
 
+	// At this point we have validated there's a failure scenario for which we have a recovery path.
+
+	// Initiate detection:
 	if _, err := checkAndExecuteFailureDetectionProcesses(analysisEntry, skipProcesses); err != nil {
 		return false, nil, err
 	}
+	// We don't mind whether detection really executed the processes or not
+	// (it may have been silenced due to previous detection). We only care there's no error.
 
+	// We're about to embark on recovery shortly...
+
+	// Check for recovery being disabled globally
+	if recoveryDisabledGlobally, err := IsRecoveryDisabled(); err != nil {
+		// Unexpected. Shouldn't get this
+		log.Errorf("Unable to determine if recovery is disabled globally: %v", err)
+	} else if recoveryDisabledGlobally {
+		log.Infof("CheckAndRecover: Analysis: %+v, InstanceKey: %+v, candidateInstanceKey: %+v, "+
+			"skipProcesses: %v: NOT Recovering host (disabled globally)",
+			analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey, candidateInstanceKey, skipProcesses)
+		return false, nil, err
+	}
+
+	// Actually attempt recovery:
 	recoveryAttempted, topologyRecovery, err = checkAndRecoverFunction(analysisEntry, candidateInstanceKey, forceInstanceRecovery, skipProcesses)
 	if !recoveryAttempted {
 		return recoveryAttempted, topologyRecovery, err
@@ -1307,11 +1326,6 @@ func CheckAndRecover(specificInstance *inst.InstanceKey, candidateInstanceKey *i
 	if err != nil {
 		return false, nil, log.Errore(err)
 	}
-	// Check for recovery being disabled globally
-	recoveryDisabledGlobally, err := IsRecoveryDisabled()
-	if err != nil {
-		log.Warningf("Unable to determine if recovery is disabled globally: %v", err)
-	}
 	if *config.RuntimeCLIFlags.Noop {
 		log.Debugf("--noop provided; will not execute processes")
 		skipProcesses = true
@@ -1335,10 +1349,6 @@ func CheckAndRecover(specificInstance *inst.InstanceKey, candidateInstanceKey *i
 			if topologyRecovery != nil {
 				promotedReplicaKey = topologyRecovery.SuccessorKey
 			}
-		} else if recoveryDisabledGlobally {
-			log.Infof("CheckAndRecover: Analysis: %+v, InstanceKey: %+v, candidateInstanceKey: %+v, "+
-				"skipProcesses: %v: NOT Recovering host (disabled globally)",
-				analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey, candidateInstanceKey, skipProcesses)
 		} else {
 			go executeCheckAndRecoverFunction(analysisEntry, candidateInstanceKey, false, skipProcesses)
 		}


### PR DESCRIPTION
With current code, when global recoveries are disabled (see `global_recovery_disable` table), detection is not running.

With this PR, detection will run, but then the recovery is skipped.

cc @sjmudd 