### PR TITLE
Add cli option --skip-continuous-registration (reduces backend db load)

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -246,7 +246,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	}
 	inst.SetMaintenanceOwner(owner)
 
-	if !skipDatabaseCommands {
+	if !skipDatabaseCommands && !*config.RuntimeCLIFlags.SkipContinuousRegistration {
 		process.ContinuousRegistration(string(process.OrchestratorExecutionCliMode), command)
 	}
 	// begin commands

--- a/go/cmd/orchestrator/main.go
+++ b/go/cmd/orchestrator/main.go
@@ -60,6 +60,7 @@ func main() {
 	config.RuntimeCLIFlags.GrabElection = flag.Bool("grab-election", false, "Grab leadership (only applies to continuous mode)")
 	config.RuntimeCLIFlags.PromotionRule = flag.String("promotion-rule", "prefer", "Promotion rule for register-andidate (prefer|neutral|must_not)")
 	config.RuntimeCLIFlags.Version = flag.Bool("version", false, "Print version and exit")
+	config.RuntimeCLIFlags.SkipContinuousRegistration = flag.Bool("skip-continuous-registration", false, "Skip cli commands performaing continuous registration (to reduce orchestratrator backend db load")
 	flag.Parse()
 
 	if *destination != "" && *sibling != "" {

--- a/go/config/cli_flags.go
+++ b/go/config/cli_flags.go
@@ -18,16 +18,17 @@ package config
 
 // CLIFlags stores some command line flags that are globally available in the process' lifetime
 type CLIFlags struct {
-	Noop               *bool
-	SkipUnresolve      *bool
-	SkipUnresolveCheck *bool
-	BinlogFile         *string
-	GrabElection       *bool
-	Version            *bool
-	Statement          *string
-	PromotionRule      *string
-	ConfiguredVersion  string
-	SkipBinlogSearch   *bool
+	Noop                       *bool
+	SkipUnresolve              *bool
+	SkipUnresolveCheck         *bool
+	BinlogFile                 *string
+	GrabElection               *bool
+	Version                    *bool
+	Statement                  *string
+	PromotionRule              *string
+	ConfiguredVersion          string
+	SkipBinlogSearch           *bool
+	SkipContinuousRegistration *bool
 }
 
 var RuntimeCLIFlags CLIFlags


### PR DESCRIPTION
I have seen that if you have a lot of orchestrator client runs they update the node_health table and while this should not be an issue as your scale grows this can lead to database bottlenecks.  For cli usage it's not always that important to actually write to the database backend and if you don't care about the clients recording this information then turning off this feature is not such a bad thing.

This patch, via the use of `--skip-continuous-registration`, will prevent the extra backend database connect and `node_health` update to alleviate this load.

I am aware that there's an `orchestrator-client` branch but that currently looks incomplete and it does resolve many of the issues I have seen in the past. Much of my code already uses http calls to prevent direct orchestrator backend access which is not really needed.  When that's complete I can imagine that using the command line tool to talk to the orchestrator backend database will happen much less frequently.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
