### PR TITLE
curl integer timeout

### DIFF
--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -158,7 +158,7 @@ function detect_leader_api() {
   fi
   for api in ${apis[@]} ; do
     api=$(normalize_orchestrator_api $api)
-    leader_check=$(curl -m 0.5 -s -o /dev/null -w "%{http_code}" "${api}/leader-check")
+    leader_check=$(curl -m 1 -s -o /dev/null -w "%{http_code}" "${api}/leader-check")
     if [ "$leader_check" == "200" ] ; then
       leader_api="$api"
       return


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/257

this ups the `curl` timeout on `orchestrator-client` to `1` sec, making it an integer, thereby supporting older versions of `curl`.
