### PR TITLE
mitigating XSS attack

### DIFF
--- a/go/http/web.go
+++ b/go/http/web.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"strconv"
+	"text/template"
 
 	"github.com/go-martini/martini"
 	"github.com/martini-contrib/auth"
@@ -51,7 +52,7 @@ func (this *HttpWeb) getInstanceKey(host string, port string) (inst.InstanceKey,
 }
 
 func (this *HttpWeb) AccessToken(params martini.Params, r render.Render, req *http.Request, resp http.ResponseWriter, user auth.User) {
-	publicToken := req.URL.Query().Get("publicToken")
+	publicToken := template.JSEscapeString(req.URL.Query().Get("publicToken"))
 	err := authenticateToken(publicToken, resp)
 	if err != nil {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
@@ -105,7 +106,7 @@ func (this *HttpWeb) Cluster(params martini.Params, r render.Render, req *http.R
 		"authorizedForAction":           isAuthorizedForAction(req, user),
 		"userId":                        getUserId(req, user),
 		"removeTextFromHostnameDisplay": config.Config.RemoveTextFromHostnameDisplay,
-		"compactDisplay":                req.URL.Query().Get("compact"),
+		"compactDisplay":                template.JSEscapeString(req.URL.Query().Get("compact")),
 		"prefix":                        this.URLPrefix,
 	})
 }
@@ -156,7 +157,7 @@ func (this *HttpWeb) ClusterPools(params martini.Params, r render.Render, req *h
 		"authorizedForAction":           isAuthorizedForAction(req, user),
 		"userId":                        getUserId(req, user),
 		"removeTextFromHostnameDisplay": config.Config.RemoveTextFromHostnameDisplay,
-		"compactDisplay":                req.URL.Query().Get("compact"),
+		"compactDisplay":                template.JSEscapeString(req.URL.Query().Get("compact")),
 		"prefix":                        this.URLPrefix,
 	})
 }
@@ -166,6 +167,7 @@ func (this *HttpWeb) Search(params martini.Params, r render.Render, req *http.Re
 	if searchString == "" {
 		searchString = req.URL.Query().Get("s")
 	}
+	searchString = template.JSEscapeString(searchString)
 	r.HTML(200, "templates/search", map[string]interface{}{
 		"agentsHttpActive":    config.Config.ServeAgentsHttp,
 		"title":               "search",
@@ -194,7 +196,7 @@ func (this *HttpWeb) Discover(params martini.Params, r render.Render, req *http.
 func (this *HttpWeb) LongQueries(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	filter := params["filter"]
 	if filter == "" {
-		filter = req.URL.Query().Get("filter")
+		filter = template.JSEscapeString(req.URL.Query().Get("filter"))
 	}
 
 	r.HTML(200, "templates/long_queries", map[string]interface{}{


### PR DESCRIPTION
The web form was using texts provided as query params. This is now mitigated by escaping values to disable javascript execution.

cc @Oneiroi
