### PR TITLE
added api/leader-check

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -2066,6 +2066,15 @@ func (this *HttpAPI) LBCheck(params martini.Params, r render.Render, req *http.R
 	r.JSON(200, "OK")
 }
 
+// LBCheck returns a constant respnse, and this can be used by load balancers that expect a given string.
+func (this *HttpAPI) LeaderCheck(params martini.Params, r render.Render, req *http.Request) {
+	if logic.IsLeader() {
+		r.JSON(200, "OK")
+	} else {
+		r.JSON(http.StatusNotFound, "Not leader")
+	}
+}
+
 // A configurable endpoint that can be for regular status checks or whatever.  While similar to
 // Health() this returns 500 on failure.  This will prevent issues for those that have come to
 // expect a 200
@@ -2604,6 +2613,8 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerRequest(m, "headers", this.Headers)
 	this.registerRequest(m, "health", this.Health)
 	this.registerRequest(m, "lb-check", this.LBCheck)
+	this.registerRequest(m, "_ping", this.LBCheck)
+	this.registerRequest(m, "leader-check", this.LeaderCheck)
 	this.registerRequest(m, "grab-election", this.GrabElection)
 	this.registerRequest(m, "reelect", this.Reelect)
 	this.registerRequest(m, "reload-configuration", this.ReloadConfiguration)

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -73,6 +73,10 @@ func init() {
 	ometrics.OnGraphiteTick(func() { isElectedGauge.Update(int64(atomic.LoadInt64(&isElectedNode))) })
 }
 
+func IsLeader() bool {
+	return atomic.LoadInt64(&isElectedNode) == 1
+}
+
 // used in several places
 func instancePollSecondsDuration() time.Duration {
 	return time.Duration(config.Config.InstancePollSeconds) * time.Second


### PR DESCRIPTION
Storyline: https://github.com/github/orchestrator/issues/185

This PR adds the `/api/leader-check` endpoint, extracted from https://github.com/github/orchestrator/commit/3f84a4dee3042a9f744dbdfb36289bd9de7e675b

calls to this endpoint resolve with:

- `HTTP 200, OK` when the node is the leader
- `HTTP 404, Not Found` when the node is not the leader.

cc @tapuhi 