### PR TITLE
Support for --ignore-raft-setup command line client invocation

### DIFF
--- a/docs/deployment-raft.md
+++ b/docs/deployment-raft.md
@@ -53,7 +53,10 @@ To interact with orchestrator from shell/automation/scripts, you may choose to:
 
     Make sure to chef/puppet/whatever the `ORCHESTRATOR_API` value such that it adapts to changes in your environment.
 
-You must _not_ use the `orchestrator` command line client. Fortunately `orchestrator-client` provides an almost identical interface as the command line client.
+- The `orchestrator` command line client will refuse to run given a raft setup, since it interacts directly with the underlying database and doesn't participate in the raft consensus, and thus cannot ensure all raft members will get visibility into it changes.
+  - Fortunately `orchestrator-client` provides an almost identical interface as the command line client.
+  - You may force the command line client to run via `--ignore-raft-setup`. This is a "I know what I'm doing" risk you take. If you do choose to use it, then it makes more sense to connect to the leader's backend DB.
+
 
 ### Orchestrator service
 

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -132,8 +132,8 @@ func validateInstanceIsFound(instanceKey *inst.InstanceKey) (instance *inst.Inst
 // CliWrapper is called from main and allows for the instance parameter
 // to take multiple instance names separated by a comma or whitespace.
 func CliWrapper(command string, strict bool, instances string, destination string, owner string, reason string, duration string, pattern string, clusterAlias string, pool string, hostnameFlag string) {
-	if config.Config.RaftEnabled && !*config.RuntimeCLIFlags.Noop {
-		log.Fatalf(`Orchestrator configured to run raft ("RaftEnabled": true). All access (except noop) must go through the web API of the active raft node. You may use the orchestrator-client script which has a similar interface to the command line invocation.`)
+	if config.Config.RaftEnabled && !*config.RuntimeCLIFlags.IgnoreRaftSetup {
+		log.Fatalf(`Orchestrator configured to run raft ("RaftEnabled": true). All access must go through the web API of the active raft node. You may use the orchestrator-client script which has a similar interface to the command line invocation. You may override this with --ignore-raft-setup`)
 	}
 	r := regexp.MustCompile(`[ ,\r\n\t]+`)
 	tokens := r.Split(instances, -1)

--- a/go/cmd/orchestrator/main.go
+++ b/go/cmd/orchestrator/main.go
@@ -62,6 +62,7 @@ func main() {
 	config.RuntimeCLIFlags.Version = flag.Bool("version", false, "Print version and exit")
 	config.RuntimeCLIFlags.SkipContinuousRegistration = flag.Bool("skip-continuous-registration", false, "Skip cli commands performaing continuous registration (to reduce orchestratrator backend db load")
 	config.RuntimeCLIFlags.EnableDatabaseUpdate = flag.Bool("enable-database-update", false, "Enable database update, overrides SkipOrchestratorDatabaseUpdate")
+	config.RuntimeCLIFlags.IgnoreRaftSetup = flag.Bool("ignore-raft-setup", false, "Override RaftEnabled for CLI invocation (CLI by default not allowed for raft setups). NOTE: operations by CLI invocation may not reflect in all raft nodes.")
 	flag.Parse()
 
 	if *destination != "" && *sibling != "" {

--- a/go/config/cli_flags.go
+++ b/go/config/cli_flags.go
@@ -30,6 +30,7 @@ type CLIFlags struct {
 	SkipBinlogSearch           *bool
 	SkipContinuousRegistration *bool
 	EnableDatabaseUpdate       *bool
+	IgnoreRaftSetup            *bool
 }
 
 var RuntimeCLIFlags CLIFlags


### PR DESCRIPTION
The orchestrator command line client should not be used with `raft` setup, because it interacts directly with the underlying database and does not go through the `raft` protocol, hence it makes changes without letting everyone know about them.

However, power to humans, this PR suggests an "I know what I'm doing" option ; with `--ignore-raft-setup` the command line client will agree to run.

If anything, it's advisable to run `orchestrator --ignore-raft-setup` on the leader node's backend DB.