### PR TITLE
Use raft advertise

### DIFF
--- a/docs/configuration-raft.md
+++ b/docs/configuration-raft.md
@@ -47,6 +47,8 @@ as well as this:
   ],
 ```
 
+If your orchestrator/raft nodes need to communicate via NAT gateways, you can additionally set "RaftAdvertise" to IP or hostname which other nodes should contact. Otherwise other nodes would try to talk to the "RaftBind" address and fail.
+
 ### Backend DB
 
 A `raft` setup supports either `MySQL` or `SQLite` backend DB. See [backend](configuration-backend.md) configuration for either. Read [high-availability](high-availability.md) page for scenarios, possibilities and reasons to using either.

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -97,6 +97,7 @@ type Configuration struct {
 	PanicIfDifferentDatabaseDeploy             bool   // When true, and this process finds the orchestrator backend DB was provisioned by a different version, panic
 	RaftEnabled                                bool   // When true, setup orchestrator in a raft consensus layout. When false (default) all Raft* variables are ignored
 	RaftBind                                   string
+	RaftAdvertise                              string
 	RaftDataDir                                string
 	DefaultRaftPort                            int      // if a RaftNodes entry does not specify port, use this one
 	RaftNodes                                  []string // Raft nodes to make initial connection with
@@ -265,6 +266,7 @@ func newConfiguration() *Configuration {
 		SkipOrchestratorDatabaseUpdate:             false,
 		PanicIfDifferentDatabaseDeploy:             false,
 		RaftBind:                                   "127.0.0.1:10008",
+		RaftAdvertise:                              "",
 		RaftDataDir:                                "",
 		DefaultRaftPort:                            10008,
 		RaftNodes:                                  []string{},

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -507,6 +507,9 @@ func (this *Configuration) postReadAdjustments() error {
 	if this.RemoteSSHForMasterFailover && this.RemoteSSHCommand == "" {
 		return fmt.Errorf("RemoteSSHCommand is required when RemoteSSHForMasterFailover is set")
 	}
+	if this.RaftAdvertise == "" {
+		this.RaftAdvertise = this.RaftBind
+	}
 	return nil
 }
 

--- a/go/raft/raft.go
+++ b/go/raft/raft.go
@@ -60,7 +60,11 @@ func Setup(applier CommandApplier, thisHostname string) error {
 	if err != nil {
 		return err
 	}
-	store = NewStore(config.Config.RaftDataDir, raftBind, applier)
+	raftAdvertise, err := normalizeRaftNode(config.Config.RaftAdvertise)
+	if err != nil {
+		return err
+	}
+	store = NewStore(config.Config.RaftDataDir, raftBind, raftAdvertise, applier)
 	peerNodes := []string{}
 	for _, raftNode := range config.Config.RaftNodes {
 		peerNode, err := normalizeRaftNode(raftNode)

--- a/go/raft/store.go
+++ b/go/raft/store.go
@@ -54,12 +54,12 @@ func (store *Store) Open(peerNodes []string) error {
 	config.SnapshotInterval = snapshotInterval
 
 	// Setup Raft communication.
-	advertise, err = net.ResolveTCPAddr("tcp", store.raftAdvertise)
+	advertise, err := net.ResolveTCPAddr("tcp", store.raftAdvertise)
 	if err != nil {
 		return err
 	}
-
 	log.Debugf("raft: advertise=%+v", advertise)
+
 	transport, err := raft.NewTCPTransport(store.raftBind, advertise, 3, 10*time.Second, os.Stderr)
 	if err != nil {
 		return err

--- a/go/raft/store.go
+++ b/go/raft/store.go
@@ -20,8 +20,9 @@ const (
 )
 
 type Store struct {
-	raftDir  string
-	raftBind string
+	raftDir       string
+	raftBind      string
+	raftAdvertise string
 
 	raft      *raft.Raft // The consensus mechanism
 	peerStore raft.PeerStore
@@ -35,11 +36,12 @@ type storeCommand struct {
 }
 
 // NewStore inits and returns a new store
-func NewStore(raftDir string, raftBind string, applier CommandApplier) *Store {
+func NewStore(raftDir string, raftBind string, raftAdvertise string, applier CommandApplier) *Store {
 	return &Store{
-		raftDir:  raftDir,
-		raftBind: raftBind,
-		applier:  applier,
+		raftDir:       raftDir,
+		raftBind:      raftBind,
+		raftAdvertise: raftAdvertise,
+		applier:       applier,
 	}
 }
 
@@ -50,14 +52,22 @@ func (store *Store) Open(peerNodes []string) error {
 	config := raft.DefaultConfig()
 	config.SnapshotThreshold = 1
 	config.SnapshotInterval = snapshotInterval
+	var advertise net.Addr
+	var err error
 
 	// Setup Raft communication.
-	addr, err := net.ResolveTCPAddr("tcp", store.raftBind)
+	if store.raftAdvertise != "" {
+		advertise, err = net.ResolveTCPAddr("tcp", store.raftAdvertise)
+	} else {
+		advertise, err = net.ResolveTCPAddr("tcp", store.raftBind)
+	}
+
 	if err != nil {
 		return err
 	}
-	log.Debugf("raft: addr=%+v", addr)
-	transport, err := raft.NewTCPTransport(store.raftBind, addr, 3, 10*time.Second, os.Stderr)
+
+	log.Debugf("raft: advertise=%+v", advertise)
+	transport, err := raft.NewTCPTransport(store.raftBind, advertise, 3, 10*time.Second, os.Stderr)
 	if err != nil {
 		return err
 	}

--- a/go/raft/store.go
+++ b/go/raft/store.go
@@ -52,16 +52,9 @@ func (store *Store) Open(peerNodes []string) error {
 	config := raft.DefaultConfig()
 	config.SnapshotThreshold = 1
 	config.SnapshotInterval = snapshotInterval
-	var advertise net.Addr
-	var err error
 
 	// Setup Raft communication.
-	if store.raftAdvertise != "" {
-		advertise, err = net.ResolveTCPAddr("tcp", store.raftAdvertise)
-	} else {
-		advertise, err = net.ResolveTCPAddr("tcp", store.raftBind)
-	}
-
+	advertise, err = net.ResolveTCPAddr("tcp", store.raftAdvertise)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Related issue: https://github.com/github/orchestrator/issues/312

### Description

This PR adds possibility to set `RaftAdvertise` in orchestrator config, and if set, uses that when setting up Raft communications.

Previously orchestrator would always set the `advertise` address to whatever RaftBind was set to, which fails if nodes need to communicate via NAT gateways.

If RaftAdvertise is not set, RaftBind is used which is same behavior as before this change.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`

