### PR TITLE
support for force-master-failover command

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1384,6 +1384,15 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				fmt.Println(promotedInstanceKey.DisplayString())
 			}
 		}
+	case registerCliCommand("force-master-failover", "Recovery", `Forcibly discard master and initiate a failover, even if orchestrator doesn't see a problem. This command lets orchestrator choose the replacement master`):
+		{
+			clusterName := getClusterName(clusterAlias, instanceKey)
+			topologyRecovery, err := logic.ForceMasterFailover(clusterName)
+			if err != nil {
+				log.Fatale(err)
+			}
+			fmt.Println(topologyRecovery.SuccessorKey.DisplayString())
+		}
 	case registerCliCommand("force-master-takeover", "Recovery", `Forcibly discard master and promote another (direct child) instance instead, even if everything is running well`):
 		{
 			clusterName := getClusterName(clusterAlias, instanceKey)

--- a/go/app/prompt.go
+++ b/go/app/prompt.go
@@ -624,7 +624,7 @@ Cheatsheet:
 
 				which-lost-in-recovery
 						List instances marked as downtimed for being lost in a recovery process. The output of this command lists
-            "lost" instances that probabaly should be recycled. 
+            "lost" instances that probabaly should be recycled.
 						The topology recovery process injects a magic hint when downtiming lost instances, that is picked up
 						by this command. Examples:
 
@@ -770,6 +770,14 @@ Cheatsheet:
             as in "-c recover". Orchestratir will *not* execute external processes.
 
             orchestrator -c recover-lite -i dead.instance.com --debug
+
+				force-master-failover
+            Forcibly begin a master failover process, even if orchestrator does not see anything wrong
+            in particular with the master.
+            - This will not work in a master-master configuration
+						- Orchestrator just treats this command as a DeadMaster failover scenario
+            - Orchestrator will issue all relevant pre-failover and post-failover external processes.
+            - Orchestrator will not attempt to recover/reconnect the old master
 
 				force-master-takeover
 						Forcibly discard master and promote another (direct child) instance instead, even if everything is running well.

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -2186,6 +2186,37 @@ func (this *HttpAPI) Recover(params martini.Params, r render.Render, req *http.R
 	}
 }
 
+// ForceMasterFailover fails over a master (even if there's no particular problem with the master)
+func (this *HttpAPI) ForceMasterFailover(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+	if !isAuthorizedForAction(req, user) {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
+		return
+	}
+	instanceKey, err := this.getInstanceKey(params["host"], params["port"])
+	if err != nil {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
+	instance, found, err := inst.ReadInstance(&instanceKey)
+	if (!found) || (err != nil) {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Cannot read instance: %+v", instanceKey)})
+		return
+	}
+
+	topologyRecovery, err := logic.ForceMasterFailover(instance.ClusterName)
+	if err != nil {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
+	fmt.Println(topologyRecovery.SuccessorKey.DisplayString())
+
+	if topologyRecovery.SuccessorKey != nil {
+		r.JSON(200, &APIResponse{Code: OK, Message: "Master failed over", Details: topologyRecovery})
+	} else {
+		r.JSON(200, &APIResponse{Code: OK, Message: "Master not failed over", Details: topologyRecovery})
+	}
+}
+
 // Registers promotion preference for given instance
 func (this *HttpAPI) RegisterCandidate(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
@@ -2574,6 +2605,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerRequest(m, "recover/:host/:port/:candidateHost/:candidatePort", this.Recover)
 	this.registerRequest(m, "recover-lite/:host/:port", this.RecoverLite)
 	this.registerRequest(m, "recover-lite/:host/:port/:candidateHost/:candidatePort", this.RecoverLite)
+	this.registerRequest(m, "force-master-failover/:host/:port", this.ForceMasterFailover)
 	this.registerRequest(m, "register-candidate/:host/:port/:promotionRule", this.RegisterCandidate)
 	this.registerRequest(m, "automated-recovery-filters", this.AutomatedRecoveryFilters)
 	this.registerRequest(m, "audit-failure-detection", this.AuditFailureDetection)

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1403,6 +1403,33 @@ func ForceExecuteRecovery(clusterName string, analysisCode inst.AnalysisCode, fa
 	return executeCheckAndRecoverFunction(analysisEntry, candidateInstanceKey, true, skipProcesses)
 }
 
+// ForceMasterFailover *trusts* master of given cluster is dead and initiates a failover
+func ForceMasterFailover(clusterName string) (topologyRecovery *TopologyRecovery, err error) {
+	clusterMasters, err := inst.ReadClusterWriteableMaster(clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot deduce cluster master for %+v", clusterName)
+	}
+	if len(clusterMasters) != 1 {
+		return nil, fmt.Errorf("Cannot deduce cluster master for %+v", clusterName)
+	}
+	clusterMaster := clusterMasters[0]
+
+	recoveryAttempted, topologyRecovery, err := ForceExecuteRecovery(clusterName, inst.DeadMaster, &clusterMaster.Key, nil, false)
+	if err != nil {
+		return nil, err
+	}
+	if !recoveryAttempted {
+		return nil, fmt.Errorf("Unexpected error: recovery not attempted. This should not happen")
+	}
+	if topologyRecovery == nil {
+		return nil, fmt.Errorf("Recovery attempted but with no results. This should not happen")
+	}
+	if topologyRecovery.SuccessorKey == nil {
+		return nil, fmt.Errorf("Recovery attempted yet no replica promoted")
+	}
+	return topologyRecovery, nil
+}
+
 // ForceMasterTakeover *trusts* master of given cluster is dead and fails over to designated instance,
 // which has to be its direct child.
 func ForceMasterTakeover(clusterName string, destination *inst.Instance) (topologyRecovery *TopologyRecovery, err error) {

--- a/resources/public/js/cluster.js
+++ b/resources/public/js/cluster.js
@@ -285,8 +285,9 @@ function Cluster() {
       openNodeModal(_instancesMap[draggedNodeId]);
       return false;
     });
+
     $("body").on("click", ".instance a[data-command], .instance button[data-command]", function(e) {
-      var target = $(e.target);
+      var target = $(e.target).closest("a");
       var instanceEl = target.closest(".instance");
       e.draggedNodeId = instanceEl.attr("data-nodeid");
 

--- a/resources/public/js/cluster.js
+++ b/resources/public/js/cluster.js
@@ -23,6 +23,10 @@ function Cluster() {
       apiCommand("/api/recover-lite/" + _instancesMap[e.draggedNodeId].Key.Hostname + "/" + _instancesMap[e.draggedNodeId].Key.Port);
       return true;
     },
+    "force-master-failover": function(e) {
+      apiCommand("/api/force-master-failover/" + _instancesMap[e.draggedNodeId].Key.Hostname + "/" + _instancesMap[e.draggedNodeId].Key.Port);
+      return true;
+    },
     "match-up-replicas": function(e) {
       apiCommand("/api/match-up-replicas/" + _instancesMap[e.draggedNodeId].Key.Hostname + "/" + _instancesMap[e.draggedNodeId].Key.Port);
       return true;
@@ -1366,6 +1370,10 @@ function Cluster() {
     recoveryListing.append('<li><a href="#" data-btn="auto-lite" data-command="recover-auto-lite">Auto (do not execute hooks/processes)</a></li>');
     recoveryListing.append('<li role="separator" class="divider"></li>');
 
+    if (instance.isMaster) {
+      recoveryListing.append('<li><a href="#" data-btn="force-master-failover" data-command="force-master-failover"><div class="glyphicon glyphicon-exclamation-sign text-danger"></div> <span class="text-danger">Force fail over <strong>now</strong> (even if normal handling would not fail over)</span></a></li>');
+      recoveryListing.append('<li role="separator" class="divider"></li>');
+    }
     if (!instance.isMaster) {
       recoveryListing.append('<li><a href="#" data-btn="match-up-replicas" data-command="match-up-replicas">Match up replicas to <code>' + instance.masterTitle + '</code></a></li>');
     }


### PR DESCRIPTION
This PR introduces the `-c force-master-failover` command.

This tells `orchestrator` to assume the master is dead, and that it should kick a full failover, by whatever means it finds necessary to promote a replica.

Usage:

```
orchestrator -c force-master-failover -alias mycluster
```
or
```
orchestrator -c force-master-failover -i some.instance.in.a.cluster
```

`orchestrator` will figure out what the master is, shut its eyes and make pretend it's `dead`, then kick a failover.

Contrast with `force-master-takeover` where the user specifies the replica which must get promoted (more control but potentially more complicated for the user).

Note: this PR extends https://github.com/github/orchestrator/pull/196

cc @github/database-infrastructure 