### PR TITLE
api: replication analysis per instance

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -2141,16 +2141,14 @@ func (this *HttpAPI) ReloadConfiguration(params martini.Params, r render.Render,
 }
 
 // ReplicationAnalysis retuens list of issues
-func (this *HttpAPI) ReplicationAnalysis(params martini.Params, r render.Render, req *http.Request) {
-	clusterName, err := inst.ReadClusterNameByAlias(params["clusterName"])
-
+func (this *HttpAPI) replicationAnalysis(clusterName string, instanceKey *inst.InstanceKey, params martini.Params, r render.Render, req *http.Request) {
 	analysis, err := inst.GetReplicationAnalysis(clusterName, true, false)
 	if err != nil {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Cannot get analysis: %+v", err)})
 		return
 	}
 	// Possibly filter single instance
-	if instanceKey, err := this.getInstanceKey(params["host"], params["port"]); err == nil && instanceKey.IsValid() {
+	if instanceKey != nil {
 		filtered := analysis[:0]
 		for _, analysisEntry := range analysis {
 			if instanceKey.Equals(&analysisEntry.AnalyzedInstanceKey) {
@@ -2161,6 +2159,41 @@ func (this *HttpAPI) ReplicationAnalysis(params martini.Params, r render.Render,
 	}
 
 	r.JSON(200, &APIResponse{Code: OK, Message: fmt.Sprintf("Analysis"), Details: analysis})
+}
+
+// ReplicationAnalysis retuens list of issues
+func (this *HttpAPI) ReplicationAnalysis(params martini.Params, r render.Render, req *http.Request) {
+	this.replicationAnalysis("", nil, params, r, req)
+}
+
+// ReplicationAnalysis retuens list of issues
+func (this *HttpAPI) ReplicationAnalysisForCluster(params martini.Params, r render.Render, req *http.Request) {
+	clusterName := params["clusterName"]
+
+	var err error
+	if clusterName, err = inst.DeduceClusterName(params["clusterName"]); err != nil {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Cannot get analysis: %+v", err)})
+		return
+	}
+	if clusterName == "" {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Cannot get cluster name: %+v", params["clusterName"])})
+		return
+	}
+	this.replicationAnalysis(clusterName, nil, params, r, req)
+}
+
+// ReplicationAnalysis retuens list of issues
+func (this *HttpAPI) ReplicationAnalysisForKey(params martini.Params, r render.Render, req *http.Request) {
+	instanceKey, err := this.getInstanceKey(params["host"], params["port"])
+	if err != nil {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Cannot get analysis: %+v", err)})
+		return
+	}
+	if !instanceKey.IsValid() {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Cannot get analysis: invalid key %+v", instanceKey)})
+		return
+	}
+	this.replicationAnalysis("", &instanceKey, params, r, req)
 }
 
 // RecoverLite attempts recovery on a given instance, without executing external processes
@@ -2612,8 +2645,8 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 
 	// Recovery:
 	this.registerRequest(m, "replication-analysis", this.ReplicationAnalysis)
-	this.registerRequest(m, "replication-analysis/:clusterName", this.ReplicationAnalysis)
-	this.registerRequest(m, "replication-analysis/instance/:host/:port", this.ReplicationAnalysis)
+	this.registerRequest(m, "replication-analysis/:clusterName", this.ReplicationAnalysisForCluster)
+	this.registerRequest(m, "replication-analysis/instance/:host/:port", this.ReplicationAnalysisForKey)
 	this.registerRequest(m, "recover/:host/:port", this.Recover)
 	this.registerRequest(m, "recover/:host/:port/:candidateHost/:candidatePort", this.Recover)
 	this.registerRequest(m, "recover-lite/:host/:port", this.RecoverLite)

--- a/go/inst/cluster_alias_dao.go
+++ b/go/inst/cluster_alias_dao.go
@@ -48,6 +48,18 @@ func ReadClusterNameByAlias(alias string) (clusterName string, err error) {
 	return clusterName, err
 }
 
+// DeduceClusterName attempts to resolve a cluster name given a name or alias.
+// If unsuccessful to match by alias, the function returns the same given string
+func DeduceClusterName(nameOrAlias string) (clusterName string, err error) {
+	if nameOrAlias == "" {
+		return "", fmt.Errorf("empty cluster name")
+	}
+	if name, err := ReadClusterNameByAlias(nameOrAlias); err == nil {
+		return name, nil
+	}
+	return nameOrAlias, nil
+}
+
 // ReadAliasByClusterName returns the cluster alias for the given cluster name,
 // or the cluster name itself if not explicit alias found
 func ReadAliasByClusterName(clusterName string) (alias string, err error) {


### PR DESCRIPTION
support for:

- `/api/replication-analysis/instance/:host/:port` - get analysis for a specific instance
- `/api/replication-analysis/:clusterName` - cluster alias supported implicitly
