### PR TITLE
fixed compact-display issue on clusters dashboard

### DIFF
--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -83,7 +83,7 @@ function isAnonymized() {
 }
 
 function isCompactDisplay() {
-	return ($.cookie("compact-display") == "true");
+  return ($.cookie("compact-display") == "true");
 }
 
 function anonymizeInstanceId(instanceId) {

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -82,6 +82,10 @@ function isAnonymized() {
   return ($.cookie("anonymize") == "true");
 }
 
+function isCompactDisplay() {
+	return ($.cookie("compact-display") == "true");
+}
+
 function anonymizeInstanceId(instanceId) {
   var tokens = instanceId.split("__");
   return "instance-" + md5(tokens[1]).substring(0, 4) + ":" + tokens[2];

--- a/resources/templates/cluster.tmpl
+++ b/resources/templates/cluster.tmpl
@@ -61,10 +61,6 @@
 	function removeTextFromHostnameDisplay() {
 		return "{{.removeTextFromHostnameDisplay}}";
 	}
-
-	function isCompactDisplay() {
-		return ($.cookie("compact-display") == "true");
-	}
 </script>
 
 <script src="{{.prefix}}/js/jquery-ui.min.js"></script>


### PR DESCRIPTION
The JS function `isCompactDisplay()` could not be found on the clusters dashboard page; refactored out of `clusters.tmpl` and into `orchestrator.js`