### PR TITLE
avoid failing raft on hostname resolve error

### DIFF
--- a/go/raft/raft.go
+++ b/go/raft/raft.go
@@ -90,7 +90,9 @@ func normalizeRaftHostnameIP(host string) (string, error) {
 	}
 	ips, err := net.LookupIP(host)
 	if err != nil {
-		return host, err
+		// resolve failed. But we don't want to fail the entire operation for that
+		log.Errore(err)
+		return host, nil
 	}
 	// resolve success!
 	for _, ip := range ips {


### PR DESCRIPTION
`RaftNodes` can be given as IP addresses or as hostnames.

With this PR, if a raft node is identified by hostname, and the hostname cannot be resolved to IP, `orchestrator/raft` logs an error message but agrees to run.

Previously it would `FATAL`, and operationally this is a mistake: a host not fully provisioned or just deprovisioned, or whatever DNS problem, shouldn't break the raft setup per se. Let the raft setup decide on its own whether there is or isn't a quorum.