### PR TITLE
Intermediate master recovery: exclude must_not servers

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -826,6 +826,9 @@ func isValidAsCandidateSiblingOfIntermediateMaster(intermediateMasterInstance *i
 	if !isGeneralyValidAsCandidateSiblingOfIntermediateMaster(sibling) {
 		return false
 	}
+	if inst.IsBannedFromBeingCandidateReplica(sibling) {
+		return false
+	}
 	if sibling.HasReplicationFilters != intermediateMasterInstance.HasReplicationFilters {
 		return false
 	}


### PR DESCRIPTION
A different, simpler take on https://github.com/github/orchestrator/pull/279

This PR makes sure to exclude servers which have `must_not` promotion rule from being promoted as result of `RecoverDeadIntermediateMaster`.

cc @sjmudd 