### PR TITLE
orchestrator-client to inline profile file

### DIFF
--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -26,6 +26,10 @@
 #   orchestrator -c register-candidate -i candidate.host.com:3306 --promotion-rule=prefer
 #   orchestrator -c recover -i failed.host.com:3306
 
+# /etc/profile.d/orchestrator-client.sh is for you to set any environment.
+# In particular, you will want to set ORCHESTRATOR_API
+[ -f /etc/profile.d/orchestrator-client.sh ] && . /etc/profile.d/orchestrator-client.sh
+
 orchestrator_api="${ORCHESTRATOR_API:-http://localhost:3000}"
 
 command=


### PR DESCRIPTION
The `orchestrator-client` shell script inlines `/etc/profile.d/orchestrator-client.sh` if exists. This allows users to create the file and populate it with any environment settings.

In particular, the user will likely set `ORCHESTRATOR_API` in that file.
