### PR TITLE
Analysis: downtimed replicas

### DIFF
--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -102,6 +102,7 @@ type ReplicationAnalysis struct {
 	Description                               string
 	StructureAnalysis                         []StructureAnalysisCode
 	IsDowntimed                               bool
+	IsReplicasDowntimed                       bool // as good as downtimed because all replicas are downtimed AND analysis is all about the replicas (e.e. AllMasterSlavesNotReplicating)
 	DowntimeEndTimestamp                      string
 	DowntimeRemainingSeconds                  int
 	IsBinlogServer                            bool

--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -94,6 +94,7 @@ type ReplicationAnalysis struct {
 	CountValidReplicatingReplicas             uint
 	CountReplicasFailingToConnectToMaster     uint
 	CountStaleReplicas                        uint
+	CountDowntimedReplicas                    uint
 	ReplicationDepth                          uint
 	SlaveHosts                                InstanceKeyMap
 	IsFailingToConnectToMaster                bool

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -391,15 +391,18 @@ func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnal
 			if a.IsDowntimed && !includeDowntimed {
 				skipThisHost = true
 			}
-			if a.CountReplicas == a.CountDowntimedReplicas && !includeDowntimed {
+			if a.CountReplicas == a.CountDowntimedReplicas {
 				switch a.Analysis {
 				case AllMasterSlavesNotReplicating,
 					AllMasterSlavesNotReplicatingOrDead,
 					AllCoMasterSlavesNotReplicating,
 					AllIntermediateMasterSlavesFailingToConnectOrDead,
 					AllIntermediateMasterSlavesNotReplicating:
-					skipThisHost = true
+					a.IsReplicasDowntimed = true
 				}
+			}
+			if a.IsReplicasDowntimed && !includeDowntimed {
+				skipThisHost = true
 			}
 			if !skipThisHost {
 				result = append(result, a)

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -124,14 +124,14 @@ func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnal
 		            AND master_instance.last_io_error like '%%error %%connecting to master%%'
 		          ) AS is_failing_to_connect_to_master,
 						MIN(
-								database_instance_downtime.downtime_active is not null
-								and ifnull(database_instance_downtime.end_timestamp, now()) > now()
+								master_downtime.downtime_active is not null
+								and ifnull(master_downtime.end_timestamp, now()) > now()
 							) AS is_downtimed,
 			    	MIN(
-				    		IFNULL(database_instance_downtime.end_timestamp, '')
+				    		IFNULL(master_downtime.end_timestamp, '')
 				    	) AS downtime_end_timestamp,
 			    	MIN(
-				    		IFNULL(unix_timestamp() - unix_timestamp(database_instance_downtime.end_timestamp), 0)
+				    		IFNULL(unix_timestamp() - unix_timestamp(master_downtime.end_timestamp), 0)
 				    	) AS downtime_remaining_seconds,
 			    	MIN(
 				    		master_instance.binlog_server
@@ -175,6 +175,10 @@ func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnal
 								AND slave_instance.log_slave_updates
 								AND slave_instance.binlog_format = 'ROW'),
               0) AS count_row_based_loggin_slaves,
+						IFNULL(SUM(
+								replica_downtime.downtime_active is not null
+								and ifnull(replica_downtime.end_timestamp, now()) > now()),
+              0) AS count_downtimed_replicas,
 						COUNT(DISTINCT case
 								when slave_instance.log_bin AND slave_instance.log_slave_updates
 								then slave_instance.major_version
@@ -183,23 +187,27 @@ func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnal
 						) AS count_distinct_logging_major_versions
 		    FROM
 		        database_instance master_instance
-		            LEFT JOIN
+          LEFT JOIN
 		        hostname_resolve ON (master_instance.hostname = hostname_resolve.hostname)
-		            LEFT JOIN
+          LEFT JOIN
 		        database_instance slave_instance ON (COALESCE(hostname_resolve.resolved_hostname,
 		                master_instance.hostname) = slave_instance.master_host
 		            	AND master_instance.port = slave_instance.master_port)
-		            LEFT JOIN
+          LEFT JOIN
 		        database_instance_maintenance ON (master_instance.hostname = database_instance_maintenance.hostname
 		        		AND master_instance.port = database_instance_maintenance.port
 		        		AND database_instance_maintenance.maintenance_active = 1)
-		            LEFT JOIN
-		        database_instance_downtime ON (master_instance.hostname = database_instance_downtime.hostname
-		        		AND master_instance.port = database_instance_downtime.port
-		        		AND database_instance_downtime.downtime_active = 1)
-		        	LEFT JOIN
+          LEFT JOIN
+		        database_instance_downtime as master_downtime ON (master_instance.hostname = master_downtime.hostname
+		        		AND master_instance.port = master_downtime.port
+		        		AND master_downtime.downtime_active = 1)
+					LEFT JOIN
+		        database_instance_downtime as replica_downtime ON (slave_instance.hostname = replica_downtime.hostname
+		        		AND slave_instance.port = replica_downtime.port
+		        		AND replica_downtime.downtime_active = 1)
+        	LEFT JOIN
 		        cluster_alias ON (cluster_alias.cluster_name = master_instance.cluster_name)
-						  LEFT JOIN
+				  LEFT JOIN
 						database_instance_recent_relaylog_history ON (
 								slave_instance.hostname = database_instance_recent_relaylog_history.hostname
 		        		AND slave_instance.port = database_instance_recent_relaylog_history.port)
@@ -233,6 +241,7 @@ func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnal
 		a.CountValidReplicas = m.GetUint("count_valid_slaves")
 		a.CountValidReplicatingReplicas = m.GetUint("count_valid_replicating_slaves")
 		a.CountReplicasFailingToConnectToMaster = m.GetUint("count_slaves_failing_to_connect_to_master")
+		a.CountDowntimedReplicas = m.GetUint("count_downtimed_replicas")
 		a.CountStaleReplicas = 0
 		a.ReplicationDepth = m.GetUint("replication_depth")
 		a.IsFailingToConnectToMaster = m.GetBool("is_failing_to_connect_to_master")
@@ -381,6 +390,16 @@ func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnal
 			}
 			if a.IsDowntimed && !includeDowntimed {
 				skipThisHost = true
+			}
+			if a.CountReplicas == a.CountDowntimedReplicas && !includeDowntimed {
+				switch a.Analysis {
+				case AllMasterSlavesNotReplicating,
+					AllMasterSlavesNotReplicatingOrDead,
+					AllCoMasterSlavesNotReplicating,
+					AllIntermediateMasterSlavesFailingToConnectOrDead,
+					AllIntermediateMasterSlavesNotReplicating:
+					skipThisHost = true
+				}
 			}
 			if !skipThisHost {
 				result = append(result, a)

--- a/resources/public/js/cluster.js
+++ b/resources/public/js/cluster.js
@@ -1343,10 +1343,11 @@ function Cluster() {
 
   function onAnalysisEntry(analysisEntry, instance) {
     var content = '<span><strong>' + analysisEntry.Analysis + (analysisEntry.IsDowntimed ? '<br/>[<i>downtime till ' + analysisEntry.DowntimeEndTimestamp + '</i>]' : '') + "</strong></span>" + "<br/>" + "<span>" + analysisEntry.AnalyzedInstanceKey.Hostname + ":" + analysisEntry.AnalyzedInstanceKey.Port + "</span>";
+    var hasDowntime = analysisEntry.IsDowntimed || analysisEntry.IsReplicasDowntimed
     if (analysisEntry.IsStructureAnalysis) {
-      content = '<div class="pull-left glyphicon glyphicon-exclamation-sign text-warning"></div>' + content;
+      content = '<div class="pull-left glyphicon glyphicon-exclamation-sign '+(hasDowntime ? "text-muted" : "text-warning")+'"></div>' + content;
     } else {
-      content = '<div class="pull-left glyphicon glyphicon-exclamation-sign text-danger"></div>' + content;
+      content = '<div class="pull-left glyphicon glyphicon-exclamation-sign '+(hasDowntime ? "text-muted" : "text-danger")+'"></div>' + content;
     }
     addSidebarInfoPopoverContent(content);
 
@@ -1417,13 +1418,15 @@ function Cluster() {
   function reviewReplicationAnalysis(replicationAnalysis) {
     var instancesMap = _instancesMap;
     var clusterHasReplicationAnalysisIssue = false;
+    var allIssuesAreDowntimed = true;
     var clusterHasStructureAnalysisIssue = false;
     replicationAnalysis.Details.forEach(function(analysisEntry) {
       if (analysisEntry.ClusterDetails.ClusterName != currentClusterName()) {
         return;
       }
-      if (analysisEntry.IsReplicasDowntimed) {
-        return;
+      var hasDowntime = analysisEntry.IsDowntimed || analysisEntry.IsReplicasDowntimed
+      if (!hasDowntime) {
+        allIssuesAreDowntimed = false;
       }
       var instanceId = getInstanceId(analysisEntry.AnalyzedInstanceKey.Hostname, analysisEntry.AnalyzedInstanceKey.Port);
       var instance = instancesMap[instanceId]
@@ -1440,9 +1443,11 @@ function Cluster() {
       });
     });
     if (clusterHasReplicationAnalysisIssue) {
-      $("#cluster_sidebar [data-bullet=info] div span").addClass("text-danger").addClass("glyphicon-exclamation-sign");;
+      var iconClass = (allIssuesAreDowntimed ? "text-muted" : "text-danger");
+      $("#cluster_sidebar [data-bullet=info] div span").addClass(iconClass).addClass("glyphicon-exclamation-sign");;
     } else if (clusterHasStructureAnalysisIssue) {
-      $("#cluster_sidebar [data-bullet=info] div span").addClass("text-warning").addClass("glyphicon-exclamation-sign");;
+      var iconClass = (allIssuesAreDowntimed ? "text-muted" : "text-warning");
+      $("#cluster_sidebar [data-bullet=info] div span").addClass(iconClass).addClass("glyphicon-exclamation-sign");;
     } else {
       $("#cluster_sidebar [data-bullet=info] div span").addClass("text-info").addClass("glyphicon-info-sign");
     }

--- a/resources/public/js/cluster.js
+++ b/resources/public/js/cluster.js
@@ -1422,6 +1422,9 @@ function Cluster() {
       if (analysisEntry.ClusterDetails.ClusterName != currentClusterName()) {
         return;
       }
+      if (analysisEntry.IsReplicasDowntimed) {
+        return;
+      }
       var instanceId = getInstanceId(analysisEntry.AnalyzedInstanceKey.Hostname, analysisEntry.AnalyzedInstanceKey.Port);
       var instance = instancesMap[instanceId]
       if (analysisEntry.Analysis in interestingAnalysis) {

--- a/resources/public/js/cluster.js
+++ b/resources/public/js/cluster.js
@@ -1342,7 +1342,13 @@ function Cluster() {
   }
 
   function onAnalysisEntry(analysisEntry, instance) {
-    var content = '<span><strong>' + analysisEntry.Analysis + (analysisEntry.IsDowntimed ? '<br/>[<i>downtime till ' + analysisEntry.DowntimeEndTimestamp + '</i>]' : '') + "</strong></span>" + "<br/>" + "<span>" + analysisEntry.AnalyzedInstanceKey.Hostname + ":" + analysisEntry.AnalyzedInstanceKey.Port + "</span>";
+    var extraText = '';
+    if  (analysisEntry.IsDowntimed) {
+      extraText = '<br/>[<i>downtime till ' + analysisEntry.DowntimeEndTimestamp + '</i>]';
+    } else if (analysisEntry.IsReplicasDowntimed) {
+      extraText = '<br/>[<i>replicas downtimed</i>]';
+    }
+    var content = '<span><strong>' + analysisEntry.Analysis + extraText + "</strong></span>" + "<br/>" + "<span>" + analysisEntry.AnalyzedInstanceKey.Hostname + ":" + analysisEntry.AnalyzedInstanceKey.Port + "</span>";
     var hasDowntime = analysisEntry.IsDowntimed || analysisEntry.IsReplicasDowntimed
     if (analysisEntry.IsStructureAnalysis) {
       content = '<div class="pull-left glyphicon glyphicon-exclamation-sign '+(hasDowntime ? "text-muted" : "text-warning")+'"></div>' + content;

--- a/resources/public/js/clusters.js
+++ b/resources/public/js/clusters.js
@@ -47,6 +47,8 @@ $(document).ready(function() {
   function displayClusters(clusters, replicationAnalysis, problemInstances) {
     hideLoader();
 
+    clusters = clusters || [];
+
     clusters.sort(sortByCountInstances);
     var clustersProblems = {};
     clusters.forEach(function(cluster) {
@@ -115,6 +117,10 @@ $(document).ready(function() {
           var analysisLabel = "text-danger";
           if (analysisEntry.IsStructureAnalysis) {
             analysisLabel = "text-warning";
+          }
+          var hasDowntime = analysisEntry.IsDowntimed || analysisEntry.IsReplicasDowntimed
+          if (hasDowntime) {
+            analysisLabel = "text-muted";
           }
           popoverElement.find("h3 .pull-left").prepend('<span class="glyphicon glyphicon-exclamation-sign ' + analysisLabel + '" title="' + analysisEntry.Analysis + ': ' + getInstanceTitle(analysisEntry.AnalyzedInstanceKey.Hostname, analysisEntry.AnalyzedInstanceKey.Port) + '"></span>');
         });

--- a/tests/integration/analysis-no-problem-downtime/create.sql
+++ b/tests/integration/analysis-no-problem-downtime/create.sql
@@ -1,0 +1,6 @@
+UPDATE database_instance SET slave_sql_running=0 where master_port=22294;
+INSERT INTO database_instance_downtime (
+    hostname, port, downtime_active, begin_timestamp, end_timestamp, owner, reason
+  ) values (
+    'testhost', 22295, 1, now(), now() + interval 1 minute, 'test', 'integration test'
+  );

--- a/tests/integration/analysis-no-problem-downtime/create.sql
+++ b/tests/integration/analysis-no-problem-downtime/create.sql
@@ -4,4 +4,4 @@ INSERT INTO database_instance_downtime (
   ) values (
     'testhost', 22295, 1, now(), now(), 'test', 'integration test'
   );
-UPDATE database_instance_downtime SET end_timestamp=now() + interval 1 hour;
+UPDATE database_instance_downtime SET end_timestamp=end_timestamp + interval 1 hour;

--- a/tests/integration/analysis-no-problem-downtime/create.sql
+++ b/tests/integration/analysis-no-problem-downtime/create.sql
@@ -4,4 +4,4 @@ INSERT INTO database_instance_downtime (
   ) values (
     'testhost', 22295, 1, current_timestamp, current_timestamp, 'test', 'integration test'
   );
-UPDATE database_instance_downtime SET end_timestamp=end_timestamp + interval 1 hour;
+UPDATE database_instance_downtime SET end_timestamp=current_timestamp + interval 1 minute;

--- a/tests/integration/analysis-no-problem-downtime/create.sql
+++ b/tests/integration/analysis-no-problem-downtime/create.sql
@@ -1,6 +1,6 @@
 UPDATE database_instance SET slave_sql_running=0 where master_port=22294;
--- INSERT INTO database_instance_downtime (
---     hostname, port, downtime_active, begin_timestamp, end_timestamp, owner, reason
---   ) values (
---     'testhost', 22295, 1, now(), now() + interval 1 minute, 'test', 'integration test'
---   );
+INSERT INTO database_instance_downtime (
+    hostname, port, downtime_active, begin_timestamp, end_timestamp, owner, reason
+  ) values (
+    'testhost', 22295, 1, now(), now() + interval 1 minute, 'test', 'integration test'
+  );

--- a/tests/integration/analysis-no-problem-downtime/create.sql
+++ b/tests/integration/analysis-no-problem-downtime/create.sql
@@ -1,6 +1,6 @@
 UPDATE database_instance SET slave_sql_running=0 where master_port=22294;
-INSERT INTO database_instance_downtime (
-    hostname, port, downtime_active, begin_timestamp, end_timestamp, owner, reason
-  ) values (
-    'testhost', 22295, 1, now(), now() + interval 1 minute, 'test', 'integration test'
-  );
+-- INSERT INTO database_instance_downtime (
+--     hostname, port, downtime_active, begin_timestamp, end_timestamp, owner, reason
+--   ) values (
+--     'testhost', 22295, 1, now(), now() + interval 1 minute, 'test', 'integration test'
+--   );

--- a/tests/integration/analysis-no-problem-downtime/create.sql
+++ b/tests/integration/analysis-no-problem-downtime/create.sql
@@ -2,5 +2,6 @@ UPDATE database_instance SET slave_sql_running=0 where master_port=22294;
 INSERT INTO database_instance_downtime (
     hostname, port, downtime_active, begin_timestamp, end_timestamp, owner, reason
   ) values (
-    'testhost', 22295, 1, now(), now() + interval 1 minute, 'test', 'integration test'
+    'testhost', 22295, 1, now(), now(), 'test', 'integration test'
   );
+UPDATE database_instance_downtime SET end_timestamp=now() + interval 1 hour;

--- a/tests/integration/analysis-no-problem-downtime/create.sql
+++ b/tests/integration/analysis-no-problem-downtime/create.sql
@@ -2,6 +2,6 @@ UPDATE database_instance SET slave_sql_running=0 where master_port=22294;
 INSERT INTO database_instance_downtime (
     hostname, port, downtime_active, begin_timestamp, end_timestamp, owner, reason
   ) values (
-    'testhost', 22295, 1, now(), now(), 'test', 'integration test'
+    'testhost', 22295, 1, current_timestamp, current_timestamp, 'test', 'integration test'
   );
 UPDATE database_instance_downtime SET end_timestamp=end_timestamp + interval 1 hour;

--- a/tests/integration/analysis-no-problem-downtime/expect_output
+++ b/tests/integration/analysis-no-problem-downtime/expect_output
@@ -1,1 +1,0 @@
-testhost:22294 (cluster testhost:22293): AllIntermediateMasterSlavesNotReplicating

--- a/tests/integration/analysis-no-problem-downtime/expect_output
+++ b/tests/integration/analysis-no-problem-downtime/expect_output
@@ -1,1 +1,1 @@
-testhost:22293 (cluster testhost:22294): AllIntermediateMasterSlavesNotReplicating
+testhost:22294 (cluster testhost:22293): AllIntermediateMasterSlavesNotReplicating

--- a/tests/integration/analysis-no-problem-downtime/expect_output
+++ b/tests/integration/analysis-no-problem-downtime/expect_output
@@ -1,0 +1,1 @@
+testhost:22293 (cluster testhost:22294): AllIntermediateMasterSlavesNotReplicating

--- a/tests/integration/analysis-no-problem-downtime/extra_args
+++ b/tests/integration/analysis-no-problem-downtime/extra_args
@@ -1,0 +1,1 @@
+-c replication-analysis

--- a/tests/integration/create-per-test.sql
+++ b/tests/integration/create-per-test.sql
@@ -7,6 +7,7 @@
 -- + 22296
 -- + 22297
 --
+DELETE FROM database_instance_downtime;
 DELETE FROM database_instance;
 
 INSERT INTO database_instance (hostname, port, last_checked, last_attempted_check, last_seen, uptime, server_id, server_uuid, version, binlog_server, read_only, binlog_format, log_bin, log_slave_updates, binary_log_file, binary_log_pos, master_host, master_port, slave_sql_running, slave_io_running, has_replication_filters, oracle_gtid, executed_gtid_set, gtid_purged, supports_oracle_gtid, mariadb_gtid, pseudo_gtid, master_log_file, read_master_log_pos, relay_master_log_file, exec_master_log_pos, relay_log_file, relay_log_pos, last_sql_error, last_io_error, seconds_behind_master, slave_lag_seconds, sql_delay, allow_tls, num_slave_hosts, slave_hosts, cluster_name, suggested_cluster_alias, data_center, physical_environment, instance_alias, semi_sync_enforced, replication_depth, is_co_master, replication_credentials_available, has_replication_credentials, version_comment, major_version) VALUES ('testhost',22293,'2017-02-02 08:29:57','2017-02-02 08:29:57','2017-02-02 08:29:57',670447,1,'00022293-1111-1111-1111-111111111111','5.6.28-log',0,0,'STATEMENT',1,1,'mysql-bin.000167',137086726,'',0,0,0,0,0,'','',0,0,1,'',0,'',0,'',0,'','',NULL,NULL,0,0,3,'[{\"Hostname\":\"testhost\",\"Port\":22294},{\"Hostname\":\"testhost\",\"Port\":22297},{\"Hostname\":\"testhost\",\"Port\":22296}]','testhost:22293','testhost','ny','','',0,0,0,0,0,'MySQL Community Server (GPL)','5.6');

--- a/tests/integration/test.sh
+++ b/tests/integration/test.sh
@@ -116,6 +116,9 @@ test_single() {
     if [ $diff_result -ne 0 ] ; then
       echo
       echo "ERROR $test_name diff failure. cat $test_diff_file"
+      echo "---"
+      cat $test_diff_file"
+      echo "---"
       return 1
     fi
   fi

--- a/tests/integration/test.sh
+++ b/tests/integration/test.sh
@@ -117,7 +117,7 @@ test_single() {
       echo
       echo "ERROR $test_name diff failure. cat $test_diff_file"
       echo "---"
-      cat $test_diff_file"
+      cat $test_diff_file
       echo "---"
       return 1
     fi

--- a/tests/integration/test.sh
+++ b/tests/integration/test.sh
@@ -22,7 +22,10 @@ function run_queries() {
   queries_file="$1"
 
   if [ "$db_type" == "sqlite" ] ; then
-    cat $queries_file | sed -e "s/last_checked - interval 1 minute/datetime('last_checked', '-1 minute')/g" | sqlite3 $sqlite_file
+    cat $queries_file |
+      sed -e "s/last_checked - interval 1 minute/datetime('last_checked', '-1 minute')/g" |
+      sed -e "s/current_timestamp + interval 1 minute/datetime('now', '+1 minute')/g" |
+      sqlite3 $sqlite_file
   else
     # Assume mysql
     mysql --default-character-set=utf8mb4 test -ss < $queries_file


### PR DESCRIPTION
This PR considers downtimed replica when evaluating analysis. 

For example, if all replicas of an intermediate master are not-replicating or dead, this should generate a `AllIntermediateMasterSlavesFailingToConnectOrDead`. However, if they're also _all downtimed_, then the analysis should go away. This PR does just that. 

Affected analysis types:

- `AllMasterSlavesNotReplicating`
- `AllMasterSlavesNotReplicatingOrDead`
- `AllCoMasterSlavesNotReplicating`
- `AllIntermediateMasterSlavesFailingToConnectOrDead`
- `AllIntermediateMasterSlavesNotReplicating`

of course, this is irrelevant if the server (master? intermediate master?) itself is dead. That's a different case with different analysis.
