### PR TITLE
Sparser binlog coordinates history; some cleanup

### DIFF
--- a/go/db/generate_patches.go
+++ b/go/db/generate_patches.go
@@ -486,4 +486,8 @@ var generateSQLPatches = []string{
 		ALTER TABLE node_health
 			ADD COLUMN db_backend varchar(255) CHARACTER SET ascii NOT NULL DEFAULT ""
 	`,
+	`
+		ALTER TABLE node_health
+			ADD COLUMN incrementing_indicator bigint not null default 0
+	`,
 }

--- a/go/inst/candidate_database_instance.go
+++ b/go/inst/candidate_database_instance.go
@@ -42,3 +42,8 @@ func NewCandidateDatabaseInstance(instanceKey *InstanceKey, promotionRule Candid
 func (cdi *CandidateDatabaseInstance) String() string {
 	return fmt.Sprintf("%s:%d %s", cdi.Hostname, cdi.Port, cdi.PromotionRule)
 }
+
+// Key returns an instance key representing this candidate
+func (cdi *CandidateDatabaseInstance) Key() *InstanceKey {
+	return &InstanceKey{Hostname: cdi.Hostname, Port: cdi.Port}
+}

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -2437,6 +2437,7 @@ func RegisterCandidateInstance(candidate *CandidateDatabaseInstance) error {
 			`, lastSuggestedHint)
 	writeFunc := func() error {
 		_, err := db.ExecOrchestrator(query, args...)
+		AuditOperation("register-candidate", candidate.Key(), string(candidate.PromotionRule))
 		return log.Errore(err)
 	}
 	return ExecDBWriteFunc(writeFunc)

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -2519,29 +2519,6 @@ func GetHeuristiclyRecentCoordinatesForInstance(instanceKey *InstanceKey) (selfC
 	return selfCoordinates, relayLogCoordinates, err
 }
 
-// GetLastKnownCoordinatesForInstance returns the very last known coordinates for an instance
-func GetLastKnownCoordinatesForInstance(instanceKey *InstanceKey) (selfCoordinates *BinlogCoordinates, relayLogCoordinates *BinlogCoordinates, err error) {
-	query := `
-		select
-			binary_log_file, binary_log_pos, relay_log_file, relay_log_pos
-		from
-			database_instance_coordinates_history
-		where
-			hostname = ?
-			and port = ?
-		order by
-			recorded_timestamp desc
-			limit 1
-			`
-	err = db.QueryOrchestrator(query, sqlutils.Args(instanceKey.Hostname, instanceKey.Port), func(m sqlutils.RowMap) error {
-		selfCoordinates = &BinlogCoordinates{LogFile: m.GetString("binary_log_file"), LogPos: m.GetInt64("binary_log_pos")}
-		relayLogCoordinates = &BinlogCoordinates{LogFile: m.GetString("relay_log_file"), LogPos: m.GetInt64("relay_log_pos")}
-
-		return nil
-	})
-	return selfCoordinates, relayLogCoordinates, err
-}
-
 // GetPreviousKnownRelayLogCoordinatesForInstance returns known relay log coordinates, that are not the
 // exact current coordinates
 func GetPreviousKnownRelayLogCoordinatesForInstance(instance *Instance) (relayLogCoordinates *BinlogCoordinates, err error) {
@@ -2592,42 +2569,6 @@ func ResetInstanceRelaylogCoordinatesHistory(instanceKey *InstanceKey) error {
 
 func ExpireInstanceBinlogFileHistory() error {
 	return ExpireTableData("database_instance_binlog_files_history", "last_seen")
-}
-
-// RecordInstanceBinlogFileHistory snapshots the binlog coordinates of instances
-func RecordInstanceBinlogFileHistory() error {
-	{
-		writeFunc := func() error {
-			_, err := db.ExecOrchestrator(`
-        	delete from database_instance_binlog_files_history
-			where
-				last_seen < NOW() - INTERVAL ? DAY
-				`, config.BinlogFileHistoryDays,
-			)
-			return log.Errore(err)
-		}
-		ExecDBWriteFunc(writeFunc)
-	}
-	writeFunc := func() error {
-		_, err := db.ExecOrchestrator(`
-      	insert into
-      		database_instance_binlog_files_history (
-					hostname, port,	first_seen, last_seen, binary_log_file, binary_log_pos
-				)
-      	select
-      		hostname, port, last_seen, last_seen, binary_log_file, binary_log_pos
-				from
-					database_instance
-				where
-					binary_log_file != ''
-				on duplicate key update
-					last_seen = VALUES(last_seen),
-					binary_log_pos = VALUES(binary_log_pos)
-				`,
-		)
-		return log.Errore(err)
-	}
-	return ExecDBWriteFunc(writeFunc)
 }
 
 // FigureClusterName will make a best effort to deduce a cluster name using either a given alias

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -2467,7 +2467,7 @@ func RecordInstanceCoordinatesHistory() error {
         	delete from database_instance_coordinates_history
 			where
 				recorded_timestamp < NOW() - INTERVAL ? MINUTE
-				`, (config.PseudoGTIDCoordinatesHistoryHeuristicMinutes + 5),
+				`, (config.PseudoGTIDCoordinatesHistoryHeuristicMinutes + 2),
 			)
 			return log.Errore(err)
 		}

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -416,7 +416,6 @@ func ContinuousDiscovery() {
 				// But rather should invoke such routinely operations that need to be as (or roughly as) frequent
 				// as instance poll
 				if IsLeaderOrActive() {
-					go inst.RecordInstanceCoordinatesHistory()
 					go inst.UpdateClusterAliases()
 					go inst.ExpireDowntime()
 				}
@@ -425,12 +424,14 @@ func ContinuousDiscovery() {
 			// Various periodic internal maintenance tasks
 			go func() {
 				if IsLeaderOrActive() {
+					go inst.RecordInstanceCoordinatesHistory()
+					go inst.ReviewUnseenInstances()
+					go inst.InjectUnseenMasters()
+
 					go inst.ForgetLongUnseenInstances()
 					go inst.ForgetUnseenInstancesDifferentlyResolved()
 					go inst.ForgetExpiredHostnameResolves()
 					go inst.DeleteInvalidHostnameResolves()
-					go inst.ReviewUnseenInstances()
-					go inst.InjectUnseenMasters()
 					go inst.ResolveUnknownMasterHostnameResolves()
 					go inst.ExpireMaintenance()
 					go inst.ExpireCandidateInstances()

--- a/go/process/health.go
+++ b/go/process/health.go
@@ -27,8 +27,6 @@ import (
 	"github.com/openark/golib/log"
 )
 
-const registrationPollSeconds = 5
-
 var lastHealthCheckUnixNano int64
 var lastGoodHealthCheckUnixNano int64
 var LastContinousCheckHealthy int64
@@ -159,7 +157,7 @@ func ContinuousRegistration(extraInfo string, command string) {
 		// First one is synchronous
 		tickOperation()
 		go func() {
-			registrationTick := time.Tick(time.Duration(registrationPollSeconds) * time.Second)
+			registrationTick := time.Tick(config.HealthPollSeconds * time.Second)
 			for range registrationTick {
 				// We already run inside a go-routine so
 				// do not do this asynchronously.  If we

--- a/go/process/health_dao.go
+++ b/go/process/health_dao.go
@@ -52,7 +52,8 @@ func WriteRegisterNode(nodeHealth *NodeHealth) (healthy bool, err error) {
 			update node_health set
 				last_seen_active = now() - interval ? second,
 				extra_info = case when ? != '' then ? else extra_info end,
-				app_version = ?
+				app_version = ?,
+				incrementing_indicator = incrementing_indicator + 1
 			where
 				hostname = ?
 				and token = ?

--- a/go/process/health_dao.go
+++ b/go/process/health_dao.go
@@ -31,7 +31,7 @@ func WriteRegisterNode(nodeHealth *NodeHealth) (healthy bool, err error) {
 	timeNow := time.Now()
 	reportedAgo := timeNow.Sub(nodeHealth.LastReported)
 	reportedSecondsAgo := int64(reportedAgo.Seconds())
-	if reportedSecondsAgo > registrationPollSeconds*2 {
+	if reportedSecondsAgo > config.HealthPollSeconds*2 {
 		// This entry is too old. No reason to persist it; already expired.
 		return false, nil
 	}
@@ -118,7 +118,7 @@ func ExpireAvailableNodes() {
 			where
 				last_seen_active < now() - interval ? second
 			`,
-		registrationPollSeconds*2,
+		config.HealthPollSeconds*5,
 	)
 	if err != nil {
 		log.Errorf("ExpireAvailableNodes: failed to remove old entries: %+v", err)
@@ -156,7 +156,7 @@ func ReadAvailableNodes(onlyHttpNodes bool) (nodes [](*NodeHealth), err error) {
 			hostname
 		`
 
-	err = db.QueryOrchestrator(query, sqlutils.Args(registrationPollSeconds*2, extraInfo), func(m sqlutils.RowMap) error {
+	err = db.QueryOrchestrator(query, sqlutils.Args(config.HealthPollSeconds*2, extraInfo), func(m sqlutils.RowMap) error {
 		nodeHealth := &NodeHealth{
 			Hostname:        m.GetString("hostname"),
 			Token:           m.GetString("token"),


### PR DESCRIPTION
With this PR the recorded history of `database_instance_coordinates_history` becomes sparser: once per minute, as opposed to once per poll-seconds.

`database_instance_coordinates_history` is _mostly_ used when relocating servers via pseudo-GTID ; recorded coordinates act as a heuristic optimization, where the search for pseudo-GTID can heuristically begin not from the top of the binary log, but from a point close to its end. This saves a lot of binlog search time.

However, the high frequency for recording such coordinates is not required. The magic number for searching pseudo-GTID entries stands at "two minutes ago" ; which means resolution of, say, once-per`5sec` is over the top. A resolution of once per minute is fine, and suggests "two minutes ago" _could_ imply "almost three minutes ago". That's fine.