### PR TITLE
rename commands start/stop/restart/reset slave->replica

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -68,6 +68,11 @@ var apiSynonyms = map[string]string{
 	"reattach-slave":             "reattach-replica",
 	"reattach-slave-master-host": "reattach-replica-master-host",
 	"cluster-osc-slaves":         "cluster-osc-replicas",
+	"start-slave":                "start-replica",
+	"restart-slave":              "restart-replica",
+	"stop-slave":                 "stop-replica",
+	"stop-slave-nice":            "stop-replica-nice",
+	"reset-slave":                "reset-replica",
 }
 
 var registeredPaths = []string{}

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -613,11 +613,11 @@ function run_command() {
     "register-hostname-unresolve") register_hostname_unresolve ;;     # Assigns the given instance a virtual (aka "unresolved") name
     "deregister-hostname-unresolve") deregister_hostname_unresolve ;; # Explicitly deregister/dosassociate a hostname with an "unresolved" name
 
-    "stop-slave") general_instance_command ;;                   # Issue a STOP SLAVE on an instance
-    "stop-slave-nice") general_instance_command ;;              # Issue a STOP SLAVE on an instance, make effort to stop such that SQL thread is in sync with IO thread (ie all relay logs consumed)
-    "start-slave") general_instance_command ;;                  # Issue a START SLAVE on an instance
-    "restart-slave") general_instance_command ;;                # Issue STOP and START SLAVE on an instance
-    "reset-slave") general_instance_command ;;                  # Issues a RESET SLAVE command; use with care
+    "stop-replica") general_instance_command ;;                 # Issue a STOP SLAVE on an instance
+    "stop-replica-nice") general_instance_command ;;            # Issue a STOP SLAVE on an instance, make effort to stop such that SQL thread is in sync with IO thread (ie all relay logs consumed)
+    "start-replica") general_instance_command ;;                # Issue a START SLAVE on an instance
+    "restart-replica") general_instance_command ;;              # Issue STOP and START SLAVE on an instance
+    "reset-replica") general_instance_command ;;                # Issues a RESET SLAVE command; use with care
     "detach-replica") general_instance_command ;;               # Stops replication and modifies binlog position into an impossible yet reversible value.
     "reattach-replica") general_instance_command ;;             # Undo a detach-replica operation
     "detach-replica-master-host") general_instance_command ;;   # Stops replication and modifies Master_Host into an impossible yet reversible value.


### PR DESCRIPTION
`orchestrator-client` will support both `start-slave` and `start-replica` ; same for `stop-`, `stop-nice-`, `restart-`, `reset-`.