### PR TITLE
Adjust db.SetMaxIdleConns for backend orchestrator to a more dynamic value

### DIFF
--- a/go/db/db.go
+++ b/go/db/db.go
@@ -1346,7 +1346,23 @@ func OpenOrchestrator() (db *sql.DB, err error) {
 		if !config.Config.SkipOrchestratorDatabaseUpdate {
 			initOrchestratorDB(db)
 		}
-		db.SetMaxIdleConns(10)
+		// A low value here will trigger reconnects which could
+		// make the number of backend connections hit the tcp
+		// limit. That's bad.  I could make this setting dynamic
+		// but then people need to know which value to use. For now
+		// allow up to 25% of MySQLOrchestratorMaxPoolConnections
+		// to be idle.  That should provide a good number which
+		// does not keep the maximum number of connections open but
+		// at the same time does not trigger disconnections and
+		// reconnections too frequently.
+		maxIdleConns := int(config.Config.MySQLOrchestratorMaxPoolConnections * 25 / 100)
+		if maxIdleConns < 10 {
+			maxIdleConns = 10
+		}
+		log.Infof("Connecting to backend: maxConnections: %d, maxIdleConns: %d",
+			config.Config.MySQLOrchestratorMaxPoolConnections,
+			maxIdleConns)
+		db.SetMaxIdleConns(maxIdleConns)
 	}
 	return db, err
 }


### PR DESCRIPTION
Recent issues seen talking to the backend can give a: cannot assign requested address error. The number of open tcp sockets to the backend went over the limit.  This was triggered by the hard-coded value of `db.SetMaxIdleConns(10)` intended to prevent too many backend database
connections being left open triggering the go driver to close connections and shortly afterwards open them again triggering the issue described.

This patch now adjusts the value of `SetMaxIdleConns` to 25% of `MySQLOrchestratorMaxPoolConnections` if this value is larger and so will trigger less reconnections and help aleviate this point of stress.

I chose not to make the setting configurable (yet) as this may confuse people. If you make MySQLOrchestratorMaxPoolConnections higher then the number of idle connections is allowed to grow.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`
