### PR TITLE
Add Bash to the container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM alpine
 
-EXPOSE  3000
+EXPOSE 3000
 
 ENV GOPATH=/tmp/go
 
 RUN set -ex \
+    && apk add --update --no-cache bash \
     && apk add --update --no-cache --virtual .build-deps \
-        bash \
         rsync \
         git \
         go \


### PR DESCRIPTION
There was an error where the orchestrator container was expecting "/bin/bash" to be present.
Adding bash to the running container removed that error.

Issue: https://github.com/github/orchestrator/issues/222