### PR TITLE
SQLite for raft log store

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -39,7 +39,7 @@ const (
 var configurationLoaded chan bool = make(chan bool)
 
 const (
-	DiscoveryPollSeconds                         = 1
+	HealthPollSeconds                            = 1
 	ActiveNodeExpireSeconds                      = 5
 	BinlogFileHistoryDays                        = 1
 	MaintenanceOwner                             = "orchestrator"

--- a/go/db/db.go
+++ b/go/db/db.go
@@ -115,10 +115,18 @@ func openOrchestratorMySQLGeneric() (db *sql.DB, fromCache bool, err error) {
 	return sqlutils.GetDB(uri)
 }
 
+func IsSQLite() bool {
+	return config.Config.IsSQLite()
+}
+
+func isInMemorySQLite() bool {
+	return config.Config.IsSQLite() && strings.Contains(config.Config.SQLite3DataFile, ":memory:")
+}
+
 // OpenTopology returns the DB instance for the orchestrator backed database
 func OpenOrchestrator() (db *sql.DB, err error) {
 	var fromCache bool
-	if config.Config.IsSQLite() {
+	if IsSQLite() {
 		db, fromCache, err = sqlutils.GetSQLiteDB(config.Config.SQLite3DataFile)
 		if err == nil && !fromCache {
 			log.Debugf("Connected to orchestrator backend: sqlite on %v", config.Config.SQLite3DataFile)
@@ -173,7 +181,7 @@ func OpenOrchestrator() (db *sql.DB, err error) {
 }
 
 func translateStatement(statement string) (string, error) {
-	if config.Config.IsSQLite() {
+	if IsSQLite() {
 		statement = sqlutils.ToSqlite3Dialect(statement)
 	}
 	return statement, nil
@@ -291,7 +299,7 @@ func initOrchestratorDB(db *sql.DB) error {
 	deployStatements(db, generateSQLPatches)
 	registerOrchestratorDeployment(db)
 
-	if config.Config.IsSQLite() {
+	if IsSQLite() {
 		ExecOrchestrator(`PRAGMA journal_mode = WAL`)
 		ExecOrchestrator(`PRAGMA synchronous = NORMAL`)
 	}

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -290,7 +290,7 @@ func onHealthTick() {
 			atomic.StoreInt64(&isElectedNode, 0)
 		}
 		if process.SinceLastGoodHealthCheck() > yieldAfterUnhealthyDuration {
-			log.Errorf("Unhealthy! raft yielding")
+			log.Errorf("Heath test is failing for over %+v seconds. raft yielding", yieldAfterUnhealthyDuration.Seconds())
 			orcraft.Yield()
 		}
 		if process.SinceLastGoodHealthCheck() > fatalAfterUnhealthyDuration {

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -362,7 +362,7 @@ func publishDiscoverMasters() error {
 // periodically investigated and their status captured, and long since unseen instances are
 // purged and forgotten.
 func ContinuousDiscovery() {
-	log.Infof("Starting continuous discovery")
+	log.Infof("continuous discovery: setting up")
 	continuousDiscoveryStartTime := time.Now()
 	checkAndRecoverWaitPeriod := 3 * instancePollSecondsDuration()
 	recentDiscoveryOperationKeys = cache.New(instancePollSecondsDuration(), time.Second)
@@ -394,6 +394,8 @@ func ContinuousDiscovery() {
 	if *config.RuntimeCLIFlags.GrabElection {
 		process.GrabElection()
 	}
+
+	log.Infof("continuous discovery: starting")
 	for {
 		select {
 		case <-discoveryTick:

--- a/go/raft/file_snapshot.go
+++ b/go/raft/file_snapshot.go
@@ -1,0 +1,501 @@
+package orcraft
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"hash/crc64"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/raft"
+)
+
+const (
+	testPath      = "permTest"
+	snapPath      = "snapshots"
+	metaFilePath  = "meta.json"
+	stateFilePath = "state.bin"
+	tmpSuffix     = ".tmp"
+)
+
+// FileSnapshotStore implements the SnapshotStore interface and allows
+// snapshots to be made on the local disk.
+type FileSnapshotStore struct {
+	path   string
+	retain int
+	logger *log.Logger
+}
+
+type snapMetaSlice []*fileSnapshotMeta
+
+// FileSnapshotSink implements SnapshotSink with a file.
+type FileSnapshotSink struct {
+	store  *FileSnapshotStore
+	logger *log.Logger
+	dir    string
+	meta   fileSnapshotMeta
+
+	stateFile *os.File
+	stateHash hash.Hash64
+	buffered  *bufio.Writer
+
+	closed bool
+}
+
+// fileSnapshotMeta is stored on disk. We also put a CRC
+// on disk so that we can verify the snapshot.
+type fileSnapshotMeta struct {
+	raft.SnapshotMeta
+	CRC []byte
+}
+
+// bufferedFile is returned when we open a snapshot. This way
+// reads are buffered and the file still gets closed.
+type bufferedFile struct {
+	bh *bufio.Reader
+	fh *os.File
+}
+
+func (b *bufferedFile) Read(p []byte) (n int, err error) {
+	return b.bh.Read(p)
+}
+
+func (b *bufferedFile) Close() error {
+	return b.fh.Close()
+}
+
+// NewFileSnapshotStoreWithLogger creates a new FileSnapshotStore based
+// on a base directory. The `retain` parameter controls how many
+// snapshots are retained. Must be at least 1.
+func NewFileSnapshotStoreWithLogger(base string, retain int, logger *log.Logger) (*FileSnapshotStore, error) {
+	if retain < 1 {
+		return nil, fmt.Errorf("must retain at least one snapshot")
+	}
+	if logger == nil {
+		logger = log.New(os.Stderr, "", log.LstdFlags)
+	}
+
+	// Ensure our path exists
+	path := filepath.Join(base, snapPath)
+	if err := os.MkdirAll(path, 0755); err != nil && !os.IsExist(err) {
+		return nil, fmt.Errorf("snapshot path not accessible: %v", err)
+	}
+
+	// Setup the store
+	store := &FileSnapshotStore{
+		path:   path,
+		retain: retain,
+		logger: logger,
+	}
+
+	// Do a permissions test
+	if err := store.testPermissions(); err != nil {
+		return nil, fmt.Errorf("permissions test failed: %v", err)
+	}
+	return store, nil
+}
+
+// NewFileSnapshotStore creates a new FileSnapshotStore based
+// on a base directory. The `retain` parameter controls how many
+// snapshots are retained. Must be at least 1.
+func NewFileSnapshotStore(base string, retain int, logOutput io.Writer) (*FileSnapshotStore, error) {
+	if logOutput == nil {
+		logOutput = os.Stderr
+	}
+	return NewFileSnapshotStoreWithLogger(base, retain, log.New(logOutput, "", log.LstdFlags))
+}
+
+// testPermissions tries to touch a file in our path to see if it works.
+func (f *FileSnapshotStore) testPermissions() error {
+	path := filepath.Join(f.path, testPath)
+	fh, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	if err = fh.Close(); err != nil {
+		return err
+	}
+
+	if err = os.Remove(path); err != nil {
+		return err
+	}
+	return nil
+}
+
+// snapshotName generates a name for the snapshot.
+func snapshotName(term, index uint64) string {
+	now := time.Now()
+	msec := now.UnixNano() / int64(time.Millisecond)
+	return fmt.Sprintf("%d-%d-%d", term, index, msec)
+}
+
+// Create is used to start a new snapshot
+func (f *FileSnapshotStore) Create(index, term uint64, peers []byte) (raft.SnapshotSink, error) {
+	// Create a new path
+	name := snapshotName(term, index)
+	path := filepath.Join(f.path, name+tmpSuffix)
+	f.logger.Printf("[INFO] snapshot: Creating new snapshot at %s", path)
+
+	// Make the directory
+	if err := os.MkdirAll(path, 0755); err != nil {
+		f.logger.Printf("[ERR] snapshot: Failed to make snapshot directory: %v", err)
+		return nil, err
+	}
+
+	// Create the sink
+	sink := &FileSnapshotSink{
+		store:  f,
+		logger: f.logger,
+		dir:    path,
+		meta: fileSnapshotMeta{
+			SnapshotMeta: raft.SnapshotMeta{
+				ID:    name,
+				Index: index,
+				Term:  term,
+				Peers: peers,
+			},
+			CRC: nil,
+		},
+	}
+
+	// Write out the meta data
+	if err := sink.writeMeta(); err != nil {
+		f.logger.Printf("[ERR] snapshot: Failed to write metadata: %v", err)
+		return nil, err
+	}
+
+	// Open the state file
+	statePath := filepath.Join(path, stateFilePath)
+	fh, err := os.Create(statePath)
+	if err != nil {
+		f.logger.Printf("[ERR] snapshot: Failed to create state file: %v", err)
+		return nil, err
+	}
+	sink.stateFile = fh
+
+	// Create a CRC64 hash
+	sink.stateHash = crc64.New(crc64.MakeTable(crc64.ECMA))
+
+	// Wrap both the hash and file in a MultiWriter with buffering
+	multi := io.MultiWriter(sink.stateFile, sink.stateHash)
+	sink.buffered = bufio.NewWriter(multi)
+
+	// Done
+	return sink, nil
+}
+
+// List returns available snapshots in the store.
+func (f *FileSnapshotStore) List() ([]*raft.SnapshotMeta, error) {
+	// Get the eligible snapshots
+	snapshots, err := f.getSnapshots()
+	if err != nil {
+		f.logger.Printf("[ERR] snapshot: Failed to get snapshots: %v", err)
+		return nil, err
+	}
+
+	var snapMeta []*raft.SnapshotMeta
+	for _, meta := range snapshots {
+		snapMeta = append(snapMeta, &meta.SnapshotMeta)
+		if len(snapMeta) == f.retain {
+			break
+		}
+	}
+	return snapMeta, nil
+}
+
+// getSnapshots returns all the known snapshots.
+func (f *FileSnapshotStore) getSnapshots() ([]*fileSnapshotMeta, error) {
+	// Get the eligible snapshots
+	snapshots, err := ioutil.ReadDir(f.path)
+	if err != nil {
+		f.logger.Printf("[ERR] snapshot: Failed to scan snapshot dir: %v", err)
+		return nil, err
+	}
+
+	// Populate the metadata
+	var snapMeta []*fileSnapshotMeta
+	for _, snap := range snapshots {
+		// Ignore any files
+		if !snap.IsDir() {
+			continue
+		}
+
+		// Ignore any temporary snapshots
+		dirName := snap.Name()
+		if strings.HasSuffix(dirName, tmpSuffix) {
+			f.logger.Printf("[WARN] snapshot: Found temporary snapshot: %v", dirName)
+			continue
+		}
+
+		// Try to read the meta data
+		meta, err := f.readMeta(dirName)
+		if err != nil {
+			f.logger.Printf("[WARN] snapshot: Failed to read metadata for %v: %v", dirName, err)
+			continue
+		}
+
+		// Append, but only return up to the retain count
+		snapMeta = append(snapMeta, meta)
+	}
+
+	// Sort the snapshot, reverse so we get new -> old
+	sort.Sort(sort.Reverse(snapMetaSlice(snapMeta)))
+
+	return snapMeta, nil
+}
+
+// readMeta is used to read the meta data for a given named backup
+func (f *FileSnapshotStore) readMeta(name string) (*fileSnapshotMeta, error) {
+	// Open the meta file
+	metaPath := filepath.Join(f.path, name, metaFilePath)
+	fh, err := os.Open(metaPath)
+	if err != nil {
+		return nil, err
+	}
+	defer fh.Close()
+
+	// Buffer the file IO
+	buffered := bufio.NewReader(fh)
+
+	// Read in the JSON
+	meta := &fileSnapshotMeta{}
+	dec := json.NewDecoder(buffered)
+	if err := dec.Decode(meta); err != nil {
+		return nil, err
+	}
+	return meta, nil
+}
+
+// Open takes a snapshot ID and returns a ReadCloser for that snapshot.
+func (f *FileSnapshotStore) Open(id string) (*raft.SnapshotMeta, io.ReadCloser, error) {
+	// Get the metadata
+	meta, err := f.readMeta(id)
+	if err != nil {
+		f.logger.Printf("[ERR] snapshot: Failed to get meta data to open snapshot: %v", err)
+		return nil, nil, err
+	}
+
+	// Open the state file
+	statePath := filepath.Join(f.path, id, stateFilePath)
+	fh, err := os.Open(statePath)
+	if err != nil {
+		f.logger.Printf("[ERR] snapshot: Failed to open state file: %v", err)
+		return nil, nil, err
+	}
+
+	// Create a CRC64 hash
+	stateHash := crc64.New(crc64.MakeTable(crc64.ECMA))
+
+	// Compute the hash
+	_, err = io.Copy(stateHash, fh)
+	if err != nil {
+		f.logger.Printf("[ERR] snapshot: Failed to read state file: %v", err)
+		fh.Close()
+		return nil, nil, err
+	}
+
+	// Verify the hash
+	computed := stateHash.Sum(nil)
+	if bytes.Compare(meta.CRC, computed) != 0 {
+		f.logger.Printf("[ERR] snapshot: CRC checksum failed (stored: %v computed: %v)",
+			meta.CRC, computed)
+		fh.Close()
+		return nil, nil, fmt.Errorf("CRC mismatch")
+	}
+
+	// Seek to the start
+	if _, err := fh.Seek(0, 0); err != nil {
+		f.logger.Printf("[ERR] snapshot: State file seek failed: %v", err)
+		fh.Close()
+		return nil, nil, err
+	}
+
+	// Return a buffered file
+	buffered := &bufferedFile{
+		bh: bufio.NewReader(fh),
+		fh: fh,
+	}
+
+	return &meta.SnapshotMeta, buffered, nil
+}
+
+// ReapSnapshots reaps any snapshots beyond the retain count.
+func (f *FileSnapshotStore) ReapSnapshots(currentSnapshotMeta *fileSnapshotMeta) error {
+
+	reapSnapshot := func(snapshot *fileSnapshotMeta) error {
+		path := filepath.Join(f.path, snapshot.ID)
+		f.logger.Printf("[INFO] snapshot: reaping snapshot %v", path)
+		if err := os.RemoveAll(path); err != nil {
+			f.logger.Printf("[ERR] snapshot: Failed to reap snapshot %v: %v", path, err)
+			return err
+		}
+		return nil
+	}
+	snapshots, err := f.getSnapshots()
+	if err != nil {
+		f.logger.Printf("[ERR] snapshot: Failed to get snapshots: %v", err)
+		return err
+	}
+
+	fmt.Println("..........checking whether we need to reap snapshots greater than ", currentSnapshotMeta.Term, " and ", currentSnapshotMeta.Index)
+	for _, snapshot := range snapshots {
+		fmt.Println("..... looking at snapshot with term ", snapshot.Term, " and ", snapshot.Index)
+		if snapshot.Term > currentSnapshotMeta.Term ||
+			snapshot.Term == currentSnapshotMeta.Term && snapshot.Index > currentSnapshotMeta.Index {
+			fmt.Println("..... YEP! reapign it")
+			reapSnapshot(snapshot)
+		}
+	}
+
+	snapshots, err = f.getSnapshots()
+	if err != nil {
+		f.logger.Printf("[ERR] snapshot: Failed to get snapshots: %v", err)
+		return err
+	}
+	for i := f.retain; i < len(snapshots); i++ {
+		reapSnapshot(snapshots[i])
+	}
+	return nil
+}
+
+// ID returns the ID of the snapshot, can be used with Open()
+// after the snapshot is finalized.
+func (s *FileSnapshotSink) ID() string {
+	return s.meta.ID
+}
+
+// Write is used to append to the state file. We write to the
+// buffered IO object to reduce the amount of context switches.
+func (s *FileSnapshotSink) Write(b []byte) (int, error) {
+	return s.buffered.Write(b)
+}
+
+// Close is used to indicate a successful end.
+func (s *FileSnapshotSink) Close() error {
+	// Make sure close is idempotent
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+
+	// Close the open handles
+	if err := s.finalize(); err != nil {
+		s.logger.Printf("[ERR] snapshot: Failed to finalize snapshot: %v", err)
+		return err
+	}
+
+	// Write out the meta data
+	if err := s.writeMeta(); err != nil {
+		s.logger.Printf("[ERR] snapshot: Failed to write metadata: %v", err)
+		return err
+	}
+
+	// Move the directory into place
+	newPath := strings.TrimSuffix(s.dir, tmpSuffix)
+	if err := os.Rename(s.dir, newPath); err != nil {
+		s.logger.Printf("[ERR] snapshot: Failed to move snapshot into place: %v", err)
+		return err
+	}
+
+	// Reap any old snapshots
+	if err := s.store.ReapSnapshots(&s.meta); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Cancel is used to indicate an unsuccessful end.
+func (s *FileSnapshotSink) Cancel() error {
+	// Make sure close is idempotent
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+
+	// Close the open handles
+	if err := s.finalize(); err != nil {
+		s.logger.Printf("[ERR] snapshot: Failed to finalize snapshot: %v", err)
+		return err
+	}
+
+	// Attempt to remove all artifacts
+	return os.RemoveAll(s.dir)
+}
+
+// finalize is used to close all of our resources.
+func (s *FileSnapshotSink) finalize() error {
+	// Flush any remaining data
+	if err := s.buffered.Flush(); err != nil {
+		return err
+	}
+
+	// Get the file size
+	stat, statErr := s.stateFile.Stat()
+
+	// Close the file
+	if err := s.stateFile.Close(); err != nil {
+		return err
+	}
+
+	// Set the file size, check after we close
+	if statErr != nil {
+		return statErr
+	}
+	s.meta.Size = stat.Size()
+
+	// Set the CRC
+	s.meta.CRC = s.stateHash.Sum(nil)
+	return nil
+}
+
+// writeMeta is used to write out the metadata we have.
+func (s *FileSnapshotSink) writeMeta() error {
+	// Open the meta file
+	metaPath := filepath.Join(s.dir, metaFilePath)
+	fh, err := os.Create(metaPath)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	// Buffer the file IO
+	buffered := bufio.NewWriter(fh)
+	defer buffered.Flush()
+
+	// Write out as JSON
+	enc := json.NewEncoder(buffered)
+	if err := enc.Encode(&s.meta); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Implement the sort interface for []*fileSnapshotMeta.
+func (s snapMetaSlice) Len() int {
+	return len(s)
+}
+
+func (s snapMetaSlice) Less(i, j int) bool {
+	if s[i].Term != s[j].Term {
+		return s[i].Term < s[j].Term
+	}
+	if s[i].Index != s[j].Index {
+		return s[i].Index < s[j].Index
+	}
+	return s[i].ID < s[j].ID
+}
+
+func (s snapMetaSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/go/raft/fsm.go
+++ b/go/raft/fsm.go
@@ -62,7 +62,7 @@ func (f *fsm) yield(toPeer string) interface{} {
 		return nil
 	}
 	log.Debugf("Yielding to %s", toPeer)
-	return yield()
+	return Yield()
 }
 
 // yieldByHint yields to a host that contains given hint
@@ -77,7 +77,7 @@ func (f *fsm) yieldByHint(hint string) interface{} {
 		return nil
 	}
 	log.Debugf("Yielding to hinted %s", hint)
-	return yield()
+	return Yield()
 }
 
 // Snapshot returns a snapshot object of freno's state

--- a/go/raft/fsm.go
+++ b/go/raft/fsm.go
@@ -31,11 +31,6 @@ type fsm Store
 
 // Apply applies a Raft log entry to the key-value store.
 func (f *fsm) Apply(l *raft.Log) interface{} {
-	if l.Index <= lastIndexOnStartup {
-		log.Debugf("orchestrator/raft: fsm will not apply index %+v: it is already found in log store", l.Index)
-		return nil
-	}
-
 	var c storeCommand
 	if err := json.Unmarshal(l.Data, &c); err != nil {
 		log.Errorf("failed to unmarshal command: %s", err.Error())
@@ -93,10 +88,6 @@ func (f *fsm) Snapshot() (raft.FSMSnapshot, error) {
 
 // Restore restores freno state
 func (f *fsm) Restore(rc io.ReadCloser) error {
-	if !isRaftSetupComplete() {
-		log.Debugf("orchestrator/raft: nooping snapshot restore")
-		return nil
-	}
 	defer rc.Close()
 
 	return f.snapshotCreatorApplier.Restore(rc)

--- a/go/raft/raft.go
+++ b/go/raft/raft.go
@@ -176,7 +176,7 @@ func StepDown() {
 	getRaft().StepDown()
 }
 
-func yield() error {
+func Yield() error {
 	if !IsRaftEnabled() {
 		return RaftNotRunning
 	}

--- a/go/raft/raft.go
+++ b/go/raft/raft.go
@@ -38,7 +38,6 @@ const (
 var RaftNotRunning = fmt.Errorf("raft is not configured/running")
 var store *Store
 var raftSetupComplete int64
-var lastIndexOnStartup uint64
 var ThisHostname string
 
 var fatalRaftErrorChan = make(chan error)

--- a/go/raft/rel_store.go
+++ b/go/raft/rel_store.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/openark/golib/log"
 	"github.com/openark/golib/sqlutils"
 
 	"github.com/hashicorp/raft"
@@ -86,6 +87,7 @@ func (relStore *RelationalStore) openDB() (*sql.DB, error) {
 			}
 		}
 		relStore.backend = sqliteDB
+		log.Infof("raft: store initialized at %+v", relStoreFile)
 	}
 	return relStore.backend, nil
 }

--- a/go/raft/rel_store.go
+++ b/go/raft/rel_store.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/github/orchestrator/go/config"
 	"github.com/openark/golib/sqlutils"
 
 	"github.com/hashicorp/raft"
@@ -59,11 +58,14 @@ var dbMutex sync.Mutex
 // - hashicorp/raft.StableStore
 // - hashicorp/log.LogStore
 type RelationalStore struct {
+	dataDir string
 	backend *sql.DB
 }
 
-func NewRelationalStore() *RelationalStore {
-	return &RelationalStore{}
+func NewRelationalStore(dataDir string) *RelationalStore {
+	return &RelationalStore{
+		dataDir: dataDir,
+	}
 }
 
 func (relStore *RelationalStore) openDB() (*sql.DB, error) {
@@ -71,7 +73,7 @@ func (relStore *RelationalStore) openDB() (*sql.DB, error) {
 	defer dbMutex.Unlock()
 
 	if relStore.backend == nil {
-		relStoreFile := filepath.Join(config.Config.RaftDataDir, raftStoreFile)
+		relStoreFile := filepath.Join(relStore.dataDir, raftStoreFile)
 		sqliteDB, _, err := sqlutils.GetSQLiteDB(relStoreFile)
 		if err != nil {
 			return nil, err

--- a/go/raft/rel_store.go
+++ b/go/raft/rel_store.go
@@ -19,24 +19,77 @@ package orcraft
 import (
 	"database/sql"
 	"encoding/binary"
+	"path/filepath"
+	"sync"
 
-	"github.com/github/orchestrator/go/db"
+	"github.com/github/orchestrator/go/config"
+	"github.com/openark/golib/sqlutils"
 
 	"github.com/hashicorp/raft"
 )
+
+const raftStoreFile = "raft_store.db"
+
+var createQueries = []string{
+	`
+		CREATE TABLE IF NOT EXISTS raft_log (
+			log_index integer,
+			term bigint not null,
+			log_type int not null,
+			data blob not null,
+			PRIMARY KEY (log_index)
+		)
+	`,
+	`
+		CREATE TABLE IF NOT EXISTS raft_store (
+			store_id integer,
+			store_key varbinary(512) not null,
+			store_value blob not null,
+			PRIMARY KEY (store_id)
+		)
+	`,
+	`
+		CREATE INDEX IF NOT EXISTS store_key_idx_raft_store ON raft_store (store_key)
+	`,
+}
+
+var dbMutex sync.Mutex
 
 // RelationalStoreimplements:
 // - hashicorp/raft.StableStore
 // - hashicorp/log.LogStore
 type RelationalStore struct {
+	backend *sql.DB
 }
 
 func NewRelationalStore() *RelationalStore {
 	return &RelationalStore{}
 }
 
+func (relStore *RelationalStore) openDB() (*sql.DB, error) {
+	dbMutex.Lock()
+	defer dbMutex.Unlock()
+
+	if relStore.backend == nil {
+		relStoreFile := filepath.Join(config.Config.RaftDataDir, raftStoreFile)
+		sqliteDB, _, err := sqlutils.GetSQLiteDB(relStoreFile)
+		if err != nil {
+			return nil, err
+		}
+		sqliteDB.SetMaxOpenConns(1)
+		sqliteDB.SetMaxIdleConns(1)
+		for _, query := range createQueries {
+			if _, err := sqliteDB.Exec(sqlutils.ToSqlite3Dialect(query)); err != nil {
+				return nil, err
+			}
+		}
+		relStore.backend = sqliteDB
+	}
+	return relStore.backend, nil
+}
+
 func (relStore *RelationalStore) Set(key []byte, val []byte) error {
-	db, err := db.OpenOrchestrator()
+	db, err := relStore.openDB()
 	if err != nil {
 		return err
 	}
@@ -70,7 +123,7 @@ func (relStore *RelationalStore) Set(key []byte, val []byte) error {
 
 // Get returns the value for key, or an empty byte slice if key was not found.
 func (relStore *RelationalStore) Get(key []byte) (val []byte, err error) {
-	db, err := db.OpenOrchestrator()
+	db, err := relStore.openDB()
 	if err != nil {
 		return val, err
 	}
@@ -100,7 +153,7 @@ func (relStore *RelationalStore) GetUint64(key []byte) (uint64, error) {
 }
 
 func (relStore *RelationalStore) FirstIndex() (idx uint64, err error) {
-	db, err := db.OpenOrchestrator()
+	db, err := relStore.openDB()
 	if err != nil {
 		return idx, err
 	}
@@ -110,7 +163,7 @@ func (relStore *RelationalStore) FirstIndex() (idx uint64, err error) {
 
 // LastIndex returns the last index written. 0 for no entries.
 func (relStore *RelationalStore) LastIndex() (idx uint64, err error) {
-	db, err := db.OpenOrchestrator()
+	db, err := relStore.openDB()
 	if err != nil {
 		return idx, err
 	}
@@ -120,7 +173,7 @@ func (relStore *RelationalStore) LastIndex() (idx uint64, err error) {
 
 // GetLog gets a log entry at a given index.
 func (relStore *RelationalStore) GetLog(index uint64, log *raft.Log) error {
-	db, err := db.OpenOrchestrator()
+	db, err := relStore.openDB()
 	if err != nil {
 		return err
 	}
@@ -142,7 +195,7 @@ func (relStore *RelationalStore) StoreLog(log *raft.Log) error {
 
 // StoreLogs stores multiple log entries.
 func (relStore *RelationalStore) StoreLogs(logs []*raft.Log) error {
-	db, err := db.OpenOrchestrator()
+	db, err := relStore.openDB()
 	if err != nil {
 		return err
 	}
@@ -171,7 +224,11 @@ func (relStore *RelationalStore) StoreLogs(logs []*raft.Log) error {
 
 // DeleteRange deletes a range of log entries. The range is inclusive.
 func (relStore *RelationalStore) DeleteRange(min, max uint64) error {
-	_, err := db.ExecOrchestrator("delete from raft_log where log_index >= ? and log_index <= ?", min, max)
+	db, err := relStore.openDB()
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("delete from raft_log where log_index >= ? and log_index <= ?", min, max)
 	return err
 }
 

--- a/go/raft/store.go
+++ b/go/raft/store.go
@@ -90,7 +90,7 @@ func (store *Store) Open(peerNodes []string) error {
 	}
 
 	// Create the snapshot store. This allows the Raft to truncate the log.
-	snapshots, err := raft.NewFileSnapshotStore(store.raftDir, retainSnapshotCount, os.Stderr)
+	snapshots, err := NewFileSnapshotStore(store.raftDir, retainSnapshotCount, os.Stderr)
 	if err != nil {
 		return log.Errorf("file snapshot store: %s", err)
 	}

--- a/go/raft/store.go
+++ b/go/raft/store.go
@@ -103,6 +103,7 @@ func (store *Store) Open(peerNodes []string) error {
 	if store.raft, err = raft.NewRaft(config, (*fsm)(store), logStore, logStore, snapshots, peerStore, transport); err != nil {
 		return fmt.Errorf("error creating new raft: %s", err)
 	}
+	store.raft.Yield()
 	store.peerStore = peerStore
 	log.Infof("new raft created")
 

--- a/go/raft/store.go
+++ b/go/raft/store.go
@@ -96,7 +96,7 @@ func (store *Store) Open(peerNodes []string) error {
 	}
 
 	// Create the log store and stable store.
-	logStore := NewRelationalStore()
+	logStore := NewRelationalStore(store.raftDir)
 	log.Debugf("raft: logStore=%+v", logStore)
 
 	// Instantiate the Raft systems.

--- a/go/raft/store.go
+++ b/go/raft/store.go
@@ -99,11 +99,6 @@ func (store *Store) Open(peerNodes []string) error {
 	logStore := NewRelationalStore()
 	log.Debugf("raft: logStore=%+v", logStore)
 
-	if lastIndex, err := logStore.LastIndex(); err == nil {
-		lastIndexOnStartup = lastIndex
-		log.Infof("orchestrator/raft: last index found in database: %+v", lastIndexOnStartup)
-	}
-
 	// Instantiate the Raft systems.
 	if store.raft, err = raft.NewRaft(config, (*fsm)(store), logStore, logStore, snapshots, peerStore, transport); err != nil {
 		return fmt.Errorf("error creating new raft: %s", err)

--- a/vendor/github.com/hashicorp/raft/raft.go
+++ b/vendor/github.com/hashicorp/raft/raft.go
@@ -684,7 +684,7 @@ func (r *Raft) runFollower() {
 					didWarn = true
 				}
 			} else {
-				if atomic.LoadInt64(&r.suspendLeadership) == 1 {
+				if atomic.LoadInt64(&r.suspendLeadership) > 0 {
 					r.logger.Printf(`[WARN] raft: Heartbeat timeout from %q reached, but leadership suspended. Will not enter Candidate mode`, lastLeader)
 					return
 				}
@@ -1946,10 +1946,10 @@ func (r *Raft) StepDown() error {
 // Yield instructs the node to not attempt becoming a leader in the
 // following duration.
 func (r *Raft) Yield() error {
-	atomic.StoreInt64(&r.suspendLeadership, 1)
+	atomic.AddInt64(&r.suspendLeadership, 1)
 	yieldDuration := r.conf.HeartbeatTimeout * 5 // time enough for the yielded-to peer to become leader
 	go time.AfterFunc(yieldDuration, func() {
-		atomic.StoreInt64(&r.suspendLeadership, 0)
+		atomic.AddInt64(&r.suspendLeadership, -1)
 	})
 	if r.getState() == Leader {
 		r.StepDown()


### PR DESCRIPTION
Only affects `orchestrator/raft` setups.

With this PR the `raft` log store is implemented via `SQLite` and external to the backend DB. Whether backend DB is `MySQL` or `SQLite`, `orchestrator` will run an independent `SQLite` to store raft replication log.

The file is `raft_store.db` located under config's `RaftDataDir`.

With this PR the `raft` setup looks more like what `hashicorp/raft` originally intend: an external snapshot system (file based) and an external log store (originally LMDB or `bolt-db`, now re-implemented via `SQLite`).

As result, behavior again aligns more with the intended `hashicorp/raft`:

- Upon service startup, the last known snapshot is loaded and subsequent logs are applied. This is true even though typically our backend DB will have all relevant data anyhow (we do use ACID backend database).
- We do not snapshot all possible tables. A restarted service where the backend DB is stable and intact will load snapshot onto relevant tables, and leave other tables untouched. This should end up with same data once the snapshot & subsequent logs are applied.
- An _empty_ database is perfectly good to go: data will be loaded and it will have enough to go by to participate in the `raft` cluster. However, it will be missing data from tables that are not considered in the snapshot. E.g. `audit`.
- This implies _there is no need for the backend DB to be durable_. Durability is achieved by snapshot + replication log.
- Users may use `SQLite` with `:memory:` storage, which is very fast yet stores _nothing_ on disk.