### PR TITLE
Allow for optional post-processing after starting orchestrator

### DIFF
--- a/etc/init.d/orchestrator.bash
+++ b/etc/init.d/orchestrator.bash
@@ -40,7 +40,8 @@ start_daemon () {
 	# collect and print PID of started process
 	echo $!
 	# space for optional processing after starting orchestrator
-	post_start_daemon_hook
+	# - redirect stdout to stderro to prevent this corrupting the pid info
+	post_start_daemon_hook 1>&2
 }
 
 # The file /etc/orchestrator_profile can be used to inject pre-service execution


### PR DESCRIPTION
This is a corrected version of https://github.com/github/orchestrator/pull/228. The commit message referenced a different project.

This is because of https://github.com/github/orchestrator/issues/227

A solution would be to add the following to /etc/orchestrator_profile

--- snip ---
post_start_daemon_hook () {
	sleep 1
}
--- snip ---

No go code changes, just the init script.