### PR TITLE
raft hostnames resolving to IP

### DIFF
--- a/go/raft/fsm.go
+++ b/go/raft/fsm.go
@@ -37,7 +37,10 @@ func (f *fsm) Apply(l *raft.Log) interface{} {
 	}
 
 	if c.Op == YieldCommand {
-		toPeer := normalizeRaftNode(string(c.Value))
+		toPeer, err := normalizeRaftNode(string(c.Value))
+		if err != nil {
+			return log.Errore(err)
+		}
 		return f.yield(toPeer)
 	}
 	if c.Op == YieldHintCommand {


### PR DESCRIPTION
Addresses https://github.com/github/orchestrator/issues/253

with this PR, `orchestrator` will resolve raft hostnames to IP addresses before handing over the details to the raft library.

This supports `orchestrator` configuration to specify hostnames rather than IP addresses.

cc @bbeaudreault 