### PR TITLE
support for silent-UI

### DIFF
--- a/resources/public/js/cluster.js
+++ b/resources/public/js/cluster.js
@@ -807,21 +807,28 @@ function Cluster() {
 
 
   function executeMoveOperation(message, apiUrl) {
-    bootbox.confirm(anonymizeIfNeedBe(message), function(confirm) {
-      if (confirm) {
-        showLoader();
-        getData(apiUrl, function(operationResult) {
-          hideLoader();
-          if (operationResult.Code == "ERROR") {
-            addAlert(operationResult.Message)
-          } else {
-            reloadWithOperationResult(operationResult);
-          }
-        });
-      }
-      $("#cluster_container .accept_drop").removeClass("accept_drop");
-      $("#cluster_container .accept_drop").removeClass("accept_drop_warning");
-    });
+    var moveOperation = function() {
+      showLoader();
+      getData(apiUrl, function(operationResult) {
+        hideLoader();
+        if (operationResult.Code == "ERROR") {
+          addAlert(operationResult.Message)
+        } else {
+          reloadWithOperationResult(operationResult);
+        }
+      });
+    }
+    if (isSilentUI()) {
+      moveOperation()
+    } else {
+      bootbox.confirm(anonymizeIfNeedBe(message), function(confirm) {
+        if (confirm) {
+          moveOperation();
+        }
+      });
+    }
+    $("#cluster_container .accept_drop").removeClass("accept_drop");
+    $("#cluster_container .accept_drop").removeClass("accept_drop_warning");
     return false;
   }
 
@@ -1305,8 +1312,9 @@ function Cluster() {
         glyph.addClass("text-muted");
         glyph.attr("title", "Color by data center");
       }
-    } {
-      // Compact display
+    }
+    // Compact display
+    {
       var anchor = $("#cluster_sidebar [data-bullet=compact-display] a");
       var glyph = $(anchor).find(".glyphicon")
       if (isCompactDisplay()) {
@@ -1337,6 +1345,17 @@ function Cluster() {
       } else {
         glyph.addClass("text-muted");
         glyph.attr("title", "Anonymize display");
+      }
+    }
+    // Silent UI
+    {
+      var glyph = $("#cluster_sidebar [data-bullet=silent-ui] .glyphicon");
+      if (isSilentUI()) {
+        glyph.addClass("text-info");
+        glyph.attr("title", "Cancel UI silence");
+      } else {
+        glyph.addClass("text-muted");
+        glyph.attr("title", "Silence UI questions");
       }
     }
   }
@@ -1663,6 +1682,21 @@ function Cluster() {
         });
       } else {
         $.cookie("compact-display", "true", {
+          path: '/',
+          expires: 1
+        });
+      }
+      location.reload();
+      return
+    });
+    $("body").on("click", "a[data-command=silent-ui]", function(event) {
+      if ($.cookie("silent-ui") == "true") {
+        $.cookie("silent-ui", "false", {
+          path: '/',
+          expires: 1
+        });
+      } else {
+        $.cookie("silent-ui", "true", {
           path: '/',
           expires: 1
         });

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -82,6 +82,10 @@ function isAnonymized() {
   return ($.cookie("anonymize") == "true");
 }
 
+function isSilentUI() {
+  return ($.cookie("silent-ui") == "true");
+}
+
 function isCompactDisplay() {
   return ($.cookie("compact-display") == "true");
 }

--- a/resources/templates/cluster.tmpl
+++ b/resources/templates/cluster.tmpl
@@ -27,6 +27,11 @@
 						<a data-command="anonymize"><span class="glyphicon glyphicon-user"></span></a>
 					</div>
 				</li>
+				<li data-bullet="silent-ui">
+					<div>
+						<a data-command="silent-ui"><span class="glyphicon glyphicon-volume-off"></span></a>
+					</div>
+				</li>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
Today, drag-n-drop operations on the web interface require a confirmation via a pop up dialog.

With this PR, it is possible to disable these dialogs and just let the user drag-n-drop. Enabling/disabling is done by clicking a "mute" icon on the left sidebar. On/off status is stored in session cookie.

Note that orchestrator will of course still validate that the operation is valid, in the first place.
