### PR TITLE
Add some presentations (more need adding later)

### DIFF
--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -1,0 +1,14 @@
+
+# Orchestrator Presentations
+
+This page lists presentations about Orchestrator made by different
+people. If you have something to add here please provide your name,
+the date and event/location of the presentation and a link to it
+and add details in reverse chronological order.
+
+
+Date (yyyy-mm-dd) | Author | Presentation Name | Venue/Location | URL
+----------------- | -------| ----------------- | -------------- | ---
+2017-05-17 | Simon Mudd | MySQL Failover and Orchestrator | Madrid MySQL Users Group | https://www.slideshare.net/sjmudd/mmug18-mysql-failover-and-orchestrator
+2017-04-25 | Shlomi Noach | Practical Orchestrator | Percona Live 2017 | https://www.percona.com/live/17/sites/default/files/slides/practical-orchestrator-pl-2017.pdf
+----------------- | -------| ----------------- | -------------- | ---

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -21,6 +21,7 @@
 - [Supported topologies and versions](supported-topologies-and-versions.md)
 - [Bugs](bugs.md)
 - [Contributions](contributions.md)
+- [Presentations](presentations.md)
 
 ## Quick guides
 


### PR DESCRIPTION
Add a list of references to presentations about Orchestrator.
I've added one I did yesterday and your previous one at Percona Live but know you've done a lot more. Perhaps they can be added later?

Either way I think it's good for users to see this list and hopefully it will give more context to people looking at Orchestrator for the first time.
