### PR TITLE
Replace InstanceKey.StringCode() and DisplayString() with String()

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -262,7 +262,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.DisplayString(), destinationKey.DisplayString()))
+			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.String(), destinationKey.String()))
 		}
 	case registerCliCommand("relocate-replicas", "Smart relocation", `Relocates all or part of the replicas of a given instance under another instance`):
 		{
@@ -278,7 +278,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 					log.Errore(e)
 				}
 				for _, replica := range replicas {
-					fmt.Println(replica.Key.DisplayString())
+					fmt.Println(replica.Key.String())
 				}
 			}
 		}
@@ -290,7 +290,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			}
 			validateInstanceIsFound(instanceKey)
 
-			lostReplicas, equalReplicas, aheadReplicas, cannotReplicateReplicas, promotedReplica, err := inst.RegroupReplicas(instanceKey, false, func(candidateReplica *inst.Instance) { fmt.Println(candidateReplica.Key.DisplayString()) }, postponedFunctionsContainer)
+			lostReplicas, equalReplicas, aheadReplicas, cannotReplicateReplicas, promotedReplica, err := inst.RegroupReplicas(instanceKey, false, func(candidateReplica *inst.Instance) { fmt.Println(candidateReplica.Key.String()) }, postponedFunctionsContainer)
 			lostReplicas = append(lostReplicas, cannotReplicateReplicas...)
 
 			postponedFunctionsContainer.Wait()
@@ -298,7 +298,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatalf("Could not regroup replicas of %+v; error: %+v", *instanceKey, err)
 			}
 			fmt.Println(fmt.Sprintf("%s lost: %d, trivial: %d, pseudo-gtid: %d",
-				promotedReplica.Key.DisplayString(), len(lostReplicas), len(equalReplicas), len(aheadReplicas)))
+				promotedReplica.Key.String(), len(lostReplicas), len(equalReplicas), len(aheadReplicas)))
 			if err != nil {
 				log.Fatale(err)
 			}
@@ -312,7 +312,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.DisplayString(), instance.MasterKey.DisplayString()))
+			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.String(), instance.MasterKey.String()))
 		}
 	case registerCliCommand("move-up-replicas", "Classic file:pos relocation", `Moves replicas of the given instance one level up the topology`):
 		{
@@ -329,7 +329,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 					log.Errore(e)
 				}
 				for _, replica := range movedReplicas {
-					fmt.Println(replica.Key.DisplayString())
+					fmt.Println(replica.Key.String())
 				}
 			}
 		}
@@ -343,7 +343,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.DisplayString(), destinationKey.DisplayString()))
+			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.String(), destinationKey.String()))
 		}
 	case registerCliCommand("move-equivalent", "Classic file:pos relocation", `Moves a replica beneath another server, based on previously recorded "equivalence coordinates"`):
 		{
@@ -355,7 +355,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.DisplayString(), destinationKey.DisplayString()))
+			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.String(), destinationKey.String()))
 		}
 	case registerCliCommand("repoint", "Classic file:pos relocation", `Make the given instance replicate from another instance without changing the binglog coordinates. Use with care`):
 		{
@@ -365,7 +365,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.DisplayString(), instance.MasterKey.DisplayString()))
+			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.String(), instance.MasterKey.String()))
 		}
 	case registerCliCommand("repoint-replicas", "Classic file:pos relocation", `Repoint all replicas of given instance to replicate back from the instance. Use with care`):
 		{
@@ -378,7 +378,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 					log.Errore(e)
 				}
 				for _, replica := range repointedReplicas {
-					fmt.Println(fmt.Sprintf("%s<%s", replica.Key.DisplayString(), instanceKey.DisplayString()))
+					fmt.Println(fmt.Sprintf("%s<%s", replica.Key.String(), instanceKey.String()))
 				}
 			}
 		}
@@ -392,7 +392,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("take-master", "Classic file:pos relocation", `Turn an instance into a master of its own master; essentially switch the two.`):
 		{
@@ -404,7 +404,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("make-co-master", "Classic file:pos relocation", `Create a master-master replication. Given instance is a replica which replicates directly from a master.`):
 		{
@@ -413,7 +413,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("get-candidate-replica", "Classic file:pos relocation", `Information command suggesting the most up-to-date replica of a given instance that is good for promotion`):
 		{
@@ -426,7 +426,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			} else {
-				fmt.Println(instance.Key.DisplayString())
+				fmt.Println(instance.Key.String())
 			}
 		}
 	case registerCliCommand("regroup-replicas-bls", "Binlog server relocation", `Regroup Binlog Server replicas of a given instance`):
@@ -441,7 +441,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if promotedBinlogServer == nil {
 				log.Fatalf("Could not regroup binlog server replicas of %+v; error: %+v", *instanceKey, err)
 			}
-			fmt.Println(promotedBinlogServer.Key.DisplayString())
+			fmt.Println(promotedBinlogServer.Key.String())
 			if err != nil {
 				log.Fatale(err)
 			}
@@ -457,7 +457,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.DisplayString(), destinationKey.DisplayString()))
+			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.String(), destinationKey.String()))
 		}
 	case registerCliCommand("move-replicas-gtid", "GTID relocation", `Moves all replicas of a given instance under another (destination) instance using GTID`):
 		{
@@ -473,7 +473,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 					log.Errore(e)
 				}
 				for _, replica := range movedReplicas {
-					fmt.Println(replica.Key.DisplayString())
+					fmt.Println(replica.Key.String())
 				}
 			}
 		}
@@ -485,14 +485,14 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			}
 			validateInstanceIsFound(instanceKey)
 
-			lostReplicas, movedReplicas, cannotReplicateReplicas, promotedReplica, err := inst.RegroupReplicasGTID(instanceKey, false, func(candidateReplica *inst.Instance) { fmt.Println(candidateReplica.Key.DisplayString()) })
+			lostReplicas, movedReplicas, cannotReplicateReplicas, promotedReplica, err := inst.RegroupReplicasGTID(instanceKey, false, func(candidateReplica *inst.Instance) { fmt.Println(candidateReplica.Key.String()) })
 			lostReplicas = append(lostReplicas, cannotReplicateReplicas...)
 
 			if promotedReplica == nil {
 				log.Fatalf("Could not regroup replicas of %+v; error: %+v", *instanceKey, err)
 			}
 			fmt.Println(fmt.Sprintf("%s lost: %d, moved: %d",
-				promotedReplica.Key.DisplayString(), len(lostReplicas), len(movedReplicas)))
+				promotedReplica.Key.String(), len(lostReplicas), len(movedReplicas)))
 			if err != nil {
 				log.Fatale(err)
 			}
@@ -508,7 +508,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.DisplayString(), destinationKey.DisplayString()))
+			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.String(), destinationKey.String()))
 		}
 	case registerCliCommand("match-up", "Pseudo-GTID relocation", `Transport the replica one level up the hierarchy, making it child of its grandparent, using Pseudo-GTID`):
 		{
@@ -517,7 +517,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.DisplayString(), instance.MasterKey.DisplayString()))
+			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.String(), instance.MasterKey.String()))
 		}
 	case registerCliCommand("rematch", "Pseudo-GTID relocation", `Reconnect a replica onto its master, via PSeudo-GTID.`):
 		{
@@ -526,7 +526,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.DisplayString(), instance.MasterKey.DisplayString()))
+			fmt.Println(fmt.Sprintf("%s<%s", instanceKey.String(), instance.MasterKey.String()))
 		}
 	case registerCliCommand("match-replicas", "Pseudo-GTID relocation", `Matches all replicas of a given instance under another (destination) instance using Pseudo-GTID`):
 		{
@@ -547,7 +547,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 					log.Errore(e)
 				}
 				for _, replica := range matchedReplicas {
-					fmt.Println(replica.Key.DisplayString())
+					fmt.Println(replica.Key.String())
 				}
 			}
 		}
@@ -566,7 +566,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 					log.Errore(e)
 				}
 				for _, replica := range matchedReplicas {
-					fmt.Println(replica.Key.DisplayString())
+					fmt.Println(replica.Key.String())
 				}
 			}
 		}
@@ -578,14 +578,14 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			}
 			validateInstanceIsFound(instanceKey)
 
-			lostReplicas, equalReplicas, aheadReplicas, cannotReplicateReplicas, promotedReplica, err := inst.RegroupReplicasPseudoGTID(instanceKey, false, func(candidateReplica *inst.Instance) { fmt.Println(candidateReplica.Key.DisplayString()) }, postponedFunctionsContainer)
+			lostReplicas, equalReplicas, aheadReplicas, cannotReplicateReplicas, promotedReplica, err := inst.RegroupReplicasPseudoGTID(instanceKey, false, func(candidateReplica *inst.Instance) { fmt.Println(candidateReplica.Key.String()) }, postponedFunctionsContainer)
 			lostReplicas = append(lostReplicas, cannotReplicateReplicas...)
 			postponedFunctionsContainer.Wait()
 			if promotedReplica == nil {
 				log.Fatalf("Could not regroup replicas of %+v; error: %+v", *instanceKey, err)
 			}
 			fmt.Println(fmt.Sprintf("%s lost: %d, trivial: %d, pseudo-gtid: %d",
-				promotedReplica.Key.DisplayString(), len(lostReplicas), len(equalReplicas), len(aheadReplicas)))
+				promotedReplica.Key.String(), len(lostReplicas), len(equalReplicas), len(aheadReplicas)))
 			if err != nil {
 				log.Fatale(err)
 			}
@@ -619,7 +619,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instance.Key.DisplayString())
+			fmt.Println(instance.Key.String())
 		}
 		// relay-log based synchronization
 	case registerCliCommand("align-via-relay-logs-ssh", "Remote relay log relocation", `Align instance's data by comparing and applying another instance's relay logs`):
@@ -650,7 +650,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instance.Key.DisplayString())
+			fmt.Println(instance.Key.String())
 		}
 	case registerCliCommand("regroup-replicas-ssh", "Remote relay log relocation", `Regroup replicas of a given instance by syncing their relay logs over SSH`):
 		{
@@ -665,7 +665,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 
 			log.Infof("synced: %d, failed: %d, postponed: %d", len(syncedReplicas), len(failedReplicas), len(postponedReplicas))
 			for _, replica := range syncedReplicas {
-				fmt.Println(replica.Key.DisplayString())
+				fmt.Println(replica.Key.String())
 			}
 			if err != nil {
 				log.Fatale(err)
@@ -684,7 +684,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 
 			log.Infof("synced: %d, failed: %d, postponed: %d", len(syncedReplicas), len(failedReplicas), len(postponedReplicas))
 			for _, replica := range syncedReplicas {
-				fmt.Println(replica.Key.DisplayString())
+				fmt.Println(replica.Key.String())
 			}
 			if err != nil {
 				log.Fatale(err)
@@ -699,7 +699,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("disable-gtid", "Replication, general", `Turn off GTID replication, back to file:pos replication`):
 		{
@@ -708,7 +708,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("reset-master-gtid-remove-own-uuid", "Replication, general", `Reset master on instance, remove GTID entries generated by instance`):
 		{
@@ -717,7 +717,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("skip-query", "Replication, general", `Skip a single statement on a replica; either when running with GTID or without`):
 		{
@@ -726,7 +726,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("stop-slave", "Replication, general", `Issue a STOP SLAVE on an instance`):
 		{
@@ -735,7 +735,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("start-slave", "Replication, general", `Issue a START SLAVE on an instance`):
 		{
@@ -744,7 +744,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("restart-slave", "Replication, general", `STOP and START SLAVE on an instance`):
 		{
@@ -753,7 +753,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("reset-slave", "Replication, general", `Issues a RESET SLAVE command; use with care`):
 		{
@@ -762,7 +762,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("detach-replica", "Replication, general", `Stops replication and modifies binlog position into an impossible, yet reversible, value.`):
 		{
@@ -771,7 +771,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("reattach-replica", "Replication, general", `Undo a detach-replica operation`):
 		{
@@ -780,7 +780,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("detach-replica-master-host", "Replication, general", `Stops replication and modifies Master_Host into an impossible, yet reversible, value.`):
 		{
@@ -792,7 +792,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("reattach-replica-master-host", "Replication, general", `Undo a detach-replica-master-host operation`):
 		{
@@ -804,7 +804,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("master-pos-wait", "Replication, general", `Wait until replica reaches given replication coordinates (--binlog=file:pos)`):
 		{
@@ -828,7 +828,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("restart-slave-statements", "Replication, general", `Get a list of statements to execute to stop then restore replica to same execution state. Provide --statement for injected statement`):
 		{
@@ -852,7 +852,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("set-writeable", "Instance", `Turn an instance writeable, via SET GLOBAL read_only := 0`):
 		{
@@ -861,7 +861,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 		// Binary log operations
 	case registerCliCommand("flush-binary-logs", "Binary logs", `Flush binary logs on an instance`):
@@ -876,7 +876,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("purge-binary-logs", "Binary logs", `Purge binary logs of an instance`):
 		{
@@ -890,7 +890,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("last-pseudo-gtid", "Binary logs", `Find latest Pseudo-GTID entry in instance's binary logs`):
 		{
@@ -1063,7 +1063,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			} else {
 				for _, instance := range instances {
-					fmt.Println(instance.Key.DisplayString())
+					fmt.Println(instance.Key.String())
 				}
 			}
 		}
@@ -1078,7 +1078,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			} else {
 				for _, instance := range instances {
-					fmt.Println(instance.Key.DisplayString())
+					fmt.Println(instance.Key.String())
 				}
 			}
 		}
@@ -1092,7 +1092,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			} else {
 				for _, instance := range instances {
-					fmt.Println(instance.Key.DisplayString())
+					fmt.Println(instance.Key.String())
 				}
 			}
 		}
@@ -1121,7 +1121,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			} else {
 				for _, instance := range instances {
-					fmt.Println(instance.Key.DisplayString())
+					fmt.Println(instance.Key.String())
 				}
 			}
 		}
@@ -1141,7 +1141,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			} else {
 				for _, instance := range instances {
-					fmt.Println(instance.Key.DisplayString())
+					fmt.Println(instance.Key.String())
 				}
 			}
 		}
@@ -1152,7 +1152,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatalf("Unable to get master: unresolved instance")
 			}
 			instance := validateInstanceIsFound(instanceKey)
-			fmt.Println(instance.Key.DisplayString())
+			fmt.Println(instance.Key.String())
 		}
 	case registerCliCommand("which-cluster", "Information", `Output the name of the cluster an instance belongs to, or error if unknown to orchestrator`):
 		{
@@ -1175,7 +1175,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("which-cluster-master", "Information", `Output the name of the master in a given cluster`):
 		{
@@ -1187,7 +1187,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if len(masters) == 0 {
 				log.Fatalf("No writeable masters found for cluster %+v", clusterName)
 			}
-			fmt.Println(masters[0].Key.DisplayString())
+			fmt.Println(masters[0].Key.String())
 		}
 	case registerCliCommand("which-cluster-instances", "Information", `Output the list of instances participating in same cluster as given instance`):
 		{
@@ -1197,7 +1197,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			}
 			for _, clusterInstance := range instances {
-				fmt.Println(clusterInstance.Key.DisplayString())
+				fmt.Println(clusterInstance.Key.String())
 			}
 		}
 	case registerCliCommand("which-cluster-osc-replicas", "Information", `Output a list of replicas in a cluster, that could serve as a pt-online-schema-change operation control replicas`):
@@ -1208,7 +1208,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			}
 			for _, clusterInstance := range instances {
-				fmt.Println(clusterInstance.Key.DisplayString())
+				fmt.Println(clusterInstance.Key.String())
 			}
 		}
 	case registerCliCommand("which-cluster-gh-ost-replicas", "Information", `Output a list of replicas in a cluster, that could serve as a gh-ost working server`):
@@ -1219,7 +1219,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			}
 			for _, clusterInstance := range instances {
-				fmt.Println(clusterInstance.Key.DisplayString())
+				fmt.Println(clusterInstance.Key.String())
 			}
 		}
 	case registerCliCommand("which-master", "Information", `Output the fully-qualified hostname:port representation of a given instance's master`):
@@ -1230,7 +1230,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			}
 			instance := validateInstanceIsFound(instanceKey)
 			if instance.MasterKey.IsValid() {
-				fmt.Println(instance.MasterKey.DisplayString())
+				fmt.Println(instance.MasterKey.String())
 			}
 		}
 	case registerCliCommand("which-replicas", "Information", `Output the fully-qualified hostname:port list of replicas of a given instance`):
@@ -1244,7 +1244,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			}
 			for _, replica := range replicas {
-				fmt.Println(replica.Key.DisplayString())
+				fmt.Println(replica.Key.String())
 			}
 		}
 	case registerCliCommand("which-lost-in-recovery", "Information", `List instances marked as downtimed for being lost in a recovery process`):
@@ -1254,7 +1254,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			}
 			for _, instance := range instances {
-				fmt.Println(instance.Key.DisplayString())
+				fmt.Println(instance.Key.String())
 			}
 		}
 	case registerCliCommand("instance-status", "Information", `Output short status on a given instance`):
@@ -1283,7 +1283,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instance.Key.DisplayString())
+			fmt.Println(instance.Key.String())
 		}
 	case registerCliCommand("forget", "Instance management", `Forget about an instance's existence`):
 		{
@@ -1295,7 +1295,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(rawInstanceKey.DisplayString())
+			fmt.Println(rawInstanceKey.String())
 		}
 	case registerCliCommand("begin-maintenance", "Instance management", `Request a maintenance lock on an instance`):
 		{
@@ -1321,7 +1321,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("end-maintenance", "Instance management", `Remove maintenance lock from an instance`):
 		{
@@ -1330,7 +1330,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("begin-downtime", "Instance management", `Mark an instance as downtimed`):
 		{
@@ -1354,7 +1354,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			} else {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("end-downtime", "Instance management", `Indicate an instance is no longer downtimed`):
 		{
@@ -1363,7 +1363,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 		// Recovery & analysis
 	case registerCliCommand("recover", "Recovery", `Do auto-recovery given a dead instance`), registerCliCommand("recover-lite", "Recovery", `Do auto-recovery given a dead instance. Orchestrator chooses the best course of actionwithout executing external processes`):
@@ -1381,7 +1381,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				if promotedInstanceKey == nil {
 					log.Fatalf("Recovery attempted yet no replica promoted")
 				}
-				fmt.Println(promotedInstanceKey.DisplayString())
+				fmt.Println(promotedInstanceKey.String())
 			}
 		}
 	case registerCliCommand("force-master-takeover", "Recovery", `Forcibly discard master and promote another (direct child) instance instead, even if everything is running well`):
@@ -1395,7 +1395,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(topologyRecovery.SuccessorKey.DisplayString())
+			fmt.Println(topologyRecovery.SuccessorKey.String())
 		}
 	case registerCliCommand("graceful-master-takeover", "Recovery", `Gracefully discard master and promote another (direct child) instance instead, even if everything is running well`):
 		{
@@ -1404,7 +1404,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(topologyRecovery.SuccessorKey.DisplayString())
+			fmt.Println(topologyRecovery.SuccessorKey.String())
 			fmt.Println(*promotedMasterCoordinates)
 			log.Debugf("Promoted %+v as new master. Binlog coordinates at time of promotion: %+v", topologyRecovery.SuccessorKey, *promotedMasterCoordinates)
 		}
@@ -1415,7 +1415,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatale(err)
 			}
 			for _, entry := range analysis {
-				fmt.Println(fmt.Sprintf("%s (cluster %s): %s", entry.AnalyzedInstanceKey.DisplayString(), entry.ClusterDetails.ClusterName, entry.AnalysisString()))
+				fmt.Println(fmt.Sprintf("%s (cluster %s): %s", entry.AnalyzedInstanceKey.String(), entry.ClusterDetails.ClusterName, entry.AnalysisString()))
 			}
 		}
 	case registerCliCommand("ack-cluster-recoveries", "Recovery", `Acknowledge recoveries for a given cluster; this unblocks pending future recoveries`):
@@ -1464,7 +1464,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(replacement.Key.DisplayString())
+			fmt.Println(replacement.Key.String())
 		}
 	// Instance meta
 	case registerCliCommand("register-candidate", "Instance, meta", `Indicate that a specific instance is a preferred candidate for master promotion`):
@@ -1478,7 +1478,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("register-hostname-unresolve", "Instance, meta", `Assigns the given instance a virtual (aka "unresolved") name`):
 		{
@@ -1487,7 +1487,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("deregister-hostname-unresolve", "Instance, meta", `Explicitly deregister/dosassociate a hostname with an "unresolved" name`):
 		{
@@ -1496,7 +1496,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 	case registerCliCommand("set-heuristic-domain-instance", "Instance, meta", `Associate domain name of given cluster with what seems to be the writer master for that cluster`):
 		{
@@ -1505,7 +1505,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(instanceKey.DisplayString())
+			fmt.Println(instanceKey.String())
 		}
 
 		// meta
@@ -1543,7 +1543,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if rawInstanceKey == nil {
 				log.Fatal("Cannot deduce instance:", instance)
 			}
-			if conn, err := net.Dial("tcp", rawInstanceKey.DisplayString()); err == nil {
+			if conn, err := net.Dial("tcp", rawInstanceKey.String()); err == nil {
 				log.Debugf("tcp test is good; got connection %+v", conn)
 				conn.Close()
 			} else {
@@ -1552,7 +1552,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if cname, err := inst.GetCNAME(rawInstanceKey.Hostname); err == nil {
 				log.Debugf("GetCNAME() %+v, %+v", cname, err)
 				rawInstanceKey.Hostname = cname
-				fmt.Println(rawInstanceKey.DisplayString())
+				fmt.Println(rawInstanceKey.String())
 			} else {
 				log.Fatale(err)
 			}

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -211,7 +211,7 @@ func (this *HttpAPI) Resolve(params martini.Params, r render.Render, req *http.R
 		return
 	}
 
-	if conn, err := net.Dial("tcp", instanceKey.DisplayString()); err == nil {
+	if conn, err := net.Dial("tcp", instanceKey.String()); err == nil {
 		conn.Close()
 	} else {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
@@ -913,7 +913,7 @@ func (this *HttpAPI) RegroupReplicas(params martini.Params, r render.Render, req
 	}
 
 	r.JSON(200, &APIResponse{Code: OK, Message: fmt.Sprintf("promoted replica: %s, lost: %d, trivial: %d, pseudo-gtid: %d",
-		promotedReplica.Key.DisplayString(), len(lostReplicas), len(equalReplicas), len(aheadReplicas)), Details: promotedReplica.Key})
+		promotedReplica.Key.String(), len(lostReplicas), len(equalReplicas), len(aheadReplicas)), Details: promotedReplica.Key})
 }
 
 // RegroupReplicas attempts to pick a replica of a given instance and make it take its siblings, efficiently,
@@ -938,7 +938,7 @@ func (this *HttpAPI) RegroupReplicasPseudoGTID(params martini.Params, r render.R
 	}
 
 	r.JSON(200, &APIResponse{Code: OK, Message: fmt.Sprintf("promoted replica: %s, lost: %d, trivial: %d, pseudo-gtid: %d",
-		promotedReplica.Key.DisplayString(), len(lostReplicas), len(equalReplicas), len(aheadReplicas)), Details: promotedReplica.Key})
+		promotedReplica.Key.String(), len(lostReplicas), len(equalReplicas), len(aheadReplicas)), Details: promotedReplica.Key})
 }
 
 // RegroupReplicasGTID attempts to pick a replica of a given instance and make it take its siblings, efficiently, using GTID
@@ -962,7 +962,7 @@ func (this *HttpAPI) RegroupReplicasGTID(params martini.Params, r render.Render,
 	}
 
 	r.JSON(200, &APIResponse{Code: OK, Message: fmt.Sprintf("promoted replica: %s, lost: %d, moved: %d",
-		promotedReplica.Key.DisplayString(), len(lostReplicas), len(movedReplicas)), Details: promotedReplica.Key})
+		promotedReplica.Key.String(), len(lostReplicas), len(movedReplicas)), Details: promotedReplica.Key})
 }
 
 // RegroupReplicasBinlogServers attempts to pick a replica of a given instance and make it take its siblings, efficiently, using GTID
@@ -985,7 +985,7 @@ func (this *HttpAPI) RegroupReplicasBinlogServers(params martini.Params, r rende
 	}
 
 	r.JSON(200, &APIResponse{Code: OK, Message: fmt.Sprintf("promoted binlog server: %s",
-		promotedBinlogServer.Key.DisplayString()), Details: promotedBinlogServer.Key})
+		promotedBinlogServer.Key.String()), Details: promotedBinlogServer.Key})
 }
 
 // MakeMaster attempts to make the given instance a master, and match its siblings to be its replicas

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -414,11 +414,11 @@ func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnal
 // To not repeat recurring analysis code, the database_instance_last_analysis table is used, so that only changes to
 // analysis codes are written.
 func auditInstanceAnalysisInChangelog(instanceKey *InstanceKey, analysisCode AnalysisCode) error {
-	if lastWrittenAnalysis, found := recentInstantAnalysis.Get(instanceKey.DisplayString()); found {
+	if lastWrittenAnalysis, found := recentInstantAnalysis.Get(instanceKey.String()); found {
 		if lastWrittenAnalysis == analysisCode {
 			// Surely nothing new.
 			// And let's expand the timeout
-			recentInstantAnalysis.Set(instanceKey.DisplayString(), analysisCode, cache.DefaultExpiration)
+			recentInstantAnalysis.Set(instanceKey.String(), analysisCode, cache.DefaultExpiration)
 			return nil
 		}
 	}
@@ -463,7 +463,7 @@ func auditInstanceAnalysisInChangelog(instanceKey *InstanceKey, analysisCode Ana
 			return log.Errore(err)
 		}
 	}
-	recentInstantAnalysis.Set(instanceKey.DisplayString(), analysisCode, cache.DefaultExpiration)
+	recentInstantAnalysis.Set(instanceKey.String(), analysisCode, cache.DefaultExpiration)
 	if !lastAnalysisChanged {
 		return nil
 	}

--- a/go/inst/audit_dao.go
+++ b/go/inst/audit_dao.go
@@ -89,7 +89,7 @@ func AuditOperation(auditType string, instanceKey *InstanceKey, message string) 
 	if err != nil {
 		return log.Errore(err)
 	}
-	logMessage := fmt.Sprintf("auditType:%s instance:%s cluster:%s message:%s", auditType, instanceKey.DisplayString(), clusterName, message)
+	logMessage := fmt.Sprintf("auditType:%s instance:%s cluster:%s message:%s", auditType, instanceKey.String(), clusterName, message)
 	if syslogWriter != nil {
 		go func() {
 			syslogWriter.Info(logMessage)

--- a/go/inst/instance_binlog_dao.go
+++ b/go/inst/instance_binlog_dao.go
@@ -63,7 +63,7 @@ func pseudoGTIDMatches(pseudoGTIDRegexp *regexp.Regexp, binlogEntryInfo string) 
 }
 
 func getInstanceBinlogEntryKey(instance *Instance, entry string) string {
-	return fmt.Sprintf("%s;%s", instance.Key.DisplayString(), entry)
+	return fmt.Sprintf("%s;%s", instance.Key.String(), entry)
 }
 
 // Try and find the last position of a pseudo GTID query entry in the given binary log.

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -772,7 +772,7 @@ func ReadInstanceClusterAttributes(instance *Instance) (err error) {
 		replicationDepth = masterReplicationDepth + 1
 		clusterName = masterClusterName
 	}
-	clusterNameByInstanceKey := instance.Key.StringCode()
+	clusterNameByInstanceKey := instance.Key.String()
 	if clusterName == "" {
 		// Nothing from master; we set it to be named after the instance itself
 		clusterName = clusterNameByInstanceKey
@@ -782,7 +782,7 @@ func ReadInstanceClusterAttributes(instance *Instance) (err error) {
 	if masterMasterKey.Equals(&instance.Key) {
 		// co-master calls for special case, in fear of the infinite loop
 		isCoMaster = true
-		clusterNameByCoMasterKey := instance.MasterKey.StringCode()
+		clusterNameByCoMasterKey := instance.MasterKey.String()
 		if clusterName != clusterNameByInstanceKey && clusterName != clusterNameByCoMasterKey {
 			// Can be caused by a co-master topology failover
 			log.Errorf("ReadInstanceClusterAttributes: in co-master topology %s is not in (%s, %s). Forcing it to become one of them", clusterName, clusterNameByInstanceKey, clusterNameByCoMasterKey)
@@ -1556,7 +1556,7 @@ func InjectUnseenMasters() error {
 	operations := 0
 	for _, masterKey := range unseenMasterKeys {
 		masterKey := masterKey
-		clusterName := masterKey.StringCode()
+		clusterName := masterKey.String()
 		// minimal details:
 		instance := Instance{Key: masterKey, Version: "Unknown", ClusterName: clusterName}
 		if err := writeInstance(&instance, false, nil); err == nil {
@@ -1717,7 +1717,7 @@ func PopulateInstancesAgents(instances [](*Instance)) error {
 }
 
 func GetClusterName(instanceKey *InstanceKey) (clusterName string, err error) {
-	if clusterName, found := instanceKeyInformativeClusterName.Get(instanceKey.StringCode()); found {
+	if clusterName, found := instanceKeyInformativeClusterName.Get(instanceKey.String()); found {
 		return clusterName.(string), nil
 	}
 	query := `
@@ -1731,7 +1731,7 @@ func GetClusterName(instanceKey *InstanceKey) (clusterName string, err error) {
 			`
 	err = db.QueryOrchestrator(query, sqlutils.Args(instanceKey.Hostname, instanceKey.Port), func(m sqlutils.RowMap) error {
 		clusterName = m.GetString("cluster_name")
-		instanceKeyInformativeClusterName.Set(instanceKey.StringCode(), clusterName, cache.DefaultExpiration)
+		instanceKeyInformativeClusterName.Set(instanceKey.String(), clusterName, cache.DefaultExpiration)
 		return nil
 	})
 
@@ -1823,7 +1823,7 @@ func HeuristicallyApplyClusterDomainInstanceAttribute(clusterName string) (insta
 		return nil, fmt.Errorf("Found %+v potential master for cluster %+v", len(masters), clusterName)
 	}
 	instanceKey = &masters[0].Key
-	return instanceKey, attributes.SetGeneralAttribute(clusterInfo.ClusterDomain, instanceKey.StringCode())
+	return instanceKey, attributes.SetGeneralAttribute(clusterInfo.ClusterDomain, instanceKey.String())
 }
 
 // GetHeuristicClusterDomainInstanceAttribute attempts detecting the cluster domain

--- a/go/inst/instance_key.go
+++ b/go/inst/instance_key.go
@@ -155,17 +155,7 @@ func (this *InstanceKey) ReattachedKey() *InstanceKey {
 	return &InstanceKey{Hostname: this.Hostname[len(detachHint):], Port: this.Port}
 }
 
-// StringCode returns an official string representation of this key
-func (this *InstanceKey) StringCode() string {
-	return fmt.Sprintf("%s:%d", this.Hostname, this.Port)
-}
-
-// DisplayString returns a user-friendly string representation of this key
-func (this *InstanceKey) DisplayString() string {
-	return this.StringCode()
-}
-
 // String returns a user-friendly string representation of this key
 func (this InstanceKey) String() string {
-	return this.StringCode()
+	return fmt.Sprintf("%s:%d", this.Hostname, this.Port)
 }

--- a/go/inst/instance_key_map.go
+++ b/go/inst/instance_key_map.go
@@ -83,7 +83,7 @@ func (this *InstanceKeyMap) ToJSONString() string {
 func (this *InstanceKeyMap) ToCommaDelimitedList() string {
 	keyDisplays := []string{}
 	for key := range *this {
-		keyDisplays = append(keyDisplays, key.DisplayString())
+		keyDisplays = append(keyDisplays, key.String())
 	}
 	return strings.Join(keyDisplays, ",")
 }

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -55,7 +55,7 @@ func getASCIITopologyEntry(depth int, instance *Instance, replicationMap map[*In
 			prefix += "- "
 		}
 	}
-	entry := fmt.Sprintf("%s%s", prefix, instance.Key.DisplayString())
+	entry := fmt.Sprintf("%s%s", prefix, instance.Key.String())
 	if extendedOutput {
 		entry = fmt.Sprintf("%s %s", entry, instance.HumanReadableDescription())
 	}
@@ -1127,7 +1127,7 @@ func ReattachReplicaMasterHost(instanceKey *InstanceKey) (*Instance, error) {
 		goto Cleanup
 	}
 	// Just in case this instance used to be a master:
-	ReplaceAliasClusterName(instanceKey.StringCode(), reattachedMasterKey.StringCode())
+	ReplaceAliasClusterName(instanceKey.String(), reattachedMasterKey.String())
 
 Cleanup:
 	instance, _ = StartSlave(instanceKey)

--- a/go/inst/instance_topology_test.go
+++ b/go/inst/instance_topology_test.go
@@ -36,7 +36,7 @@ func generateTestInstances() (instances [](*Instance), instancesMap map[string](
 	}
 	instancesMap = make(map[string](*Instance))
 	for _, instance := range instances {
-		instancesMap[instance.Key.StringCode()] = instance
+		instancesMap[instance.Key.String()] = instance
 	}
 	return instances, instancesMap
 }
@@ -70,8 +70,8 @@ func TestSortInstancesSameCoordinatesDifferingBinlogFormats(t *testing.T) {
 		instance.ExecBinlogCoordinates = instances[0].ExecBinlogCoordinates
 		instance.Binlog_format = "MIXED"
 	}
-	instancesMap[i810Key.StringCode()].Binlog_format = "STATEMENT"
-	instancesMap[i720Key.StringCode()].Binlog_format = "ROW"
+	instancesMap[i810Key.String()].Binlog_format = "STATEMENT"
+	instancesMap[i720Key.String()].Binlog_format = "ROW"
 	sortInstances(instances)
 	test.S(t).ExpectEquals(instances[0].Key, i810Key)
 	test.S(t).ExpectEquals(instances[5].Key, i720Key)
@@ -82,8 +82,8 @@ func TestSortInstancesSameCoordinatesDifferingVersions(t *testing.T) {
 	for _, instance := range instances {
 		instance.ExecBinlogCoordinates = instances[0].ExecBinlogCoordinates
 	}
-	instancesMap[i810Key.StringCode()].Version = "5.5.1"
-	instancesMap[i720Key.StringCode()].Version = "5.7.8"
+	instancesMap[i810Key.String()].Version = "5.5.1"
+	instancesMap[i720Key.String()].Version = "5.7.8"
 	sortInstances(instances)
 	test.S(t).ExpectEquals(instances[0].Key, i810Key)
 	test.S(t).ExpectEquals(instances[5].Key, i720Key)
@@ -95,7 +95,7 @@ func TestSortInstancesDataCenterHint(t *testing.T) {
 		instance.ExecBinlogCoordinates = instances[0].ExecBinlogCoordinates
 		instance.DataCenter = "somedc"
 	}
-	instancesMap[i810Key.StringCode()].DataCenter = "localdc"
+	instancesMap[i810Key.String()].DataCenter = "localdc"
 	sortInstancesDataCenterHint(instances, "localdc")
 	test.S(t).ExpectEquals(instances[0].Key, i810Key)
 }
@@ -107,16 +107,16 @@ func TestGetPriorityMajorVersionForCandidate(t *testing.T) {
 	test.S(t).ExpectNil(err)
 	test.S(t).ExpectEquals(priorityMajorVersion, "5.6")
 
-	instancesMap[i810Key.StringCode()].Version = "5.5.1"
-	instancesMap[i720Key.StringCode()].Version = "5.7.8"
+	instancesMap[i810Key.String()].Version = "5.5.1"
+	instancesMap[i720Key.String()].Version = "5.7.8"
 	priorityMajorVersion, err = getPriorityMajorVersionForCandidate(instances)
 	test.S(t).ExpectNil(err)
 	test.S(t).ExpectEquals(priorityMajorVersion, "5.6")
 
-	instancesMap[i710Key.StringCode()].Version = "5.7.8"
-	instancesMap[i720Key.StringCode()].Version = "5.7.8"
-	instancesMap[i730Key.StringCode()].Version = "5.7.8"
-	instancesMap[i830Key.StringCode()].Version = "5.7.8"
+	instancesMap[i710Key.String()].Version = "5.7.8"
+	instancesMap[i720Key.String()].Version = "5.7.8"
+	instancesMap[i730Key.String()].Version = "5.7.8"
+	instancesMap[i830Key.String()].Version = "5.7.8"
 	priorityMajorVersion, err = getPriorityMajorVersionForCandidate(instances)
 	test.S(t).ExpectNil(err)
 	test.S(t).ExpectEquals(priorityMajorVersion, "5.7")
@@ -129,16 +129,16 @@ func TestGetPriorityBinlogFormatForCandidate(t *testing.T) {
 	test.S(t).ExpectNil(err)
 	test.S(t).ExpectEquals(priorityBinlogFormat, "STATEMENT")
 
-	instancesMap[i810Key.StringCode()].Binlog_format = "MIXED"
-	instancesMap[i720Key.StringCode()].Binlog_format = "ROW"
+	instancesMap[i810Key.String()].Binlog_format = "MIXED"
+	instancesMap[i720Key.String()].Binlog_format = "ROW"
 	priorityBinlogFormat, err = getPriorityBinlogFormatForCandidate(instances)
 	test.S(t).ExpectNil(err)
 	test.S(t).ExpectEquals(priorityBinlogFormat, "STATEMENT")
 
-	instancesMap[i710Key.StringCode()].Binlog_format = "ROW"
-	instancesMap[i720Key.StringCode()].Binlog_format = "ROW"
-	instancesMap[i730Key.StringCode()].Binlog_format = "ROW"
-	instancesMap[i830Key.StringCode()].Binlog_format = "ROW"
+	instancesMap[i710Key.String()].Binlog_format = "ROW"
+	instancesMap[i720Key.String()].Binlog_format = "ROW"
+	instancesMap[i730Key.String()].Binlog_format = "ROW"
+	instancesMap[i830Key.String()].Binlog_format = "ROW"
 	priorityBinlogFormat, err = getPriorityBinlogFormatForCandidate(instances)
 	test.S(t).ExpectNil(err)
 	test.S(t).ExpectEquals(priorityBinlogFormat, "ROW")
@@ -208,8 +208,8 @@ func TestChooseCandidateReplica(t *testing.T) {
 func TestChooseCandidateReplica2(t *testing.T) {
 	instances, instancesMap := generateTestInstances()
 	applyGeneralGoodToGoReplicationParams(instances)
-	instancesMap[i830Key.StringCode()].LogSlaveUpdatesEnabled = false
-	instancesMap[i820Key.StringCode()].LogBinEnabled = false
+	instancesMap[i830Key.String()].LogSlaveUpdatesEnabled = false
+	instancesMap[i820Key.String()].LogBinEnabled = false
 	instances = sortedReplicas(instances, NoStopReplication)
 	candidate, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := chooseCandidateReplica(instances)
 	test.S(t).ExpectNil(err)
@@ -226,8 +226,8 @@ func TestChooseCandidateReplicaSameCoordinatesDifferentVersions(t *testing.T) {
 	for _, instance := range instances {
 		instance.ExecBinlogCoordinates = instances[0].ExecBinlogCoordinates
 	}
-	instancesMap[i810Key.StringCode()].Version = "5.5.1"
-	instancesMap[i720Key.StringCode()].Version = "5.7.8"
+	instancesMap[i810Key.String()].Version = "5.5.1"
+	instancesMap[i720Key.String()].Version = "5.7.8"
 	instances = sortedReplicas(instances, NoStopReplication)
 	candidate, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := chooseCandidateReplica(instances)
 	test.S(t).ExpectNil(err)
@@ -241,7 +241,7 @@ func TestChooseCandidateReplicaSameCoordinatesDifferentVersions(t *testing.T) {
 func TestChooseCandidateReplicaPriorityVersionNoLoss(t *testing.T) {
 	instances, instancesMap := generateTestInstances()
 	applyGeneralGoodToGoReplicationParams(instances)
-	instancesMap[i830Key.StringCode()].Version = "5.5.1"
+	instancesMap[i830Key.String()].Version = "5.5.1"
 	instances = sortedReplicas(instances, NoStopReplication)
 	candidate, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := chooseCandidateReplica(instances)
 	test.S(t).ExpectNil(err)
@@ -255,7 +255,7 @@ func TestChooseCandidateReplicaPriorityVersionNoLoss(t *testing.T) {
 func TestChooseCandidateReplicaPriorityVersionLosesOne(t *testing.T) {
 	instances, instancesMap := generateTestInstances()
 	applyGeneralGoodToGoReplicationParams(instances)
-	instancesMap[i830Key.StringCode()].Version = "5.7.8"
+	instancesMap[i830Key.String()].Version = "5.7.8"
 	instances = sortedReplicas(instances, NoStopReplication)
 	candidate, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := chooseCandidateReplica(instances)
 	test.S(t).ExpectNil(err)
@@ -269,8 +269,8 @@ func TestChooseCandidateReplicaPriorityVersionLosesOne(t *testing.T) {
 func TestChooseCandidateReplicaPriorityVersionLosesTwo(t *testing.T) {
 	instances, instancesMap := generateTestInstances()
 	applyGeneralGoodToGoReplicationParams(instances)
-	instancesMap[i830Key.StringCode()].Version = "5.7.8"
-	instancesMap[i820Key.StringCode()].Version = "5.7.18"
+	instancesMap[i830Key.String()].Version = "5.7.8"
+	instancesMap[i820Key.String()].Version = "5.7.18"
 	instances = sortedReplicas(instances, NoStopReplication)
 	candidate, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := chooseCandidateReplica(instances)
 	test.S(t).ExpectNil(err)
@@ -284,10 +284,10 @@ func TestChooseCandidateReplicaPriorityVersionLosesTwo(t *testing.T) {
 func TestChooseCandidateReplicaPriorityVersionHigherVersionOverrides(t *testing.T) {
 	instances, instancesMap := generateTestInstances()
 	applyGeneralGoodToGoReplicationParams(instances)
-	instancesMap[i830Key.StringCode()].Version = "5.7.8"
-	instancesMap[i820Key.StringCode()].Version = "5.7.18"
-	instancesMap[i810Key.StringCode()].Version = "5.7.5"
-	instancesMap[i730Key.StringCode()].Version = "5.7.30"
+	instancesMap[i830Key.String()].Version = "5.7.8"
+	instancesMap[i820Key.String()].Version = "5.7.18"
+	instancesMap[i810Key.String()].Version = "5.7.5"
+	instancesMap[i730Key.String()].Version = "5.7.30"
 	instances = sortedReplicas(instances, NoStopReplication)
 	candidate, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := chooseCandidateReplica(instances)
 	test.S(t).ExpectNil(err)
@@ -304,7 +304,7 @@ func TestChooseCandidateReplicaLosesOneDueToBinlogFormat(t *testing.T) {
 	for _, instance := range instances {
 		instance.Binlog_format = "ROW"
 	}
-	instancesMap[i730Key.StringCode()].Binlog_format = "STATEMENT"
+	instancesMap[i730Key.String()].Binlog_format = "STATEMENT"
 
 	instances = sortedReplicas(instances, NoStopReplication)
 	candidate, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := chooseCandidateReplica(instances)
@@ -322,7 +322,7 @@ func TestChooseCandidateReplicaPriorityBinlogFormatNoLoss(t *testing.T) {
 	for _, instance := range instances {
 		instance.Binlog_format = "MIXED"
 	}
-	instancesMap[i830Key.StringCode()].Binlog_format = "STATEMENT"
+	instancesMap[i830Key.String()].Binlog_format = "STATEMENT"
 	instances = sortedReplicas(instances, NoStopReplication)
 	candidate, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := chooseCandidateReplica(instances)
 	test.S(t).ExpectNil(err)
@@ -336,7 +336,7 @@ func TestChooseCandidateReplicaPriorityBinlogFormatNoLoss(t *testing.T) {
 func TestChooseCandidateReplicaPriorityBinlogFormatLosesOne(t *testing.T) {
 	instances, instancesMap := generateTestInstances()
 	applyGeneralGoodToGoReplicationParams(instances)
-	instancesMap[i830Key.StringCode()].Binlog_format = "ROW"
+	instancesMap[i830Key.String()].Binlog_format = "ROW"
 	instances = sortedReplicas(instances, NoStopReplication)
 	candidate, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := chooseCandidateReplica(instances)
 	test.S(t).ExpectNil(err)
@@ -350,8 +350,8 @@ func TestChooseCandidateReplicaPriorityBinlogFormatLosesOne(t *testing.T) {
 func TestChooseCandidateReplicaPriorityBinlogFormatLosesTwo(t *testing.T) {
 	instances, instancesMap := generateTestInstances()
 	applyGeneralGoodToGoReplicationParams(instances)
-	instancesMap[i830Key.StringCode()].Binlog_format = "ROW"
-	instancesMap[i820Key.StringCode()].Binlog_format = "ROW"
+	instancesMap[i830Key.String()].Binlog_format = "ROW"
+	instancesMap[i820Key.String()].Binlog_format = "ROW"
 	instances = sortedReplicas(instances, NoStopReplication)
 	candidate, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := chooseCandidateReplica(instances)
 	test.S(t).ExpectNil(err)
@@ -365,10 +365,10 @@ func TestChooseCandidateReplicaPriorityBinlogFormatLosesTwo(t *testing.T) {
 func TestChooseCandidateReplicaPriorityBinlogFormatRowOverrides(t *testing.T) {
 	instances, instancesMap := generateTestInstances()
 	applyGeneralGoodToGoReplicationParams(instances)
-	instancesMap[i830Key.StringCode()].Binlog_format = "ROW"
-	instancesMap[i820Key.StringCode()].Binlog_format = "ROW"
-	instancesMap[i810Key.StringCode()].Binlog_format = "ROW"
-	instancesMap[i730Key.StringCode()].Binlog_format = "ROW"
+	instancesMap[i830Key.String()].Binlog_format = "ROW"
+	instancesMap[i820Key.String()].Binlog_format = "ROW"
+	instancesMap[i810Key.String()].Binlog_format = "ROW"
+	instancesMap[i730Key.String()].Binlog_format = "ROW"
 	instances = sortedReplicas(instances, NoStopReplication)
 	candidate, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := chooseCandidateReplica(instances)
 	test.S(t).ExpectNil(err)

--- a/go/inst/instance_utils.go
+++ b/go/inst/instance_utils.go
@@ -84,7 +84,7 @@ func filterInstancesByPattern(instances [](*Instance), pattern string) [](*Insta
 	}
 	filtered := [](*Instance){}
 	for _, instance := range instances {
-		if matched, _ := regexp.MatchString(pattern, instance.Key.DisplayString()); matched {
+		if matched, _ := regexp.MatchString(pattern, instance.Key.String()); matched {
 			filtered = append(filtered, instance)
 		}
 	}

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -165,7 +165,7 @@ func discoverInstance(instanceKey inst.InstanceKey) {
 	// Calculate the expiry period each time as InstancePollSeconds
 	// _may_ change during the run of the process (via SIGHUP) and
 	// it is not possible to change the cache's default expiry..
-	if existsInCacheError := recentDiscoveryOperationKeys.Add(instanceKey.DisplayString(), true, instancePollSecondsDuration()); existsInCacheError != nil {
+	if existsInCacheError := recentDiscoveryOperationKeys.Add(instanceKey.String(), true, instancePollSecondsDuration()); existsInCacheError != nil {
 		// Just recently attempted
 		return
 	}

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -684,14 +684,14 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 			topologyRecovery.AddPostponedFunction(postponedFunction, fmt.Sprintf("RecoverDeadMaster, detaching promoted master host %+v", promotedReplica.Key))
 		}
 		func() error {
-			before := analysisEntry.AnalyzedInstanceKey.StringCode()
-			after := promotedReplica.Key.StringCode()
+			before := analysisEntry.AnalyzedInstanceKey.String()
+			after := promotedReplica.Key.String()
 			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadMaster: updating cluster_alias: %v -> %v", before, after))
 			inst.ReplaceAliasClusterName(before, after)
 			return nil
 		}()
 
-		attributes.SetGeneralAttribute(analysisEntry.ClusterDetails.ClusterDomain, promotedReplica.Key.StringCode())
+		attributes.SetGeneralAttribute(analysisEntry.ClusterDetails.ClusterDomain, promotedReplica.Key.String())
 	} else {
 		recoverDeadMasterFailureCounter.Inc(1)
 	}
@@ -1194,7 +1194,7 @@ func checkAndRecoverGenericProblem(analysisEntry inst.ReplicationAnalysis, candi
 // Force a re-read of a topology instance; this is done because we need to substantiate a suspicion
 // that we may have a failover scenario. we want to speed up reading the complete picture.
 func emergentlyReadTopologyInstance(instanceKey *inst.InstanceKey, analysisCode inst.AnalysisCode) {
-	if existsInCacheError := emergencyReadTopologyInstanceMap.Add(instanceKey.StringCode(), true, cache.DefaultExpiration); existsInCacheError != nil {
+	if existsInCacheError := emergencyReadTopologyInstanceMap.Add(instanceKey.String(), true, cache.DefaultExpiration); existsInCacheError != nil {
 		// Just recently attempted
 		return
 	}


### PR DESCRIPTION
The 3 functions generated the same output and were interchangeable so the code is cleaner and easier to understand if just String() is used.  This suggested patch removes the redundant functions.

It's confusing otherwise and you need to check the code to see what the difference is between the 3 functions when actually there's no difference at all.  There are no functional changes to any of the code.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
