### PR TITLE
Added ability to mix TLS and non-TLS connections to nodes.

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -260,7 +260,7 @@ func newConfiguration() *Configuration {
 		MySQLOrchestratorMaxPoolConnections:        128, // limit concurrent conns to backend DB
 		MySQLOrchestratorPort:                      3306,
 		MySQLTopologyUseMutualTLS:                  false,
-		MySQLTopologyUseMixedTLS:                   false,
+		MySQLTopologyUseMixedTLS:                   true,
 		MySQLOrchestratorUseMutualTLS:              false,
 		MySQLConnectTimeoutSeconds:                 2,
 		MySQLOrchestratorReadTimeoutSeconds:        30,

--- a/go/db/tls.go
+++ b/go/db/tls.go
@@ -40,7 +40,7 @@ var topologyTLSConfigured bool = false
 // Track if a TLS has already been configured for Orchestrator
 var orchestratorTLSConfigured bool = false
 
-var requireTLSCache *cache.Cache = cache.New(time.Duration(config.Config.TLSCacheTTLFactor)*time.Second, time.Second)
+var requireTLSCache *cache.Cache = cache.New(time.Duration(config.Config.TLSCacheTTLFactor*config.Config.InstancePollSeconds)*time.Second, time.Second)
 
 var readInstanceTLSCounter = metrics.NewCounter()
 var writeInstanceTLSCounter = metrics.NewCounter()


### PR DESCRIPTION
Encapsulated all TLS logic in db/tls.go.

Created new DB table database_instance_tls to record TLS requirement per host/port. Tested both in MySQL and sqlite3.

Set a configurable TLS info cache TTL (TLSCacheTTLFactor * InstancePollSeconds).

New metrics exposed: "instance_tls.read", "instance_tls.write", "instance_tls.read_cache", "instance_tls.write_cache",

Note that for this to work the go-sql-driver needs to be updated ( #239 ) otherwise having a single TLS config for more than one host is not possible due to issue go-sql-driver/mysql#536 .