### PR TITLE
KV store: internal key/value + Consul + ZooKeeper support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@
 
 #### Failure detection & recovery
 - [Topology recovery](topology-recovery.md): failure detection and recovery
+- [Key-Value stores](kv.md): master discovery for your apps
 
 #### Various
 - [Docker](docker.md)

--- a/docs/configuration-kv.md
+++ b/docs/configuration-kv.md
@@ -1,0 +1,28 @@
+# Configuration: Key-Value stores
+
+`orchestrator` supports these key-value stores:
+
+- An internal store based on a relational table
+- [Consul](https://github.com/hashicorp/consul)
+- [ZooKeeper](https://zookeeper.apache.org/) - TO BE IMPLEMENTED
+
+`orchestrator` supports master discovery by storing clusters' masters in KV.
+
+```json
+  "KVClusterMasterPrefix": "mysql/master",
+  "ConsulAddress": "127.0.0.1:8500",
+  "ZkAddress": "srv-a,srv-b:12181,srv-c",
+```
+
+`KVClusterMasterPrefix` is the prefix to use for master discovery entries. As example, your cluster alias is `mycluster` and the master host is `some.host-17.com` then you will expect an entry where:
+
+- The Key is `mysql/master/mycluster`
+- The Value is `some.host-17.com`
+
+If specified, `ConsulAddress` indicates an address where a Consul HTTP service is available. If unspecified, no Consul access is attempted.
+
+**UNIMPLEMENTED YET** If specified, `ZkAddress` indicates one or more ZooKeeper servers to connect to. Default port per server is `2181`. All the following are equivalent:
+
+- `srv-a,srv-b:12181,srv-c`
+- `srv-a,srv-b:12181,srv-c:2181`
+- `srv-a:2181,srv-b:12181,srv-c:2181`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,3 +17,4 @@ Use the following small steps to configure `orchestrator`:
 - [Recovery](configuration-recovery.md)
 - [Raft](configuration-raft.md): configure a [orchestrator/raft](raft.md) cluster for high availability
 - Security: See [security](#security) section.
+- [Key-Value stores](configuration-kv.md): configure and use key-value stores for master discovery.

--- a/docs/kv.md
+++ b/docs/kv.md
@@ -1,0 +1,47 @@
+# Key-Value stores
+
+`orchestrator` supports these key value stores:
+
+- An internal store based on a relational table
+- [Consul](https://github.com/hashicorp/consul)
+- [ZooKeeper](https://zookeeper.apache.org/) - **TO BE IMPLEMENTED**
+
+See also [Key-Value configuration](configuration-kv.md).
+
+### Key-Value usage
+
+At this time Key-Value (aka KV) stores are used for:
+
+- Master discoveries
+
+### Master discoveries, key-values and failovers
+
+The objective is that service discoveries such as `Consul` or `ZookKeeper`-based would be able serve master discovery and/or take action based on cluster's master identity and change.
+
+The most common scenario is to update a Proxy to direct cluster's write traffic to a specific master. As an example, one may set up `HAProxy` via `consul-template`, such that `consul-template` populates a single-host master pool based on the key-value store authored by `orchestrator`.
+
+`orchestrator` updates all KV stores upon master failover.
+
+#### Populating master entries
+
+Clusters' master entries are populated on:
+
+- An actual failover: `orchestrator` overwrites existing entry with identity of new master
+- A manual request for entry population
+
+  For each cluster, you will want to make one manual request for entry population. KV stores have no initial knowledge of your setup. `orchestrator` does, but does not routinely update the stores. Use:
+
+  - `orchestrator-client -c submit-masters-to-kv-stores` to submit all clusters' masters to KV, or
+  - `orchestrator-client -c submit-masters-to-kv-stores -alias mycluster` to submit the master of `mycluster` to KV
+
+    See [orchestrator-client.md](orchestrator-client) documentation. You may use the `orchestrator`
+    command line invocation as well.
+
+  Or you may directly accessing the API via:
+
+  - `/api/submit-masters-to-kv-stores`, or
+  - `/api/submit-masters-to-kv-stores/:alias`, or
+
+  respectively.
+
+### KV and raft setups

--- a/docs/raft.md
+++ b/docs/raft.md
@@ -155,6 +155,8 @@ new-node$    sqlite3 /var/lib/orchestrator/orchestrator.db < /tmp/orchestrator-d
 
   - With `MySQL` use your favorite backup/restore method.
 
+See also [Master discovery with Key Value stores](kv.md#kv-and-orchestratorraft) via `orchestrator/raft`.
+
 ### Main advantages of orchestrator/raft
 
 - Highly available

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -25,6 +25,7 @@
 
 #### Failure detection & recovery
 - [Topology recovery](topology-recovery.md): failure detection and recovery
+- [Key-Value stores](kv.md): master discovery for your apps
 
 #### Various
 - [Docker](docker.md)

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -29,6 +29,7 @@ import (
 	"github.com/github/orchestrator/go/agent"
 	"github.com/github/orchestrator/go/config"
 	"github.com/github/orchestrator/go/inst"
+	"github.com/github/orchestrator/go/kv"
 	"github.com/github/orchestrator/go/logic"
 	"github.com/github/orchestrator/go/process"
 	"github.com/github/orchestrator/go/remote"
@@ -1246,6 +1247,25 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			}
 			fmt.Println(lag)
 		}
+	case registerCliCommand("submit-masters-to-kv-stores", "key-value", `Submit master of a specific cluster, or all masters of all clusters to key-value stores`):
+		{
+			clusterName := getClusterName(clusterAlias, instanceKey)
+			log.Debugf("cluster name is <%s>", clusterName)
+
+			kvPairs, err := inst.GetMastersKVPairs(clusterName)
+			if err != nil {
+				log.Fatale(err)
+			}
+			for _, kvPair := range kvPairs {
+				if err := kv.PutKVPair(kvPair); err != nil {
+					log.Fatale(err)
+				}
+			}
+			for _, kvPair := range kvPairs {
+				fmt.Println(fmt.Sprintf("%s:%s", kvPair.Key, kvPair.Value))
+			}
+		}
+
 		// Instance management
 	case registerCliCommand("discover", "Instance management", `Lookup an instance, investigate it`):
 		{

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1247,7 +1247,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			}
 			fmt.Println(lag)
 		}
-	case registerCliCommand("submit-masters-to-kv-stores", "key-value", `Submit master of a specific cluster, or all masters of all clusters to key-value stores`):
+	case registerCliCommand("submit-masters-to-kv-stores", "Key-value", `Submit master of a specific cluster, or all masters of all clusters to key-value stores`):
 		{
 			clusterName := getClusterName(clusterAlias, instanceKey)
 			log.Debugf("cluster name is <%s>", clusterName)

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -241,6 +241,7 @@ type Configuration struct {
 	MaxOutdatedKeysToShow                      int               // Maximum number of keys to show in ContinuousDiscovery. If the number of polled hosts grows too far then showing the complete list is not ideal.
 	DiscoveryIgnoreReplicaHostnameFilters      []string          // Regexp filters to apply to prevent auto-discovering new replicas. Usage: unreachable servers due to firewalls, applications which trigger binlog dumps
 	ConsulAddress                              string            // Address where Consul HTTP api is found. Example: 127.0.0.1:8500
+	ZkAddress                                  string            // UNSUPPERTED YET. Address where (single or multiple) ZooKeeper servers are found, in `srv1[:port1][,srv2[:port2]...]` format. Default port is 2181. Example: srv-a,srv-b:12181,srv-c
 	KVClusterMasterPrefix                      string            // Prefix to use for clusters' masters entries in KV stores (internal, consul, ZK), default: "mysql/master"
 }
 
@@ -396,6 +397,7 @@ func newConfiguration() *Configuration {
 		MaxOutdatedKeysToShow:                      64,
 		DiscoveryIgnoreReplicaHostnameFilters:      []string{},
 		ConsulAddress:                              "",
+		ZkAddress:                                  "",
 		KVClusterMasterPrefix:                      "mysql/master",
 	}
 }

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -240,7 +240,7 @@ type Configuration struct {
 	MaxOutdatedKeysToShow                      int               // Maximum number of keys to show in ContinuousDiscovery. If the number of polled hosts grows too far then showing the complete list is not ideal.
 	DiscoveryIgnoreReplicaHostnameFilters      []string          // Regexp filters to apply to prevent auto-discovering new replicas. Usage: unreachable servers due to firewalls, applications which trigger binlog dumps
 	ConsulAddress                              string            // Address where Consul HTTP api is found. Example: 127.0.0.1:8500
-	KVClusterMasterPrefix                      string            // Prefix to use for clusters' masters entries in KV stores (internal, consul, ZK), default: "orchestrator/master/cluster"
+	KVClusterMasterPrefix                      string            // Prefix to use for clusters' masters entries in KV stores (internal, consul, ZK), default: "mysql/master"
 }
 
 // ToJSONString will marshal this configuration as JSON
@@ -394,7 +394,7 @@ func newConfiguration() *Configuration {
 		MaxOutdatedKeysToShow:                      64,
 		DiscoveryIgnoreReplicaHostnameFilters:      []string{},
 		ConsulAddress:                              "",
-		KVClusterMasterPrefix:                      "orchestrator/master/cluster",
+		KVClusterMasterPrefix:                      "mysql/master",
 	}
 }
 

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -239,6 +239,8 @@ type Configuration struct {
 	URLPrefix                                  string            // URL prefix to run orchestrator on non-root web path, e.g. /orchestrator to put it behind nginx.
 	MaxOutdatedKeysToShow                      int               // Maximum number of keys to show in ContinuousDiscovery. If the number of polled hosts grows too far then showing the complete list is not ideal.
 	DiscoveryIgnoreReplicaHostnameFilters      []string          // Regexp filters to apply to prevent auto-discovering new replicas. Usage: unreachable servers due to firewalls, applications which trigger binlog dumps
+	ConsulAddress                              string            // Address where Consul HTTP api is found. Example: 127.0.0.1:8500
+	ConsulKVPrefix                             string            // Prefix to use for Consul KV store, default: "orchestrator"
 }
 
 // ToJSONString will marshal this configuration as JSON
@@ -391,6 +393,8 @@ func newConfiguration() *Configuration {
 		URLPrefix:                                  "",
 		MaxOutdatedKeysToShow:                      64,
 		DiscoveryIgnoreReplicaHostnameFilters:      []string{},
+		ConsulAddress:                              "",
+		ConsulKVPrefix:                             "orchestrator",
 	}
 }
 
@@ -509,6 +513,9 @@ func (this *Configuration) postReadAdjustments() error {
 	}
 	if this.RaftAdvertise == "" {
 		this.RaftAdvertise = this.RaftBind
+	}
+	if this.ConsulKVPrefix != "" {
+		this.ConsulKVPrefix = strings.TrimRight(this.ConsulKVPrefix, "/")
 	}
 	return nil
 }

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -525,6 +525,9 @@ func (this *Configuration) postReadAdjustments() error {
 		this.KVClusterMasterPrefix = strings.TrimRight(this.KVClusterMasterPrefix, "/")
 		this.KVClusterMasterPrefix = fmt.Sprintf("%s/", this.KVClusterMasterPrefix)
 	}
+	if this.ZkAddress != "" {
+		return fmt.Errorf("ZkAddress (ZooKeeper) configuration is unsupported yet")
+	}
 	return nil
 }
 

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -147,6 +147,7 @@ type Configuration struct {
 	CandidateInstanceExpireMinutes             uint     // Minutes after which a suggestion to use an instance as a candidate replica (to be preferably promoted on master failover) is expired.
 	AuditLogFile                               string   // Name of log file for audit operations. Disabled when empty.
 	AuditToSyslog                              bool     // If true, audit messages are written to syslog
+	AuditToBackendDB                           bool     // If true, audit messages are written to the backend DB's `audit` table (default: true)
 	RemoveTextFromHostnameDisplay              string   // Text to strip off the hostname on cluster/clusters pages
 	ReadOnly                                   bool
 	AuthenticationMethod                       string // Type of autherntication to use, if any. "" for none, "basic" for BasicAuth, "multi" for advanced BasicAuth, "proxy" for forwarded credentials via reverse proxy, "token" for token based access
@@ -310,6 +311,7 @@ func newConfiguration() *Configuration {
 		CandidateInstanceExpireMinutes:             60,
 		AuditLogFile:                               "",
 		AuditToSyslog:                              false,
+		AuditToBackendDB:                           false,
 		RemoveTextFromHostnameDisplay:              "",
 		ReadOnly:                                   false,
 		AuthenticationMethod:                       "",

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -240,7 +240,7 @@ type Configuration struct {
 	MaxOutdatedKeysToShow                      int               // Maximum number of keys to show in ContinuousDiscovery. If the number of polled hosts grows too far then showing the complete list is not ideal.
 	DiscoveryIgnoreReplicaHostnameFilters      []string          // Regexp filters to apply to prevent auto-discovering new replicas. Usage: unreachable servers due to firewalls, applications which trigger binlog dumps
 	ConsulAddress                              string            // Address where Consul HTTP api is found. Example: 127.0.0.1:8500
-	ConsulKVPrefix                             string            // Prefix to use for Consul KV store, default: "orchestrator"
+	KVClusterMasterPrefix                      string            // Prefix to use for clusters' masters entries in KV stores (internal, consul, ZK), default: "orchestrator/master/cluster"
 }
 
 // ToJSONString will marshal this configuration as JSON
@@ -394,7 +394,7 @@ func newConfiguration() *Configuration {
 		MaxOutdatedKeysToShow:                      64,
 		DiscoveryIgnoreReplicaHostnameFilters:      []string{},
 		ConsulAddress:                              "",
-		ConsulKVPrefix:                             "orchestrator",
+		KVClusterMasterPrefix:                      "orchestrator/master/cluster",
 	}
 }
 
@@ -514,8 +514,12 @@ func (this *Configuration) postReadAdjustments() error {
 	if this.RaftAdvertise == "" {
 		this.RaftAdvertise = this.RaftBind
 	}
-	if this.ConsulKVPrefix != "" {
-		this.ConsulKVPrefix = strings.TrimRight(this.ConsulKVPrefix, "/")
+	if this.KVClusterMasterPrefix != "/" {
+		// "/" remains "/"
+		// "prefix" turns to "prefix/"
+		// "some/prefix///" turns to "some/prefix/"
+		this.KVClusterMasterPrefix = strings.TrimRight(this.KVClusterMasterPrefix, "/")
+		this.KVClusterMasterPrefix = fmt.Sprintf("%s/", this.KVClusterMasterPrefix)
 	}
 	return nil
 }

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -147,6 +147,7 @@ type Configuration struct {
 	CandidateInstanceExpireMinutes             uint     // Minutes after which a suggestion to use an instance as a candidate replica (to be preferably promoted on master failover) is expired.
 	AuditLogFile                               string   // Name of log file for audit operations. Disabled when empty.
 	AuditToSyslog                              bool     // If true, audit messages are written to syslog
+	AuditToBackendDB                           bool     // If true, audit messages are written to the backend DB's `audit` table (default: true)
 	RemoveTextFromHostnameDisplay              string   // Text to strip off the hostname on cluster/clusters pages
 	ReadOnly                                   bool
 	AuthenticationMethod                       string // Type of autherntication to use, if any. "" for none, "basic" for BasicAuth, "multi" for advanced BasicAuth, "proxy" for forwarded credentials via reverse proxy, "token" for token based access
@@ -308,6 +309,7 @@ func newConfiguration() *Configuration {
 		CandidateInstanceExpireMinutes:             60,
 		AuditLogFile:                               "",
 		AuditToSyslog:                              false,
+		AuditToBackendDB:                           false,
 		RemoveTextFromHostnameDisplay:              "",
 		ReadOnly:                                   false,
 		AuthenticationMethod:                       "",

--- a/go/db/generate_base.go
+++ b/go/db/generate_base.go
@@ -801,4 +801,12 @@ var generateSQLBase = []string{
 			PRIMARY KEY (hostname,port)
 		) ENGINE=InnoDB DEFAULT CHARSET=ascii
 	`,
+	`
+		CREATE TABLE IF NOT EXISTS kv_store (
+			store_key varchar(255) CHARACTER SET ascii NOT NULL,
+			store_value text CHARACTER SET utf8 not null,
+			last_updated timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (store_key)
+		) ENGINE=InnoDB DEFAULT CHARSET=ascii
+	`,
 }

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -3081,8 +3081,6 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerRequest(m, "set-cluster-alias/:clusterName", this.SetClusterAliasManualOverride)
 	this.registerRequest(m, "clusters", this.Clusters)
 	this.registerRequest(m, "clusters-info", this.ClustersInfo)
-	this.registerRequest(m, "submit-masters-to-kv-stores", this.SubmitMastersToKvStores)
-	this.registerRequest(m, "submit-masters-to-kv-stores/:clusterHint", this.SubmitMastersToKvStores)
 
 	this.registerRequest(m, "masters", this.Masters)
 	this.registerRequest(m, "master/:clusterHint", this.ClusterMaster)
@@ -3092,6 +3090,10 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerRequest(m, "downtimed/:clusterHint", this.Downtimed)
 	this.registerRequest(m, "topology/:clusterHint", this.AsciiTopology)
 	this.registerRequest(m, "topology/:host/:port", this.AsciiTopology)
+
+	// Key-value:
+	this.registerRequest(m, "submit-masters-to-kv-stores", this.SubmitMastersToKvStores)
+	this.registerRequest(m, "submit-masters-to-kv-stores/:clusterHint", this.SubmitMastersToKvStores)
 
 	// Instance management:
 	this.registerRequest(m, "instance/:host/:port", this.Instance)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1537,7 +1537,7 @@ func (this *HttpAPI) SubmitMastersToKvStores(params martini.Params, r render.Ren
 			return
 		}
 	}
-	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Submitted %d masters", len(kvPairs))})
+	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Submitted %d masters", len(kvPairs)), Details: kvPairs})
 }
 
 // Clusters provides list of known masters

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -37,6 +37,7 @@ import (
 	"github.com/github/orchestrator/go/config"
 	"github.com/github/orchestrator/go/discovery"
 	"github.com/github/orchestrator/go/inst"
+	"github.com/github/orchestrator/go/kv"
 	"github.com/github/orchestrator/go/logic"
 	"github.com/github/orchestrator/go/metrics/query"
 	"github.com/github/orchestrator/go/process"
@@ -1511,6 +1512,34 @@ func (this *HttpAPI) ClustersInfo(params martini.Params, r render.Render, req *h
 	r.JSON(http.StatusOK, clustersInfo)
 }
 
+// Write a cluster's master (or all clusters masters) to kv stores.
+// This should generally only happen once in a lifetime of a cluster. Otherwise KV
+// stores are updated via failovers.
+func (this *HttpAPI) SubmitMastersToKvStores(params martini.Params, r render.Render, req *http.Request) {
+	clusterName, err := getClusterNameIfExists(params)
+	if err != nil {
+		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
+		return
+	}
+	kvPairs, err := inst.GetMastersKVPairs(clusterName)
+	if err != nil {
+		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
+		return
+	}
+	for _, kvPair := range kvPairs {
+		if orcraft.IsRaftEnabled() {
+			_, err = orcraft.PublishCommand("put-key-value", kvPair)
+		} else {
+			err = kv.PutKVPair(kvPair)
+		}
+		if err != nil {
+			Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
+			return
+		}
+	}
+	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Submitted %d masters", len(kvPairs))})
+}
+
 // Clusters provides list of known masters
 func (this *HttpAPI) Masters(params martini.Params, r render.Render, req *http.Request) {
 	instances, err := inst.ReadWriteableClustersMasters()
@@ -1546,18 +1575,13 @@ func (this *HttpAPI) ClusterMaster(params martini.Params, r render.Render, req *
 
 // Downtimed lists downtimed instances, potentially filtered by cluster
 func (this *HttpAPI) Downtimed(params martini.Params, r render.Render, req *http.Request) {
-	clusterName := ""
-	if clusterHint := getClusterHint(params); clusterHint != "" {
-		var err error
-		clusterName, err = figureClusterName(clusterHint)
-		if err != nil {
-			Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
-			return
-		}
+	clusterName, err := getClusterNameIfExists(params)
+	if err != nil {
+		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
+		return
 	}
 
 	instances, err := inst.ReadDowntimedInstances(clusterName)
-
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return
@@ -3057,6 +3081,9 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerRequest(m, "set-cluster-alias/:clusterName", this.SetClusterAliasManualOverride)
 	this.registerRequest(m, "clusters", this.Clusters)
 	this.registerRequest(m, "clusters-info", this.ClustersInfo)
+	this.registerRequest(m, "submit-masters-to-kv-stores", this.SubmitMastersToKvStores)
+	this.registerRequest(m, "submit-masters-to-kv-stores/:clusterHint", this.SubmitMastersToKvStores)
+
 	this.registerRequest(m, "masters", this.Masters)
 	this.registerRequest(m, "master/:clusterHint", this.ClusterMaster)
 	this.registerRequest(m, "instance-replicas/:host/:port", this.InstanceReplicas)

--- a/go/http/httpbase.go
+++ b/go/http/httpbase.go
@@ -161,3 +161,13 @@ func figureClusterName(hint string) (clusterName string, err error) {
 	instanceKey, _ := inst.ParseRawInstanceKeyLoose(hint)
 	return inst.FigureClusterName(hint, instanceKey, nil)
 }
+
+// getClusterNameIfExists returns a cluster name by params hint, or an empty cluster name
+// if no hint is given
+func getClusterNameIfExists(params map[string]string) (clusterName string, err error) {
+	if clusterHint := getClusterHint(params); clusterHint == "" {
+		return "", nil
+	} else {
+		return figureClusterName(clusterHint)
+	}
+}

--- a/go/inst/cluster.go
+++ b/go/inst/cluster.go
@@ -17,10 +17,27 @@
 package inst
 
 import (
-	"github.com/github/orchestrator/go/config"
+	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/github/orchestrator/go/config"
+	"github.com/github/orchestrator/go/kv"
 )
+
+func GetClusterMasterKVKey(clusterAlias string) string {
+	return fmt.Sprintf("%s%s", config.Config.KVClusterMasterPrefix, clusterAlias)
+}
+
+func GetClusterMasterKVPair(clusterAlias string, masterKey *InstanceKey) *kv.KVPair {
+	if clusterAlias == "" {
+		return nil
+	}
+	if masterKey == nil {
+		return nil
+	}
+	return kv.NewKVPair(GetClusterMasterKVKey(clusterAlias), masterKey.StringCode())
+}
 
 // mappedClusterNameToAlias attempts to match a cluster with an alias based on
 // configured ClusterNameToAlias map

--- a/go/inst/cluster_alias.go
+++ b/go/inst/cluster_alias.go
@@ -18,12 +18,12 @@ package inst
 
 // SetClusterAlias will write (and override) a single cluster name mapping
 func SetClusterAlias(clusterName string, alias string) error {
-	return WriteClusterAlias(clusterName, alias)
+	return writeClusterAlias(clusterName, alias)
 }
 
 // SetClusterAliasManualOverride will write (and override) a single cluster name mapping
 func SetClusterAliasManualOverride(clusterName string, alias string) error {
-	return WriteClusterAliasManualOverride(clusterName, alias)
+	return writeClusterAliasManualOverride(clusterName, alias)
 }
 
 // GetClusterByAlias returns the cluster name associated with given alias.

--- a/go/inst/cluster_alias_dao.go
+++ b/go/inst/cluster_alias_dao.go
@@ -80,7 +80,7 @@ func ReadAliasByClusterName(clusterName string) (alias string, err error) {
 }
 
 // WriteClusterAlias will write (and override) a single cluster name mapping
-func WriteClusterAlias(clusterName string, alias string) error {
+func writeClusterAlias(clusterName string, alias string) error {
 	writeFunc := func() error {
 		_, err := db.ExecOrchestrator(`
 			replace into
@@ -94,8 +94,8 @@ func WriteClusterAlias(clusterName string, alias string) error {
 	return ExecDBWriteFunc(writeFunc)
 }
 
-// WriteClusterAliasManualOverride will write (and override) a single cluster name mapping
-func WriteClusterAliasManualOverride(clusterName string, alias string) error {
+// writeClusterAliasManualOverride will write (and override) a single cluster name mapping
+func writeClusterAliasManualOverride(clusterName string, alias string) error {
 	writeFunc := func() error {
 		_, err := db.ExecOrchestrator(`
 			replace into

--- a/go/inst/cluster_test.go
+++ b/go/inst/cluster_test.go
@@ -1,0 +1,55 @@
+/*
+   Copyright 2014 Outbrain Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package inst
+
+import (
+	"github.com/github/orchestrator/go/config"
+	"github.com/openark/golib/log"
+	test "github.com/openark/golib/tests"
+	"testing"
+)
+
+var masterKey = InstanceKey{Hostname: "host1", Port: 3306}
+
+func init() {
+	config.Config.HostnameResolveMethod = "none"
+	config.Config.KVClusterMasterPrefix = "test/master/"
+	config.MarkConfigurationLoaded()
+	log.SetLevel(log.ERROR)
+}
+
+func TestGetClusterMasterKVKey(t *testing.T) {
+	kvKey := GetClusterMasterKVKey("foo")
+	test.S(t).ExpectEquals(kvKey, "test/master/foo")
+}
+
+func TestGetClusterMasterKVPair(t *testing.T) {
+	{
+		kvPair := GetClusterMasterKVPair("myalias", &masterKey)
+		test.S(t).ExpectNotNil(kvPair)
+		test.S(t).ExpectEquals(kvPair.Key, "test/master/myalias")
+		test.S(t).ExpectEquals(kvPair.Value, masterKey.StringCode())
+	}
+	{
+		kvPair := GetClusterMasterKVPair("", &masterKey)
+		test.S(t).ExpectTrue(kvPair == nil)
+	}
+	{
+		kvPair := GetClusterMasterKVPair("myalias", nil)
+		test.S(t).ExpectTrue(kvPair == nil)
+	}
+}

--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -453,7 +453,7 @@ func (this *Instance) HumanReadableDescription() string {
 	if this.LogBinEnabled && this.LogSlaveUpdatesEnabled {
 		tokens = append(tokens, ">>")
 	}
-	if this.UsingGTID() {
+	if this.UsingGTID() || this.SupportsOracleGTID {
 		tokens = append(tokens, "GTID")
 	}
 	if this.UsingPseudoGTID {

--- a/go/kv/consul.go
+++ b/go/kv/consul.go
@@ -17,19 +17,58 @@
 package kv
 
 import (
+	"fmt"
+
+	consulapi "github.com/armon/consul-api"
 	"github.com/github/orchestrator/go/config"
 	"github.com/openark/golib/log"
 )
 
+// A Consul store based on config's `ConsulAddress` and `ConsulKVPrefix`
 type consulStore struct {
+	client *consulapi.Client
 }
 
+// NewConsulStore creates a new consul store. It is possible that the client for this store is nil,
+// which is the case if no consul config is provided.
 func NewConsulStore() KVStore {
-	return &consulStore{}
+	store := &consulStore{}
+
+	if config.Config.ConsulAddress != "" {
+		consulConfig := consulapi.DefaultConfig()
+		consulConfig.Address = config.Config.ConsulAddress
+		if client, err := consulapi.NewClient(consulConfig); err != nil {
+			log.Errore(err)
+		} else {
+			store.client = client
+		}
+	}
+	return store
+}
+
+func (this *consulStore) fullKey(key string) string {
+	if config.Config.ConsulKVPrefix != "" {
+		return fmt.Sprintf("%s/%s", config.Config.ConsulKVPrefix, key)
+	}
+	return key
 }
 
 func (this *consulStore) PutKeyValue(key string, value string) (err error) {
+	if this.client == nil {
+		return nil
+	}
+	pair := &consulapi.KVPair{Key: this.fullKey(key), Value: []byte(value)}
+	_, err = this.client.KV().Put(pair, nil)
+	return err
 }
 
 func (this *consulStore) GetKeyValue(key string) (value string, err error) {
+	if this.client == nil {
+		return value, nil
+	}
+	pair, _, err := this.client.KV().Get(this.fullKey(key), nil)
+	if err != nil {
+		return value, err
+	}
+	return string(pair.Value), nil
 }

--- a/go/kv/consul.go
+++ b/go/kv/consul.go
@@ -1,0 +1,17 @@
+/*
+   Copyright 2017 Shlomi Noach, GitHub Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kv

--- a/go/kv/consul.go
+++ b/go/kv/consul.go
@@ -15,3 +15,21 @@
 */
 
 package kv
+
+import (
+	"github.com/github/orchestrator/go/config"
+	"github.com/openark/golib/log"
+)
+
+type consulStore struct {
+}
+
+func NewConsulStore() KVStore {
+	return &consulStore{}
+}
+
+func (this *consulStore) PutKeyValue(key string, value string) (err error) {
+}
+
+func (this *consulStore) GetKeyValue(key string) (value string, err error) {
+}

--- a/go/kv/consul.go
+++ b/go/kv/consul.go
@@ -17,8 +17,6 @@
 package kv
 
 import (
-	"fmt"
-
 	consulapi "github.com/armon/consul-api"
 	"github.com/github/orchestrator/go/config"
 	"github.com/openark/golib/log"
@@ -46,18 +44,11 @@ func NewConsulStore() KVStore {
 	return store
 }
 
-func (this *consulStore) fullKey(key string) string {
-	if config.Config.ConsulKVPrefix != "" {
-		return fmt.Sprintf("%s/%s", config.Config.ConsulKVPrefix, key)
-	}
-	return key
-}
-
 func (this *consulStore) PutKeyValue(key string, value string) (err error) {
 	if this.client == nil {
 		return nil
 	}
-	pair := &consulapi.KVPair{Key: this.fullKey(key), Value: []byte(value)}
+	pair := &consulapi.KVPair{Key: key, Value: []byte(value)}
 	_, err = this.client.KV().Put(pair, nil)
 	return err
 }
@@ -66,7 +57,7 @@ func (this *consulStore) GetKeyValue(key string) (value string, err error) {
 	if this.client == nil {
 		return value, nil
 	}
-	pair, _, err := this.client.KV().Get(this.fullKey(key), nil)
+	pair, _, err := this.client.KV().Get(key, nil)
 	if err != nil {
 		return value, err
 	}

--- a/go/kv/internal.go
+++ b/go/kv/internal.go
@@ -1,0 +1,62 @@
+/*
+   Copyright 2017 Shlomi Noach, GitHub Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kv
+
+import (
+	"github.com/github/orchestrator/go/db"
+	"github.com/openark/golib/log"
+	"github.com/openark/golib/sqlutils"
+)
+
+// Internal key-value store, based on relational backend
+type internalKVStore struct {
+}
+
+func NewInternalKVStore() KVStore {
+	return &internalKVStore{}
+}
+
+func (this *internalKVStore) PutKeyValue(key string, value string) (err error) {
+	_, err = db.ExecOrchestrator(`
+		replace
+			into kv_store (
+        store_key, store_value, last_updated
+			) values (
+				?, ?, now()
+			)
+		`, key, value,
+	)
+	return log.Errore(err)
+}
+
+func (this *internalKVStore) GetKeyValue(key string) (value string, err error) {
+	query := `
+		select
+			store_value
+		from
+			kv_store
+		where
+      key = ?
+		`
+
+	err = db.QueryOrchestrator(query, sqlutils.Args(key), func(m sqlutils.RowMap) error {
+		value = m.GetString("store_value")
+		return nil
+	})
+
+	return value, log.Errore(err)
+}

--- a/go/kv/kv.go
+++ b/go/kv/kv.go
@@ -20,6 +20,15 @@ import (
 	"sync"
 )
 
+type KVPair struct {
+	Key   string
+	Value string
+}
+
+func NewKVPair(key string, value string) *KVPair {
+	return &KVPair{Key: key, Value: value}
+}
+
 type KVStore interface {
 	PutKeyValue(key string, value string) (err error)
 	GetKeyValue(key string) (value string, err error)
@@ -56,9 +65,17 @@ func PutValue(key string, value string) (err error) {
 	return nil
 }
 
+func PutKVPair(kvPair *KVPair) (err error) {
+	if kvPair == nil {
+		return nil
+	}
+	return PutValue(kvPair.Key, kvPair.Value)
+}
+
 func GetValue(key string) (value string, err error) {
 	for _, store := range getKVStores() {
+		// It's really only the first (internal) that matters here
 		return store.GetKeyValue(key)
 	}
-	return value, nil
+	return value, err
 }

--- a/go/kv/kv.go
+++ b/go/kv/kv.go
@@ -1,0 +1,17 @@
+/*
+   Copyright 2017 Shlomi Noach, GitHub Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kv

--- a/go/kv/kv.go
+++ b/go/kv/kv.go
@@ -15,3 +15,10 @@
 */
 
 package kv
+
+type KVStore interface {
+	PutKeyValue(key string, value string) (err error)
+	GetKeyValue(key string) (value string, err error)
+}
+
+var kvStores []KVStore

--- a/go/kv/kv.go
+++ b/go/kv/kv.go
@@ -56,6 +56,14 @@ func getKVStores() (stores []KVStore) {
 	return stores
 }
 
+func GetValue(key string) (value string, err error) {
+	for _, store := range getKVStores() {
+		// It's really only the first (internal) that matters here
+		return store.GetKeyValue(key)
+	}
+	return value, err
+}
+
 func PutValue(key string, value string) (err error) {
 	for _, store := range getKVStores() {
 		if err := store.PutKeyValue(key, value); err != nil {
@@ -70,12 +78,4 @@ func PutKVPair(kvPair *KVPair) (err error) {
 		return nil
 	}
 	return PutValue(kvPair.Key, kvPair.Value)
-}
-
-func GetValue(key string) (value string, err error) {
-	for _, store := range getKVStores() {
-		// It's really only the first (internal) that matters here
-		return store.GetKeyValue(key)
-	}
-	return value, err
 }

--- a/go/kv/zk.go
+++ b/go/kv/zk.go
@@ -20,6 +20,10 @@ package kv
 type zkStore struct {
 }
 
+// TODO: use config.Config.ZkAddress to put/get k/v in ZooKeeper. See
+// - https://github.com/outbrain/zookeepercli
+// - https://github.com/samuel/go-zookeeper/zk
+
 func NewZkStore() KVStore {
 	return &zkStore{}
 }

--- a/go/kv/zk.go
+++ b/go/kv/zk.go
@@ -15,3 +15,19 @@
 */
 
 package kv
+
+// Internal key-value store, based on relational backend
+type zkStore struct {
+}
+
+func NewZkStore() KVStore {
+	return &zkStore{}
+}
+
+func (this *zkStore) PutKeyValue(key string, value string) (err error) {
+	return
+}
+
+func (this *zkStore) GetKeyValue(key string) (value string, err error) {
+	return
+}

--- a/go/kv/zk.go
+++ b/go/kv/zk.go
@@ -1,0 +1,17 @@
+/*
+   Copyright 2017 Shlomi Noach, GitHub Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kv

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/github/orchestrator/go/inst"
 	"github.com/github/orchestrator/go/kv"
+	"github.com/github/orchestrator/go/raft"
 
 	"github.com/openark/golib/log"
 )
@@ -38,6 +39,8 @@ func (applier *CommandApplier) ApplyCommand(op string, value []byte) interface{}
 	switch op {
 	case "heartbeat":
 		return nil
+	case "async-snapshot":
+		return applier.asyncSnapshot(value)
 	case "register-node":
 		return applier.registerNode(value)
 	case "discover":
@@ -72,6 +75,11 @@ func (applier *CommandApplier) ApplyCommand(op string, value []byte) interface{}
 		return applier.putKeyValue(value)
 	}
 	return log.Errorf("Unknown command op: %s", op)
+}
+
+func (applier *CommandApplier) asyncSnapshot(value []byte) interface{} {
+	err := orcraft.AsyncSnapshot()
+	return err
 }
 
 func (applier *CommandApplier) registerNode(value []byte) interface{} {

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 
 	"github.com/github/orchestrator/go/inst"
+	"github.com/github/orchestrator/go/kv"
 
 	"github.com/openark/golib/log"
 )
@@ -67,6 +68,8 @@ func (applier *CommandApplier) ApplyCommand(op string, value []byte) interface{}
 		return applier.disableGlobalRecoveries(value)
 	case "enable-global-recoveries":
 		return applier.enableGlobalRecoveries(value)
+	case "put-key-value":
+		return applier.putKeyValue(value)
 	}
 	return log.Errorf("Unknown command op: %s", op)
 }
@@ -196,5 +199,14 @@ func (applier *CommandApplier) disableGlobalRecoveries(value []byte) interface{}
 
 func (applier *CommandApplier) enableGlobalRecoveries(value []byte) interface{} {
 	err := EnableRecovery()
+	return err
+}
+
+func (applier *CommandApplier) putKeyValue(value []byte) interface{} {
+	kvPair := kv.KVPair{}
+	if err := json.Unmarshal(value, &kvPair); err != nil {
+		return log.Errore(err)
+	}
+	err := kv.PutKVPair(&kvPair)
 	return err
 }

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -30,6 +30,7 @@ import (
 	"github.com/github/orchestrator/go/config"
 	"github.com/github/orchestrator/go/discovery"
 	"github.com/github/orchestrator/go/inst"
+	"github.com/github/orchestrator/go/kv"
 	ometrics "github.com/github/orchestrator/go/metrics"
 	"github.com/github/orchestrator/go/process"
 	"github.com/github/orchestrator/go/raft"
@@ -391,6 +392,7 @@ func ContinuousDiscovery() {
 	go ometrics.InitMetrics()
 	go ometrics.InitGraphiteMetrics()
 	go acceptSignals()
+	go kv.InitKVStores()
 
 	if config.Config.RaftEnabled {
 		if err := orcraft.Setup(NewCommandApplier(), NewSnapshotDataCreatorApplier(), process.ThisHostname); err != nil {

--- a/go/logic/snapshot_data.go
+++ b/go/logic/snapshot_data.go
@@ -44,6 +44,7 @@ type SnapshotData struct {
 	DowntimedInstances,
 	Candidates,
 	Detections,
+	KVStore,
 	Recovery,
 	RecoverySteps sqlutils.NamedResultData
 }
@@ -88,6 +89,7 @@ func CreateSnapshotData() *SnapshotData {
 	readTableData("database_instance_downtime", &snapshotData.DowntimedInstances)
 	readTableData("candidate_database_instance", &snapshotData.Candidates)
 	readTableData("topology_failure_detection", &snapshotData.Detections)
+	readTableData("kv_store", &snapshotData.KVStore)
 	readTableData("topology_recovery", &snapshotData.Recovery)
 	readTableData("topology_recovery_steps", &snapshotData.RecoverySteps)
 
@@ -173,6 +175,7 @@ func (this *SnapshotDataCreatorApplier) Restore(rc io.ReadCloser) error {
 	writeTableData("hostname_unresolve", &snapshotData.HostnameUnresolves)
 	writeTableData("database_instance_downtime", &snapshotData.DowntimedInstances)
 	writeTableData("candidate_database_instance", &snapshotData.Candidates)
+	writeTableData("kv_store", &snapshotData.KVStore)
 	writeTableData("topology_recovery", &snapshotData.Recovery)
 	writeTableData("topology_failure_detection", &snapshotData.Detections)
 	writeTableData("topology_recovery_steps", &snapshotData.RecoverySteps)

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -773,7 +773,7 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 			inst.SetReadOnly(&promotedReplica.Key, false)
 		}
 
-		kvPair := kv.NewKVPair(analysisEntry.ClusterDetails.ClusterAlias, promotedReplica.Key.StringCode())
+		kvPair := inst.GetClusterMasterKVPair(analysisEntry.ClusterDetails.ClusterAlias, &promotedReplica.Key)
 		if orcraft.IsRaftEnabled() {
 			orcraft.PublishCommand("put-key-value", kvPair)
 		} else {

--- a/go/raft/store.go
+++ b/go/raft/store.go
@@ -13,12 +13,6 @@ import (
 	"github.com/hashicorp/raft"
 )
 
-const (
-	retainSnapshotCount = 10
-	snapshotInterval    = 30 * time.Minute
-	raftTimeout         = 10 * time.Second
-)
-
 type Store struct {
 	raftDir       string
 	raftBind      string

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -338,11 +338,6 @@ function which_cluster_osc_replicas() {
   print_response | filter_keys | print_key
 }
 
-function submit_masters_to_kv_stores() {
-  api "submit-masters-to-kv-stores/${alias}"
-  print_details | jq -r .
-}
-
 function downtimed() {
   api "downtimed/${alias:-$instance}"
   print_response | filter_keys | print_key
@@ -351,6 +346,11 @@ function downtimed() {
 function dominant_dc() {
   api "masters"
   print_response | jq -r '.[].DataCenter' | sort | uniq -c | sort -nr | head -n 1 | awk '{print $2}'
+}
+
+function submit_masters_to_kv_stores() {
+  api "submit-masters-to-kv-stores/${alias}"
+  print_details | jq -r .
 }
 
 function submit_pool_instances() {
@@ -592,7 +592,8 @@ function run_command() {
     "which-cluster-osc-replicas") which_cluster_osc_replicas ;; # Output a list of replicas in a cluster, that could serve as a pt-online-schema-change operation control replicas
     "downtimed") downtimed ;;                                   # List all downtimed instances
     "dominant-dc") dominant_dc ;;                               # Name the data center where most masters are found
-    "submit-masters-to-kv-stores") submit_masters_to_kv_stores;;# Submit a cluster's master, or all clusters' masters to KV stores
+
+    "submit-masters-to-kv-stores") submit_masters_to_kv_stores;; # Submit a cluster's master, or all clusters' masters to KV stores
 
     "relocate") general_relocate_command ;;                   # Relocate a replica beneath another instance
     "relocate-replicas") general_relocate_replicas_command ;; # Relocates all or part of the replicas of a given instance under another instance

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -340,7 +340,7 @@ function which_cluster_osc_replicas() {
 
 function submit_masters_to_kv_stores() {
   api "submit-masters-to-kv-stores/${alias}"
-  print_response | jq .
+  print_details | jq -r .
 }
 
 function downtimed() {

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -350,7 +350,7 @@ function dominant_dc() {
 
 function submit_masters_to_kv_stores() {
   api "submit-masters-to-kv-stores/${alias}"
-  print_details | jq -r .
+  print_details | jq -r '.[] | (.Key + ":" + .Value)'
 }
 
 function submit_pool_instances() {

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -338,6 +338,11 @@ function which_cluster_osc_replicas() {
   print_response | filter_keys | print_key
 }
 
+function submit_masters_to_kv_stores() {
+  api "submit-masters-to-kv-stores/${alias}"
+  print_response | jq .
+}
+
 function downtimed() {
   api "downtimed/${alias:-$instance}"
   print_response | filter_keys | print_key
@@ -587,6 +592,7 @@ function run_command() {
     "which-cluster-osc-replicas") which_cluster_osc_replicas ;; # Output a list of replicas in a cluster, that could serve as a pt-online-schema-change operation control replicas
     "downtimed") downtimed ;;                                   # List all downtimed instances
     "dominant-dc") dominant_dc ;;                               # Name the data center where most masters are found
+    "submit-masters-to-kv-stores") submit_masters_to_kv_stores;;# Submit a cluster's master, or all clusters' masters to KV stores
 
     "relocate") general_relocate_command ;;                   # Relocate a replica beneath another instance
     "relocate-replicas") general_relocate_replicas_command ;; # Relocates all or part of the replicas of a given instance under another instance

--- a/vendor/github.com/armon/consul-api/.gitignore
+++ b/vendor/github.com/armon/consul-api/.gitignore
@@ -1,0 +1,23 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test

--- a/vendor/github.com/armon/consul-api/LICENSE
+++ b/vendor/github.com/armon/consul-api/LICENSE
@@ -1,0 +1,362 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/armon/consul-api/README.md
+++ b/vendor/github.com/armon/consul-api/README.md
@@ -1,0 +1,42 @@
+consul-api
+==========
+
+*DEPRECATED* Please use [consul api package](https://github.com/hashicorp/consul/tree/master/api) instead.
+Godocs for that package [are here](http://godoc.org/github.com/hashicorp/consul/api).
+
+This package provides the `consulapi` package which attempts to
+provide programmatic access to the full Consul API.
+
+Currently, all of the Consul APIs included in version 0.4 are supported.
+
+Documentation
+=============
+
+The full documentation is available on [Godoc](http://godoc.org/github.com/armon/consul-api)
+
+Usage
+=====
+
+Below is an example of using the Consul client:
+
+```go
+// Get a new client, with KV endpoints
+client, _ := consulapi.NewClient(consulapi.DefaultConfig())
+kv := client.KV()
+
+// PUT a new KV pair
+p := &consulapi.KVPair{Key: "foo", Value: []byte("test")}
+_, err := kv.Put(p, nil)
+if err != nil {
+    panic(err)
+}
+
+// Lookup the pair
+pair, _, err := kv.Get("foo", nil)
+if err != nil {
+    panic(err)
+}
+fmt.Printf("KV: %v", pair)
+
+```
+

--- a/vendor/github.com/armon/consul-api/acl.go
+++ b/vendor/github.com/armon/consul-api/acl.go
@@ -1,0 +1,140 @@
+package consulapi
+
+const (
+	// ACLCLientType is the client type token
+	ACLClientType = "client"
+
+	// ACLManagementType is the management type token
+	ACLManagementType = "management"
+)
+
+// ACLEntry is used to represent an ACL entry
+type ACLEntry struct {
+	CreateIndex uint64
+	ModifyIndex uint64
+	ID          string
+	Name        string
+	Type        string
+	Rules       string
+}
+
+// ACL can be used to query the ACL endpoints
+type ACL struct {
+	c *Client
+}
+
+// ACL returns a handle to the ACL endpoints
+func (c *Client) ACL() *ACL {
+	return &ACL{c}
+}
+
+// Create is used to generate a new token with the given parameters
+func (a *ACL) Create(acl *ACLEntry, q *WriteOptions) (string, *WriteMeta, error) {
+	r := a.c.newRequest("PUT", "/v1/acl/create")
+	r.setWriteOptions(q)
+	r.obj = acl
+	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return "", nil, err
+	}
+	defer resp.Body.Close()
+
+	wm := &WriteMeta{RequestTime: rtt}
+	var out struct{ ID string }
+	if err := decodeBody(resp, &out); err != nil {
+		return "", nil, err
+	}
+	return out.ID, wm, nil
+}
+
+// Update is used to update the rules of an existing token
+func (a *ACL) Update(acl *ACLEntry, q *WriteOptions) (*WriteMeta, error) {
+	r := a.c.newRequest("PUT", "/v1/acl/update")
+	r.setWriteOptions(q)
+	r.obj = acl
+	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	wm := &WriteMeta{RequestTime: rtt}
+	return wm, nil
+}
+
+// Destroy is used to destroy a given ACL token ID
+func (a *ACL) Destroy(id string, q *WriteOptions) (*WriteMeta, error) {
+	r := a.c.newRequest("PUT", "/v1/acl/destroy/"+id)
+	r.setWriteOptions(q)
+	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	wm := &WriteMeta{RequestTime: rtt}
+	return wm, nil
+}
+
+// Clone is used to return a new token cloned from an existing one
+func (a *ACL) Clone(id string, q *WriteOptions) (string, *WriteMeta, error) {
+	r := a.c.newRequest("PUT", "/v1/acl/clone/"+id)
+	r.setWriteOptions(q)
+	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return "", nil, err
+	}
+	defer resp.Body.Close()
+
+	wm := &WriteMeta{RequestTime: rtt}
+	var out struct{ ID string }
+	if err := decodeBody(resp, &out); err != nil {
+		return "", nil, err
+	}
+	return out.ID, wm, nil
+}
+
+// Info is used to query for information about an ACL token
+func (a *ACL) Info(id string, q *QueryOptions) (*ACLEntry, *QueryMeta, error) {
+	r := a.c.newRequest("GET", "/v1/acl/info/"+id)
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var entries []*ACLEntry
+	if err := decodeBody(resp, &entries); err != nil {
+		return nil, nil, err
+	}
+	if len(entries) > 0 {
+		return entries[0], qm, nil
+	}
+	return nil, qm, nil
+}
+
+// List is used to get all the ACL tokens
+func (a *ACL) List(q *QueryOptions) ([]*ACLEntry, *QueryMeta, error) {
+	r := a.c.newRequest("GET", "/v1/acl/list")
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var entries []*ACLEntry
+	if err := decodeBody(resp, &entries); err != nil {
+		return nil, nil, err
+	}
+	return entries, qm, nil
+}

--- a/vendor/github.com/armon/consul-api/acl_test.go
+++ b/vendor/github.com/armon/consul-api/acl_test.go
@@ -1,0 +1,140 @@
+package consulapi
+
+import (
+	"os"
+	"testing"
+)
+
+// ROOT is a management token for the tests
+var CONSUL_ROOT string
+
+func init() {
+	CONSUL_ROOT = os.Getenv("CONSUL_ROOT")
+}
+
+func TestACL_CreateDestroy(t *testing.T) {
+	if CONSUL_ROOT == "" {
+		t.SkipNow()
+	}
+	c := makeClient(t)
+	c.config.Token = CONSUL_ROOT
+	acl := c.ACL()
+
+	ae := ACLEntry{
+		Name:  "API test",
+		Type:  ACLClientType,
+		Rules: `key "" { policy = "deny" }`,
+	}
+
+	id, wm, err := acl.Create(&ae, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if wm.RequestTime == 0 {
+		t.Fatalf("bad: %v", wm)
+	}
+
+	if id == "" {
+		t.Fatalf("invalid: %v", id)
+	}
+
+	ae2, _, err := acl.Info(id, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if ae2.Name != ae.Name || ae2.Type != ae.Type || ae2.Rules != ae.Rules {
+		t.Fatalf("Bad: %#v", ae2)
+	}
+
+	wm, err = acl.Destroy(id, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if wm.RequestTime == 0 {
+		t.Fatalf("bad: %v", wm)
+	}
+}
+
+func TestACL_CloneDestroy(t *testing.T) {
+	if CONSUL_ROOT == "" {
+		t.SkipNow()
+	}
+	c := makeClient(t)
+	c.config.Token = CONSUL_ROOT
+	acl := c.ACL()
+
+	id, wm, err := acl.Clone(CONSUL_ROOT, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if wm.RequestTime == 0 {
+		t.Fatalf("bad: %v", wm)
+	}
+
+	if id == "" {
+		t.Fatalf("invalid: %v", id)
+	}
+
+	wm, err = acl.Destroy(id, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if wm.RequestTime == 0 {
+		t.Fatalf("bad: %v", wm)
+	}
+}
+
+func TestACL_Info(t *testing.T) {
+	if CONSUL_ROOT == "" {
+		t.SkipNow()
+	}
+	c := makeClient(t)
+	c.config.Token = CONSUL_ROOT
+	acl := c.ACL()
+
+	ae, qm, err := acl.Info(CONSUL_ROOT, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if qm.LastIndex == 0 {
+		t.Fatalf("bad: %v", qm)
+	}
+	if !qm.KnownLeader {
+		t.Fatalf("bad: %v", qm)
+	}
+
+	if ae == nil || ae.ID != CONSUL_ROOT || ae.Type != ACLManagementType {
+		t.Fatalf("bad: %#v", ae)
+	}
+}
+
+func TestACL_List(t *testing.T) {
+	if CONSUL_ROOT == "" {
+		t.SkipNow()
+	}
+	c := makeClient(t)
+	c.config.Token = CONSUL_ROOT
+	acl := c.ACL()
+
+	acls, qm, err := acl.List(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(acls) < 2 {
+		t.Fatalf("bad: %v", acls)
+	}
+
+	if qm.LastIndex == 0 {
+		t.Fatalf("bad: %v", qm)
+	}
+	if !qm.KnownLeader {
+		t.Fatalf("bad: %v", qm)
+	}
+}

--- a/vendor/github.com/armon/consul-api/agent.go
+++ b/vendor/github.com/armon/consul-api/agent.go
@@ -1,0 +1,272 @@
+package consulapi
+
+import (
+	"fmt"
+)
+
+// AgentCheck represents a check known to the agent
+type AgentCheck struct {
+	Node        string
+	CheckID     string
+	Name        string
+	Status      string
+	Notes       string
+	Output      string
+	ServiceID   string
+	ServiceName string
+}
+
+// AgentService represents a service known to the agent
+type AgentService struct {
+	ID      string
+	Service string
+	Tags    []string
+	Port    int
+}
+
+// AgentMember represents a cluster member known to the agent
+type AgentMember struct {
+	Name        string
+	Addr        string
+	Port        uint16
+	Tags        map[string]string
+	Status      int
+	ProtocolMin uint8
+	ProtocolMax uint8
+	ProtocolCur uint8
+	DelegateMin uint8
+	DelegateMax uint8
+	DelegateCur uint8
+}
+
+// AgentServiceRegistration is used to register a new service
+type AgentServiceRegistration struct {
+	ID    string   `json:",omitempty"`
+	Name  string   `json:",omitempty"`
+	Tags  []string `json:",omitempty"`
+	Port  int      `json:",omitempty"`
+	Check *AgentServiceCheck
+}
+
+// AgentCheckRegistration is used to register a new check
+type AgentCheckRegistration struct {
+	ID    string `json:",omitempty"`
+	Name  string `json:",omitempty"`
+	Notes string `json:",omitempty"`
+	AgentServiceCheck
+}
+
+// AgentServiceCheck is used to create an associated
+// check for a service
+type AgentServiceCheck struct {
+	Script   string `json:",omitempty"`
+	Interval string `json:",omitempty"`
+	TTL      string `json:",omitempty"`
+}
+
+// Agent can be used to query the Agent endpoints
+type Agent struct {
+	c *Client
+
+	// cache the node name
+	nodeName string
+}
+
+// Agent returns a handle to the agent endpoints
+func (c *Client) Agent() *Agent {
+	return &Agent{c: c}
+}
+
+// Self is used to query the agent we are speaking to for
+// information about itself
+func (a *Agent) Self() (map[string]map[string]interface{}, error) {
+	r := a.c.newRequest("GET", "/v1/agent/self")
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var out map[string]map[string]interface{}
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// NodeName is used to get the node name of the agent
+func (a *Agent) NodeName() (string, error) {
+	if a.nodeName != "" {
+		return a.nodeName, nil
+	}
+	info, err := a.Self()
+	if err != nil {
+		return "", err
+	}
+	name := info["Config"]["NodeName"].(string)
+	a.nodeName = name
+	return name, nil
+}
+
+// Checks returns the locally registered checks
+func (a *Agent) Checks() (map[string]*AgentCheck, error) {
+	r := a.c.newRequest("GET", "/v1/agent/checks")
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var out map[string]*AgentCheck
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Services returns the locally registered services
+func (a *Agent) Services() (map[string]*AgentService, error) {
+	r := a.c.newRequest("GET", "/v1/agent/services")
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var out map[string]*AgentService
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Members returns the known gossip members. The WAN
+// flag can be used to query a server for WAN members.
+func (a *Agent) Members(wan bool) ([]*AgentMember, error) {
+	r := a.c.newRequest("GET", "/v1/agent/members")
+	if wan {
+		r.params.Set("wan", "1")
+	}
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var out []*AgentMember
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ServiceRegister is used to register a new service with
+// the local agent
+func (a *Agent) ServiceRegister(service *AgentServiceRegistration) error {
+	r := a.c.newRequest("PUT", "/v1/agent/service/register")
+	r.obj = service
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// ServiceDeregister is used to deregister a service with
+// the local agent
+func (a *Agent) ServiceDeregister(serviceID string) error {
+	r := a.c.newRequest("PUT", "/v1/agent/service/deregister/"+serviceID)
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// PassTTL is used to set a TTL check to the passing state
+func (a *Agent) PassTTL(checkID, note string) error {
+	return a.UpdateTTL(checkID, note, "pass")
+}
+
+// WarnTTL is used to set a TTL check to the warning state
+func (a *Agent) WarnTTL(checkID, note string) error {
+	return a.UpdateTTL(checkID, note, "warn")
+}
+
+// FailTTL is used to set a TTL check to the failing state
+func (a *Agent) FailTTL(checkID, note string) error {
+	return a.UpdateTTL(checkID, note, "fail")
+}
+
+// UpdateTTL is used to update the TTL of a check
+func (a *Agent) UpdateTTL(checkID, note, status string) error {
+	switch status {
+	case "pass":
+	case "warn":
+	case "fail":
+	default:
+		return fmt.Errorf("Invalid status: %s", status)
+	}
+	endpoint := fmt.Sprintf("/v1/agent/check/%s/%s", status, checkID)
+	r := a.c.newRequest("PUT", endpoint)
+	r.params.Set("note", note)
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// CheckRegister is used to register a new check with
+// the local agent
+func (a *Agent) CheckRegister(check *AgentCheckRegistration) error {
+	r := a.c.newRequest("PUT", "/v1/agent/check/register")
+	r.obj = check
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// CheckDeregister is used to deregister a check with
+// the local agent
+func (a *Agent) CheckDeregister(checkID string) error {
+	r := a.c.newRequest("PUT", "/v1/agent/check/deregister/"+checkID)
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// Join is used to instruct the agent to attempt a join to
+// another cluster member
+func (a *Agent) Join(addr string, wan bool) error {
+	r := a.c.newRequest("PUT", "/v1/agent/join/"+addr)
+	if wan {
+		r.params.Set("wan", "1")
+	}
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// ForceLeave is used to have the agent eject a failed node
+func (a *Agent) ForceLeave(node string) error {
+	r := a.c.newRequest("PUT", "/v1/agent/force-leave/"+node)
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/vendor/github.com/armon/consul-api/agent_test.go
+++ b/vendor/github.com/armon/consul-api/agent_test.go
@@ -1,0 +1,162 @@
+package consulapi
+
+import (
+	"testing"
+)
+
+func TestAgent_Self(t *testing.T) {
+	c := makeClient(t)
+	agent := c.Agent()
+
+	info, err := agent.Self()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	name := info["Config"]["NodeName"]
+	if name == "" {
+		t.Fatalf("bad: %v", info)
+	}
+}
+
+func TestAgent_Members(t *testing.T) {
+	c := makeClient(t)
+	agent := c.Agent()
+
+	members, err := agent.Members(false)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(members) != 1 {
+		t.Fatalf("bad: %v", members)
+	}
+}
+
+func TestAgent_Services(t *testing.T) {
+	c := makeClient(t)
+	agent := c.Agent()
+
+	reg := &AgentServiceRegistration{
+		Name: "foo",
+		Tags: []string{"bar", "baz"},
+		Port: 8000,
+		Check: &AgentServiceCheck{
+			TTL: "15s",
+		},
+	}
+	if err := agent.ServiceRegister(reg); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	services, err := agent.Services()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, ok := services["foo"]; !ok {
+		t.Fatalf("missing service: %v", services)
+	}
+
+	checks, err := agent.Checks()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, ok := checks["service:foo"]; !ok {
+		t.Fatalf("missing check: %v", checks)
+	}
+
+	if err := agent.ServiceDeregister("foo"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestAgent_SetTTLStatus(t *testing.T) {
+	c := makeClient(t)
+	agent := c.Agent()
+
+	reg := &AgentServiceRegistration{
+		Name: "foo",
+		Check: &AgentServiceCheck{
+			TTL: "15s",
+		},
+	}
+	if err := agent.ServiceRegister(reg); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if err := agent.WarnTTL("service:foo", "test"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	checks, err := agent.Checks()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	chk, ok := checks["service:foo"]
+	if !ok {
+		t.Fatalf("missing check: %v", checks)
+	}
+	if chk.Status != "warning" {
+		t.Fatalf("Bad: %#v", chk)
+	}
+	if chk.Output != "test" {
+		t.Fatalf("Bad: %#v", chk)
+	}
+
+	if err := agent.ServiceDeregister("foo"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestAgent_Checks(t *testing.T) {
+	c := makeClient(t)
+	agent := c.Agent()
+
+	reg := &AgentCheckRegistration{
+		Name: "foo",
+	}
+	reg.TTL = "15s"
+	if err := agent.CheckRegister(reg); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	checks, err := agent.Checks()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, ok := checks["foo"]; !ok {
+		t.Fatalf("missing check: %v", checks)
+	}
+
+	if err := agent.CheckDeregister("foo"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestAgent_Join(t *testing.T) {
+	c := makeClient(t)
+	agent := c.Agent()
+
+	info, err := agent.Self()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Join ourself
+	addr := info["Config"]["AdvertiseAddr"].(string)
+	err = agent.Join(addr, false)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestAgent_ForceLeave(t *testing.T) {
+	c := makeClient(t)
+	agent := c.Agent()
+
+	// Eject somebody
+	err := agent.ForceLeave("foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}

--- a/vendor/github.com/armon/consul-api/api.go
+++ b/vendor/github.com/armon/consul-api/api.go
@@ -1,0 +1,323 @@
+package consulapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// QueryOptions are used to parameterize a query
+type QueryOptions struct {
+	// Providing a datacenter overwrites the DC provided
+	// by the Config
+	Datacenter string
+
+	// AllowStale allows any Consul server (non-leader) to service
+	// a read. This allows for lower latency and higher throughput
+	AllowStale bool
+
+	// RequireConsistent forces the read to be fully consistent.
+	// This is more expensive but prevents ever performing a stale
+	// read.
+	RequireConsistent bool
+
+	// WaitIndex is used to enable a blocking query. Waits
+	// until the timeout or the next index is reached
+	WaitIndex uint64
+
+	// WaitTime is used to bound the duration of a wait.
+	// Defaults to that of the Config, but can be overriden.
+	WaitTime time.Duration
+
+	// Token is used to provide a per-request ACL token
+	// which overrides the agent's default token.
+	Token string
+}
+
+// WriteOptions are used to parameterize a write
+type WriteOptions struct {
+	// Providing a datacenter overwrites the DC provided
+	// by the Config
+	Datacenter string
+
+	// Token is used to provide a per-request ACL token
+	// which overrides the agent's default token.
+	Token string
+}
+
+// QueryMeta is used to return meta data about a query
+type QueryMeta struct {
+	// LastIndex. This can be used as a WaitIndex to perform
+	// a blocking query
+	LastIndex uint64
+
+	// Time of last contact from the leader for the
+	// server servicing the request
+	LastContact time.Duration
+
+	// Is there a known leader
+	KnownLeader bool
+
+	// How long did the request take
+	RequestTime time.Duration
+}
+
+// WriteMeta is used to return meta data about a write
+type WriteMeta struct {
+	// How long did the request take
+	RequestTime time.Duration
+}
+
+// HttpBasicAuth is used to authenticate http client with HTTP Basic Authentication
+type HttpBasicAuth struct {
+	// Username to use for HTTP Basic Authentication
+	Username string
+
+	// Password to use for HTTP Basic Authentication
+	Password string
+}
+
+// Config is used to configure the creation of a client
+type Config struct {
+	// Address is the address of the Consul server
+	Address string
+
+	// Scheme is the URI scheme for the Consul server
+	Scheme string
+
+	// Datacenter to use. If not provided, the default agent datacenter is used.
+	Datacenter string
+
+	// HttpClient is the client to use. Default will be
+	// used if not provided.
+	HttpClient *http.Client
+
+	// HttpAuth is the auth info to use for http access.
+	HttpAuth *HttpBasicAuth
+
+	// WaitTime limits how long a Watch will block. If not provided,
+	// the agent default values will be used.
+	WaitTime time.Duration
+
+	// Token is used to provide a per-request ACL token
+	// which overrides the agent's default token.
+	Token string
+}
+
+// DefaultConfig returns a default configuration for the client
+func DefaultConfig() *Config {
+	return &Config{
+		Address:    "127.0.0.1:8500",
+		Scheme:     "http",
+		HttpClient: http.DefaultClient,
+	}
+}
+
+// Client provides a client to the Consul API
+type Client struct {
+	config Config
+}
+
+// NewClient returns a new client
+func NewClient(config *Config) (*Client, error) {
+	// bootstrap the config
+	defConfig := DefaultConfig()
+
+	if len(config.Address) == 0 {
+		config.Address = defConfig.Address
+	}
+
+	if len(config.Scheme) == 0 {
+		config.Scheme = defConfig.Scheme
+	}
+
+	if config.HttpClient == nil {
+		config.HttpClient = defConfig.HttpClient
+	}
+
+	client := &Client{
+		config: *config,
+	}
+	return client, nil
+}
+
+// request is used to help build up a request
+type request struct {
+	config *Config
+	method string
+	url    *url.URL
+	params url.Values
+	body   io.Reader
+	obj    interface{}
+}
+
+// setQueryOptions is used to annotate the request with
+// additional query options
+func (r *request) setQueryOptions(q *QueryOptions) {
+	if q == nil {
+		return
+	}
+	if q.Datacenter != "" {
+		r.params.Set("dc", q.Datacenter)
+	}
+	if q.AllowStale {
+		r.params.Set("stale", "")
+	}
+	if q.RequireConsistent {
+		r.params.Set("consistent", "")
+	}
+	if q.WaitIndex != 0 {
+		r.params.Set("index", strconv.FormatUint(q.WaitIndex, 10))
+	}
+	if q.WaitTime != 0 {
+		r.params.Set("wait", durToMsec(q.WaitTime))
+	}
+	if q.Token != "" {
+		r.params.Set("token", q.Token)
+	}
+}
+
+// durToMsec converts a duration to a millisecond specified string
+func durToMsec(dur time.Duration) string {
+	return fmt.Sprintf("%dms", dur/time.Millisecond)
+}
+
+// setWriteOptions is used to annotate the request with
+// additional write options
+func (r *request) setWriteOptions(q *WriteOptions) {
+	if q == nil {
+		return
+	}
+	if q.Datacenter != "" {
+		r.params.Set("dc", q.Datacenter)
+	}
+	if q.Token != "" {
+		r.params.Set("token", q.Token)
+	}
+}
+
+// toHTTP converts the request to an HTTP request
+func (r *request) toHTTP() (*http.Request, error) {
+	// Encode the query parameters
+	r.url.RawQuery = r.params.Encode()
+
+	// Get the url sring
+	urlRaw := r.url.String()
+
+	// Check if we should encode the body
+	if r.body == nil && r.obj != nil {
+		if b, err := encodeBody(r.obj); err != nil {
+			return nil, err
+		} else {
+			r.body = b
+		}
+	}
+
+	// Create the HTTP request
+	req, err := http.NewRequest(r.method, urlRaw, r.body)
+
+	// Setup auth
+	if err == nil && r.config.HttpAuth != nil {
+		req.SetBasicAuth(r.config.HttpAuth.Username, r.config.HttpAuth.Password)
+	}
+
+	return req, err
+}
+
+// newRequest is used to create a new request
+func (c *Client) newRequest(method, path string) *request {
+	r := &request{
+		config: &c.config,
+		method: method,
+		url: &url.URL{
+			Scheme: c.config.Scheme,
+			Host:   c.config.Address,
+			Path:   path,
+		},
+		params: make(map[string][]string),
+	}
+	if c.config.Datacenter != "" {
+		r.params.Set("dc", c.config.Datacenter)
+	}
+	if c.config.WaitTime != 0 {
+		r.params.Set("wait", durToMsec(r.config.WaitTime))
+	}
+	if c.config.Token != "" {
+		r.params.Set("token", r.config.Token)
+	}
+	return r
+}
+
+// doRequest runs a request with our client
+func (c *Client) doRequest(r *request) (time.Duration, *http.Response, error) {
+	req, err := r.toHTTP()
+	if err != nil {
+		return 0, nil, err
+	}
+	start := time.Now()
+	resp, err := c.config.HttpClient.Do(req)
+	diff := time.Now().Sub(start)
+	return diff, resp, err
+}
+
+// parseQueryMeta is used to help parse query meta-data
+func parseQueryMeta(resp *http.Response, q *QueryMeta) error {
+	header := resp.Header
+
+	// Parse the X-Consul-Index
+	index, err := strconv.ParseUint(header.Get("X-Consul-Index"), 10, 64)
+	if err != nil {
+		return fmt.Errorf("Failed to parse X-Consul-Index: %v", err)
+	}
+	q.LastIndex = index
+
+	// Parse the X-Consul-LastContact
+	last, err := strconv.ParseUint(header.Get("X-Consul-LastContact"), 10, 64)
+	if err != nil {
+		return fmt.Errorf("Failed to parse X-Consul-LastContact: %v", err)
+	}
+	q.LastContact = time.Duration(last) * time.Millisecond
+
+	// Parse the X-Consul-KnownLeader
+	switch header.Get("X-Consul-KnownLeader") {
+	case "true":
+		q.KnownLeader = true
+	default:
+		q.KnownLeader = false
+	}
+	return nil
+}
+
+// decodeBody is used to JSON decode a body
+func decodeBody(resp *http.Response, out interface{}) error {
+	dec := json.NewDecoder(resp.Body)
+	return dec.Decode(out)
+}
+
+// encodeBody is used to encode a request body
+func encodeBody(obj interface{}) (io.Reader, error) {
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	if err := enc.Encode(obj); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// requireOK is used to wrap doRequest and check for a 200
+func requireOK(d time.Duration, resp *http.Response, e error) (time.Duration, *http.Response, error) {
+	if e != nil {
+		return d, resp, e
+	}
+	if resp.StatusCode != 200 {
+		var buf bytes.Buffer
+		io.Copy(&buf, resp.Body)
+		return d, resp, fmt.Errorf("Unexpected response code: %d (%s)", resp.StatusCode, buf.Bytes())
+	}
+	return d, resp, e
+}

--- a/vendor/github.com/armon/consul-api/api_test.go
+++ b/vendor/github.com/armon/consul-api/api_test.go
@@ -1,0 +1,126 @@
+package consulapi
+
+import (
+	crand "crypto/rand"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func makeClient(t *testing.T) *Client {
+	conf := DefaultConfig()
+	client, err := NewClient(conf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	return client
+}
+
+func testKey() string {
+	buf := make([]byte, 16)
+	if _, err := crand.Read(buf); err != nil {
+		panic(fmt.Errorf("Failed to read random bytes: %v", err))
+	}
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
+		buf[0:4],
+		buf[4:6],
+		buf[6:8],
+		buf[8:10],
+		buf[10:16])
+}
+
+func TestSetQueryOptions(t *testing.T) {
+	c := makeClient(t)
+	r := c.newRequest("GET", "/v1/kv/foo")
+	q := &QueryOptions{
+		Datacenter:        "foo",
+		AllowStale:        true,
+		RequireConsistent: true,
+		WaitIndex:         1000,
+		WaitTime:          100 * time.Second,
+		Token:             "12345",
+	}
+	r.setQueryOptions(q)
+
+	if r.params.Get("dc") != "foo" {
+		t.Fatalf("bad: %v", r.params)
+	}
+	if _, ok := r.params["stale"]; !ok {
+		t.Fatalf("bad: %v", r.params)
+	}
+	if _, ok := r.params["consistent"]; !ok {
+		t.Fatalf("bad: %v", r.params)
+	}
+	if r.params.Get("index") != "1000" {
+		t.Fatalf("bad: %v", r.params)
+	}
+	if r.params.Get("wait") != "100000ms" {
+		t.Fatalf("bad: %v", r.params)
+	}
+	if r.params.Get("token") != "12345" {
+		t.Fatalf("bad: %v", r.params)
+	}
+}
+
+func TestSetWriteOptions(t *testing.T) {
+	c := makeClient(t)
+	r := c.newRequest("GET", "/v1/kv/foo")
+	q := &WriteOptions{
+		Datacenter: "foo",
+		Token:      "23456",
+	}
+	r.setWriteOptions(q)
+
+	if r.params.Get("dc") != "foo" {
+		t.Fatalf("bad: %v", r.params)
+	}
+	if r.params.Get("token") != "23456" {
+		t.Fatalf("bad: %v", r.params)
+	}
+}
+
+func TestRequestToHTTP(t *testing.T) {
+	c := makeClient(t)
+	r := c.newRequest("DELETE", "/v1/kv/foo")
+	q := &QueryOptions{
+		Datacenter: "foo",
+	}
+	r.setQueryOptions(q)
+	req, err := r.toHTTP()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if req.Method != "DELETE" {
+		t.Fatalf("bad: %v", req)
+	}
+	if req.URL.String() != "http://127.0.0.1:8500/v1/kv/foo?dc=foo" {
+		t.Fatalf("bad: %v", req)
+	}
+}
+
+func TestParseQueryMeta(t *testing.T) {
+	resp := &http.Response{
+		Header: make(map[string][]string),
+	}
+	resp.Header.Set("X-Consul-Index", "12345")
+	resp.Header.Set("X-Consul-LastContact", "80")
+	resp.Header.Set("X-Consul-KnownLeader", "true")
+
+	qm := &QueryMeta{}
+	if err := parseQueryMeta(resp, qm); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if qm.LastIndex != 12345 {
+		t.Fatalf("Bad: %v", qm)
+	}
+	if qm.LastContact != 80*time.Millisecond {
+		t.Fatalf("Bad: %v", qm)
+	}
+	if !qm.KnownLeader {
+		t.Fatalf("Bad: %v", qm)
+	}
+}

--- a/vendor/github.com/armon/consul-api/catalog.go
+++ b/vendor/github.com/armon/consul-api/catalog.go
@@ -1,0 +1,181 @@
+package consulapi
+
+type Node struct {
+	Node    string
+	Address string
+}
+
+type CatalogService struct {
+	Node        string
+	Address     string
+	ServiceID   string
+	ServiceName string
+	ServiceTags []string
+	ServicePort int
+}
+
+type CatalogNode struct {
+	Node     *Node
+	Services map[string]*AgentService
+}
+
+type CatalogRegistration struct {
+	Node       string
+	Address    string
+	Datacenter string
+	Service    *AgentService
+	Check      *AgentCheck
+}
+
+type CatalogDeregistration struct {
+	Node       string
+	Address    string
+	Datacenter string
+	ServiceID  string
+	CheckID    string
+}
+
+// Catalog can be used to query the Catalog endpoints
+type Catalog struct {
+	c *Client
+}
+
+// Catalog returns a handle to the catalog endpoints
+func (c *Client) Catalog() *Catalog {
+	return &Catalog{c}
+}
+
+func (c *Catalog) Register(reg *CatalogRegistration, q *WriteOptions) (*WriteMeta, error) {
+	r := c.c.newRequest("PUT", "/v1/catalog/register")
+	r.setWriteOptions(q)
+	r.obj = reg
+	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	wm := &WriteMeta{}
+	wm.RequestTime = rtt
+
+	return wm, nil
+}
+
+func (c *Catalog) Deregister(dereg *CatalogDeregistration, q *WriteOptions) (*WriteMeta, error) {
+	r := c.c.newRequest("PUT", "/v1/catalog/deregister")
+	r.setWriteOptions(q)
+	r.obj = dereg
+	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	wm := &WriteMeta{}
+	wm.RequestTime = rtt
+
+	return wm, nil
+}
+
+// Datacenters is used to query for all the known datacenters
+func (c *Catalog) Datacenters() ([]string, error) {
+	r := c.c.newRequest("GET", "/v1/catalog/datacenters")
+	_, resp, err := requireOK(c.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var out []string
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Nodes is used to query all the known nodes
+func (c *Catalog) Nodes(q *QueryOptions) ([]*Node, *QueryMeta, error) {
+	r := c.c.newRequest("GET", "/v1/catalog/nodes")
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var out []*Node
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, nil, err
+	}
+	return out, qm, nil
+}
+
+// Services is used to query for all known services
+func (c *Catalog) Services(q *QueryOptions) (map[string][]string, *QueryMeta, error) {
+	r := c.c.newRequest("GET", "/v1/catalog/services")
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var out map[string][]string
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, nil, err
+	}
+	return out, qm, nil
+}
+
+// Service is used to query catalog entries for a given service
+func (c *Catalog) Service(service, tag string, q *QueryOptions) ([]*CatalogService, *QueryMeta, error) {
+	r := c.c.newRequest("GET", "/v1/catalog/service/"+service)
+	r.setQueryOptions(q)
+	if tag != "" {
+		r.params.Set("tag", tag)
+	}
+	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var out []*CatalogService
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, nil, err
+	}
+	return out, qm, nil
+}
+
+// Node is used to query for service information about a single node
+func (c *Catalog) Node(node string, q *QueryOptions) (*CatalogNode, *QueryMeta, error) {
+	r := c.c.newRequest("GET", "/v1/catalog/node/"+node)
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var out *CatalogNode
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, nil, err
+	}
+	return out, qm, nil
+}

--- a/vendor/github.com/armon/consul-api/catalog_test.go
+++ b/vendor/github.com/armon/consul-api/catalog_test.go
@@ -1,0 +1,219 @@
+package consulapi
+
+import (
+	"testing"
+)
+
+func TestCatalog_Datacenters(t *testing.T) {
+	c := makeClient(t)
+	catalog := c.Catalog()
+
+	datacenters, err := catalog.Datacenters()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(datacenters) == 0 {
+		t.Fatalf("Bad: %v", datacenters)
+	}
+}
+
+func TestCatalog_Nodes(t *testing.T) {
+	c := makeClient(t)
+	catalog := c.Catalog()
+
+	nodes, meta, err := catalog.Nodes(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if meta.LastIndex == 0 {
+		t.Fatalf("Bad: %v", meta)
+	}
+
+	if len(nodes) == 0 {
+		t.Fatalf("Bad: %v", nodes)
+	}
+}
+
+func TestCatalog_Services(t *testing.T) {
+	c := makeClient(t)
+	catalog := c.Catalog()
+
+	services, meta, err := catalog.Services(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if meta.LastIndex == 0 {
+		t.Fatalf("Bad: %v", meta)
+	}
+
+	if len(services) == 0 {
+		t.Fatalf("Bad: %v", services)
+	}
+}
+
+func TestCatalog_Service(t *testing.T) {
+	c := makeClient(t)
+	catalog := c.Catalog()
+
+	services, meta, err := catalog.Service("consul", "", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if meta.LastIndex == 0 {
+		t.Fatalf("Bad: %v", meta)
+	}
+
+	if len(services) == 0 {
+		t.Fatalf("Bad: %v", services)
+	}
+}
+
+func TestCatalog_Node(t *testing.T) {
+	c := makeClient(t)
+	catalog := c.Catalog()
+
+	name, _ := c.Agent().NodeName()
+	info, meta, err := catalog.Node(name, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if meta.LastIndex == 0 {
+		t.Fatalf("Bad: %v", meta)
+	}
+	if len(info.Services) == 0 {
+		t.Fatalf("Bad: %v", info)
+	}
+}
+
+func TestCatalog_Registration(t *testing.T) {
+	c := makeClient(t)
+	catalog := c.Catalog()
+
+	service := &AgentService{
+		ID:      "redis1",
+		Service: "redis",
+		Tags:    []string{"master", "v1"},
+		Port:    8000,
+	}
+
+	check := &AgentCheck{
+		Node:      "foobar",
+		CheckID:   "service:redis1",
+		Name:      "Redis health check",
+		Notes:     "Script based health check",
+		Status:    "passing",
+		ServiceID: "redis1",
+	}
+
+	reg := &CatalogRegistration{
+		Datacenter: "dc1",
+		Node:       "foobar",
+		Address:    "192.168.10.10",
+		Service:    service,
+		Check:      check,
+	}
+
+	_, err := catalog.Register(reg, nil)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	node, _, err := catalog.Node("foobar", nil)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if _, ok := node.Services["redis1"]; !ok {
+		t.Fatalf("missing service: redis1")
+	}
+
+	health, _, err := c.Health().Node("foobar", nil)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if health[0].CheckID != "service:redis1" {
+		t.Fatalf("missing checkid service:redis1")
+	}
+}
+
+func TestCatalog_Deregistration(t *testing.T) {
+	c := makeClient(t)
+	catalog := c.Catalog()
+
+	dereg := &CatalogDeregistration{
+		Datacenter: "dc1",
+		Node:       "foobar",
+		Address:    "192.168.10.10",
+		ServiceID:  "redis1",
+	}
+
+	_, err := catalog.Deregister(dereg, nil)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	node, _, err := catalog.Node("foobar", nil)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if _, ok := node.Services["redis1"]; ok {
+		t.Fatalf("ServiceID:redis1 is not deregistered")
+	}
+
+	dereg = &CatalogDeregistration{
+		Datacenter: "dc1",
+		Node:       "foobar",
+		Address:    "192.168.10.10",
+		CheckID:    "service:redis1",
+	}
+
+	_, err = catalog.Deregister(dereg, nil)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	health, _, err := c.Health().Node("foobar", nil)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(health) != 0 {
+		t.Fatalf("CheckID:service:redis1 is not deregistered")
+	}
+
+	dereg = &CatalogDeregistration{
+		Datacenter: "dc1",
+		Node:       "foobar",
+		Address:    "192.168.10.10",
+	}
+
+	_, err = catalog.Deregister(dereg, nil)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	node, _, err = catalog.Node("foobar", nil)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if node != nil {
+		t.Fatalf("node is not deregistered: %v", node)
+	}
+}

--- a/vendor/github.com/armon/consul-api/event.go
+++ b/vendor/github.com/armon/consul-api/event.go
@@ -1,0 +1,104 @@
+package consulapi
+
+import (
+	"bytes"
+	"strconv"
+)
+
+// Event can be used to query the Event endpoints
+type Event struct {
+	c *Client
+}
+
+// UserEvent represents an event that was fired by the user
+type UserEvent struct {
+	ID            string
+	Name          string
+	Payload       []byte
+	NodeFilter    string
+	ServiceFilter string
+	TagFilter     string
+	Version       int
+	LTime         uint64
+}
+
+// Event returns a handle to the event endpoints
+func (c *Client) Event() *Event {
+	return &Event{c}
+}
+
+// Fire is used to fire a new user event. Only the Name, Payload and Filters
+// are respected. This returns the ID or an associated error. Cross DC requests
+// are supported.
+func (e *Event) Fire(params *UserEvent, q *WriteOptions) (string, *WriteMeta, error) {
+	r := e.c.newRequest("PUT", "/v1/event/fire/"+params.Name)
+	r.setWriteOptions(q)
+	if params.NodeFilter != "" {
+		r.params.Set("node", params.NodeFilter)
+	}
+	if params.ServiceFilter != "" {
+		r.params.Set("service", params.ServiceFilter)
+	}
+	if params.TagFilter != "" {
+		r.params.Set("tag", params.TagFilter)
+	}
+	if params.Payload != nil {
+		r.body = bytes.NewReader(params.Payload)
+	}
+
+	rtt, resp, err := requireOK(e.c.doRequest(r))
+	if err != nil {
+		return "", nil, err
+	}
+	defer resp.Body.Close()
+
+	wm := &WriteMeta{RequestTime: rtt}
+	var out UserEvent
+	if err := decodeBody(resp, &out); err != nil {
+		return "", nil, err
+	}
+	return out.ID, wm, nil
+}
+
+// List is used to get the most recent events an agent has received.
+// This list can be optionally filtered by the name. This endpoint supports
+// quasi-blocking queries. The index is not monotonic, nor does it provide provide
+// LastContact or KnownLeader.
+func (e *Event) List(name string, q *QueryOptions) ([]*UserEvent, *QueryMeta, error) {
+	r := e.c.newRequest("GET", "/v1/event/list")
+	r.setQueryOptions(q)
+	if name != "" {
+		r.params.Set("name", name)
+	}
+	rtt, resp, err := requireOK(e.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var entries []*UserEvent
+	if err := decodeBody(resp, &entries); err != nil {
+		return nil, nil, err
+	}
+	return entries, qm, nil
+}
+
+// IDToIndex is a bit of a hack. This simulates the index generation to
+// convert an event ID into a WaitIndex.
+func (e *Event) IDToIndex(uuid string) uint64 {
+	lower := uuid[0:8] + uuid[9:13] + uuid[14:18]
+	upper := uuid[19:23] + uuid[24:36]
+	lowVal, err := strconv.ParseUint(lower, 16, 64)
+	if err != nil {
+		panic("Failed to convert " + lower)
+	}
+	highVal, err := strconv.ParseUint(upper, 16, 64)
+	if err != nil {
+		panic("Failed to convert " + upper)
+	}
+	return lowVal ^ highVal
+}

--- a/vendor/github.com/armon/consul-api/event_test.go
+++ b/vendor/github.com/armon/consul-api/event_test.go
@@ -1,0 +1,37 @@
+package consulapi
+
+import (
+	"testing"
+)
+
+func TestEvent_FireList(t *testing.T) {
+	c := makeClient(t)
+	event := c.Event()
+
+	params := &UserEvent{Name: "foo"}
+	id, meta, err := event.Fire(params, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if meta.RequestTime == 0 {
+		t.Fatalf("bad: %v", meta)
+	}
+
+	if id == "" {
+		t.Fatalf("invalid: %v", id)
+	}
+
+	events, qm, err := event.List("", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if qm.LastIndex != event.IDToIndex(id) {
+		t.Fatalf("Bad: %#v", qm)
+	}
+
+	if events[len(events)-1].ID != id {
+		t.Fatalf("bad: %#v", events)
+	}
+}

--- a/vendor/github.com/armon/consul-api/health.go
+++ b/vendor/github.com/armon/consul-api/health.go
@@ -1,0 +1,136 @@
+package consulapi
+
+import (
+	"fmt"
+)
+
+// HealthCheck is used to represent a single check
+type HealthCheck struct {
+	Node        string
+	CheckID     string
+	Name        string
+	Status      string
+	Notes       string
+	Output      string
+	ServiceID   string
+	ServiceName string
+}
+
+// ServiceEntry is used for the health service endpoint
+type ServiceEntry struct {
+	Node    *Node
+	Service *AgentService
+	Checks  []*HealthCheck
+}
+
+// Health can be used to query the Health endpoints
+type Health struct {
+	c *Client
+}
+
+// Health returns a handle to the health endpoints
+func (c *Client) Health() *Health {
+	return &Health{c}
+}
+
+// Node is used to query for checks belonging to a given node
+func (h *Health) Node(node string, q *QueryOptions) ([]*HealthCheck, *QueryMeta, error) {
+	r := h.c.newRequest("GET", "/v1/health/node/"+node)
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(h.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var out []*HealthCheck
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, nil, err
+	}
+	return out, qm, nil
+}
+
+// Checks is used to return the checks associated with a service
+func (h *Health) Checks(service string, q *QueryOptions) ([]*HealthCheck, *QueryMeta, error) {
+	r := h.c.newRequest("GET", "/v1/health/checks/"+service)
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(h.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var out []*HealthCheck
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, nil, err
+	}
+	return out, qm, nil
+}
+
+// Service is used to query health information along with service info
+// for a given service. It can optionally do server-side filtering on a tag
+// or nodes with passing health checks only.
+func (h *Health) Service(service, tag string, passingOnly bool, q *QueryOptions) ([]*ServiceEntry, *QueryMeta, error) {
+	r := h.c.newRequest("GET", "/v1/health/service/"+service)
+	r.setQueryOptions(q)
+	if tag != "" {
+		r.params.Set("tag", tag)
+	}
+	if passingOnly {
+		r.params.Set("passing", "1")
+	}
+	rtt, resp, err := requireOK(h.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var out []*ServiceEntry
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, nil, err
+	}
+	return out, qm, nil
+}
+
+// State is used to retreive all the checks in a given state.
+// The wildcard "any" state can also be used for all checks.
+func (h *Health) State(state string, q *QueryOptions) ([]*HealthCheck, *QueryMeta, error) {
+	switch state {
+	case "any":
+	case "warning":
+	case "critical":
+	case "passing":
+	case "unknown":
+	default:
+		return nil, nil, fmt.Errorf("Unsupported state: %v", state)
+	}
+	r := h.c.newRequest("GET", "/v1/health/state/"+state)
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(h.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var out []*HealthCheck
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, nil, err
+	}
+	return out, qm, nil
+}

--- a/vendor/github.com/armon/consul-api/health_test.go
+++ b/vendor/github.com/armon/consul-api/health_test.go
@@ -1,0 +1,98 @@
+package consulapi
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHealth_Node(t *testing.T) {
+	c := makeClient(t)
+	agent := c.Agent()
+	health := c.Health()
+
+	info, err := agent.Self()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	name := info["Config"]["NodeName"].(string)
+
+	checks, meta, err := health.Node(name, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if meta.LastIndex == 0 {
+		t.Fatalf("bad: %v", meta)
+	}
+	if len(checks) == 0 {
+		t.Fatalf("Bad: %v", checks)
+	}
+}
+
+func TestHealth_Checks(t *testing.T) {
+	c := makeClient(t)
+	agent := c.Agent()
+	health := c.Health()
+
+	// Make a service with a check
+	reg := &AgentServiceRegistration{
+		Name: "foo",
+		Check: &AgentServiceCheck{
+			TTL: "15s",
+		},
+	}
+	if err := agent.ServiceRegister(reg); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer agent.ServiceDeregister("foo")
+
+	// Wait for the register...
+	time.Sleep(20 * time.Millisecond)
+
+	checks, meta, err := health.Checks("foo", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if meta.LastIndex == 0 {
+		t.Fatalf("bad: %v", meta)
+	}
+	if len(checks) == 0 {
+		t.Fatalf("Bad: %v", checks)
+	}
+}
+
+func TestHealth_Service(t *testing.T) {
+	c := makeClient(t)
+	health := c.Health()
+
+	// consul service should always exist...
+	checks, meta, err := health.Service("consul", "", true, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if meta.LastIndex == 0 {
+		t.Fatalf("bad: %v", meta)
+	}
+	if len(checks) == 0 {
+		t.Fatalf("Bad: %v", checks)
+	}
+}
+
+func TestHealth_State(t *testing.T) {
+	c := makeClient(t)
+	health := c.Health()
+
+	checks, meta, err := health.State("any", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if meta.LastIndex == 0 {
+		t.Fatalf("bad: %v", meta)
+	}
+	if len(checks) == 0 {
+		t.Fatalf("Bad: %v", checks)
+	}
+}

--- a/vendor/github.com/armon/consul-api/kv.go
+++ b/vendor/github.com/armon/consul-api/kv.go
@@ -1,0 +1,219 @@
+package consulapi
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// KVPair is used to represent a single K/V entry
+type KVPair struct {
+	Key         string
+	CreateIndex uint64
+	ModifyIndex uint64
+	LockIndex   uint64
+	Flags       uint64
+	Value       []byte
+	Session     string
+}
+
+// KVPairs is a list of KVPair objects
+type KVPairs []*KVPair
+
+// KV is used to manipulate the K/V API
+type KV struct {
+	c *Client
+}
+
+// KV is used to return a handle to the K/V apis
+func (c *Client) KV() *KV {
+	return &KV{c}
+}
+
+// Get is used to lookup a single key
+func (k *KV) Get(key string, q *QueryOptions) (*KVPair, *QueryMeta, error) {
+	resp, qm, err := k.getInternal(key, nil, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp == nil {
+		return nil, qm, nil
+	}
+	defer resp.Body.Close()
+
+	var entries []*KVPair
+	if err := decodeBody(resp, &entries); err != nil {
+		return nil, nil, err
+	}
+	if len(entries) > 0 {
+		return entries[0], qm, nil
+	}
+	return nil, qm, nil
+}
+
+// List is used to lookup all keys under a prefix
+func (k *KV) List(prefix string, q *QueryOptions) (KVPairs, *QueryMeta, error) {
+	resp, qm, err := k.getInternal(prefix, map[string]string{"recurse": ""}, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp == nil {
+		return nil, qm, nil
+	}
+	defer resp.Body.Close()
+
+	var entries []*KVPair
+	if err := decodeBody(resp, &entries); err != nil {
+		return nil, nil, err
+	}
+	return entries, qm, nil
+}
+
+// Keys is used to list all the keys under a prefix. Optionally,
+// a separator can be used to limit the responses.
+func (k *KV) Keys(prefix, separator string, q *QueryOptions) ([]string, *QueryMeta, error) {
+	params := map[string]string{"keys": ""}
+	if separator != "" {
+		params["separator"] = separator
+	}
+	resp, qm, err := k.getInternal(prefix, params, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp == nil {
+		return nil, qm, nil
+	}
+	defer resp.Body.Close()
+
+	var entries []string
+	if err := decodeBody(resp, &entries); err != nil {
+		return nil, nil, err
+	}
+	return entries, qm, nil
+}
+
+func (k *KV) getInternal(key string, params map[string]string, q *QueryOptions) (*http.Response, *QueryMeta, error) {
+	r := k.c.newRequest("GET", "/v1/kv/"+key)
+	r.setQueryOptions(q)
+	for param, val := range params {
+		r.params.Set(param, val)
+	}
+	rtt, resp, err := k.c.doRequest(r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	if resp.StatusCode == 404 {
+		resp.Body.Close()
+		return nil, qm, nil
+	} else if resp.StatusCode != 200 {
+		resp.Body.Close()
+		return nil, nil, fmt.Errorf("Unexpected response code: %d", resp.StatusCode)
+	}
+	return resp, qm, nil
+}
+
+// Put is used to write a new value. Only the
+// Key, Flags and Value is respected.
+func (k *KV) Put(p *KVPair, q *WriteOptions) (*WriteMeta, error) {
+	params := make(map[string]string, 1)
+	if p.Flags != 0 {
+		params["flags"] = strconv.FormatUint(p.Flags, 10)
+	}
+	_, wm, err := k.put(p.Key, params, p.Value, q)
+	return wm, err
+}
+
+// CAS is used for a Check-And-Set operation. The Key,
+// ModifyIndex, Flags and Value are respected. Returns true
+// on success or false on failures.
+func (k *KV) CAS(p *KVPair, q *WriteOptions) (bool, *WriteMeta, error) {
+	params := make(map[string]string, 2)
+	if p.Flags != 0 {
+		params["flags"] = strconv.FormatUint(p.Flags, 10)
+	}
+	params["cas"] = strconv.FormatUint(p.ModifyIndex, 10)
+	return k.put(p.Key, params, p.Value, q)
+}
+
+// Acquire is used for a lock acquisiiton operation. The Key,
+// Flags, Value and Session are respected. Returns true
+// on success or false on failures.
+func (k *KV) Acquire(p *KVPair, q *WriteOptions) (bool, *WriteMeta, error) {
+	params := make(map[string]string, 2)
+	if p.Flags != 0 {
+		params["flags"] = strconv.FormatUint(p.Flags, 10)
+	}
+	params["acquire"] = p.Session
+	return k.put(p.Key, params, p.Value, q)
+}
+
+// Release is used for a lock release operation. The Key,
+// Flags, Value and Session are respected. Returns true
+// on success or false on failures.
+func (k *KV) Release(p *KVPair, q *WriteOptions) (bool, *WriteMeta, error) {
+	params := make(map[string]string, 2)
+	if p.Flags != 0 {
+		params["flags"] = strconv.FormatUint(p.Flags, 10)
+	}
+	params["release"] = p.Session
+	return k.put(p.Key, params, p.Value, q)
+}
+
+func (k *KV) put(key string, params map[string]string, body []byte, q *WriteOptions) (bool, *WriteMeta, error) {
+	r := k.c.newRequest("PUT", "/v1/kv/"+key)
+	r.setWriteOptions(q)
+	for param, val := range params {
+		r.params.Set(param, val)
+	}
+	r.body = bytes.NewReader(body)
+	rtt, resp, err := requireOK(k.c.doRequest(r))
+	if err != nil {
+		return false, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &WriteMeta{}
+	qm.RequestTime = rtt
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, resp.Body); err != nil {
+		return false, nil, fmt.Errorf("Failed to read response: %v", err)
+	}
+	res := strings.Contains(string(buf.Bytes()), "true")
+	return res, qm, nil
+}
+
+// Delete is used to delete a single key
+func (k *KV) Delete(key string, w *WriteOptions) (*WriteMeta, error) {
+	return k.deleteInternal(key, nil, w)
+}
+
+// DeleteTree is used to delete all keys under a prefix
+func (k *KV) DeleteTree(prefix string, w *WriteOptions) (*WriteMeta, error) {
+	return k.deleteInternal(prefix, []string{"recurse"}, w)
+}
+
+func (k *KV) deleteInternal(key string, params []string, q *WriteOptions) (*WriteMeta, error) {
+	r := k.c.newRequest("DELETE", "/v1/kv/"+key)
+	r.setWriteOptions(q)
+	for _, param := range params {
+		r.params.Set(param, "")
+	}
+	rtt, resp, err := requireOK(k.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	qm := &WriteMeta{}
+	qm.RequestTime = rtt
+	return qm, nil
+}

--- a/vendor/github.com/armon/consul-api/kv_test.go
+++ b/vendor/github.com/armon/consul-api/kv_test.go
@@ -1,0 +1,374 @@
+package consulapi
+
+import (
+	"bytes"
+	"path"
+	"testing"
+	"time"
+)
+
+func TestClientPutGetDelete(t *testing.T) {
+	c := makeClient(t)
+	kv := c.KV()
+
+	// Get a get without a key
+	key := testKey()
+	pair, _, err := kv.Get(key, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if pair != nil {
+		t.Fatalf("unexpected value: %#v", pair)
+	}
+
+	// Put the key
+	value := []byte("test")
+	p := &KVPair{Key: key, Flags: 42, Value: value}
+	if _, err := kv.Put(p, nil); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Get should work
+	pair, meta, err := kv.Get(key, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if pair == nil {
+		t.Fatalf("expected value: %#v", pair)
+	}
+	if !bytes.Equal(pair.Value, value) {
+		t.Fatalf("unexpected value: %#v", pair)
+	}
+	if pair.Flags != 42 {
+		t.Fatalf("unexpected value: %#v", pair)
+	}
+	if meta.LastIndex == 0 {
+		t.Fatalf("unexpected value: %#v", meta)
+	}
+
+	// Delete
+	if _, err := kv.Delete(key, nil); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Get should fail
+	pair, _, err = kv.Get(key, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if pair != nil {
+		t.Fatalf("unexpected value: %#v", pair)
+	}
+}
+
+func TestClient_List_DeleteRecurse(t *testing.T) {
+	c := makeClient(t)
+	kv := c.KV()
+
+	// Generate some test keys
+	prefix := testKey()
+	var keys []string
+	for i := 0; i < 100; i++ {
+		keys = append(keys, path.Join(prefix, testKey()))
+	}
+
+	// Set values
+	value := []byte("test")
+	for _, key := range keys {
+		p := &KVPair{Key: key, Value: value}
+		if _, err := kv.Put(p, nil); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	// List the values
+	pairs, meta, err := kv.List(prefix, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(pairs) != len(keys) {
+		t.Fatalf("got %d keys", len(pairs))
+	}
+	for _, pair := range pairs {
+		if !bytes.Equal(pair.Value, value) {
+			t.Fatalf("unexpected value: %#v", pair)
+		}
+	}
+	if meta.LastIndex == 0 {
+		t.Fatalf("unexpected value: %#v", meta)
+	}
+
+	// Delete all
+	if _, err := kv.DeleteTree(prefix, nil); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// List the values
+	pairs, _, err = kv.List(prefix, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(pairs) != 0 {
+		t.Fatalf("got %d keys", len(pairs))
+	}
+}
+
+func TestClient_CAS(t *testing.T) {
+	c := makeClient(t)
+	kv := c.KV()
+
+	// Put the key
+	key := testKey()
+	value := []byte("test")
+	p := &KVPair{Key: key, Value: value}
+	if work, _, err := kv.CAS(p, nil); err != nil {
+		t.Fatalf("err: %v", err)
+	} else if !work {
+		t.Fatalf("CAS failure")
+	}
+
+	// Get should work
+	pair, meta, err := kv.Get(key, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if pair == nil {
+		t.Fatalf("expected value: %#v", pair)
+	}
+	if meta.LastIndex == 0 {
+		t.Fatalf("unexpected value: %#v", meta)
+	}
+
+	// CAS update with bad index
+	newVal := []byte("foo")
+	p.Value = newVal
+	p.ModifyIndex = 1
+	if work, _, err := kv.CAS(p, nil); err != nil {
+		t.Fatalf("err: %v", err)
+	} else if work {
+		t.Fatalf("unexpected CAS")
+	}
+
+	// CAS update with valid index
+	p.ModifyIndex = meta.LastIndex
+	if work, _, err := kv.CAS(p, nil); err != nil {
+		t.Fatalf("err: %v", err)
+	} else if !work {
+		t.Fatalf("unexpected CAS failure")
+	}
+}
+
+func TestClient_WatchGet(t *testing.T) {
+	c := makeClient(t)
+	kv := c.KV()
+
+	// Get a get without a key
+	key := testKey()
+	pair, meta, err := kv.Get(key, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if pair != nil {
+		t.Fatalf("unexpected value: %#v", pair)
+	}
+	if meta.LastIndex == 0 {
+		t.Fatalf("unexpected value: %#v", meta)
+	}
+
+	// Put the key
+	value := []byte("test")
+	go func() {
+		c := makeClient(t)
+		kv := c.KV()
+
+		time.Sleep(100 * time.Millisecond)
+		p := &KVPair{Key: key, Flags: 42, Value: value}
+		if _, err := kv.Put(p, nil); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}()
+
+	// Get should work
+	options := &QueryOptions{WaitIndex: meta.LastIndex}
+	pair, meta2, err := kv.Get(key, options)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if pair == nil {
+		t.Fatalf("expected value: %#v", pair)
+	}
+	if !bytes.Equal(pair.Value, value) {
+		t.Fatalf("unexpected value: %#v", pair)
+	}
+	if pair.Flags != 42 {
+		t.Fatalf("unexpected value: %#v", pair)
+	}
+	if meta2.LastIndex <= meta.LastIndex {
+		t.Fatalf("unexpected value: %#v", meta2)
+	}
+}
+
+func TestClient_WatchList(t *testing.T) {
+	c := makeClient(t)
+	kv := c.KV()
+
+	// Get a get without a key
+	prefix := testKey()
+	key := path.Join(prefix, testKey())
+	pairs, meta, err := kv.List(prefix, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(pairs) != 0 {
+		t.Fatalf("unexpected value: %#v", pairs)
+	}
+	if meta.LastIndex == 0 {
+		t.Fatalf("unexpected value: %#v", meta)
+	}
+
+	// Put the key
+	value := []byte("test")
+	go func() {
+		c := makeClient(t)
+		kv := c.KV()
+
+		time.Sleep(100 * time.Millisecond)
+		p := &KVPair{Key: key, Flags: 42, Value: value}
+		if _, err := kv.Put(p, nil); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}()
+
+	// Get should work
+	options := &QueryOptions{WaitIndex: meta.LastIndex}
+	pairs, meta2, err := kv.List(prefix, options)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(pairs) != 1 {
+		t.Fatalf("expected value: %#v", pairs)
+	}
+	if !bytes.Equal(pairs[0].Value, value) {
+		t.Fatalf("unexpected value: %#v", pairs)
+	}
+	if pairs[0].Flags != 42 {
+		t.Fatalf("unexpected value: %#v", pairs)
+	}
+	if meta2.LastIndex <= meta.LastIndex {
+		t.Fatalf("unexpected value: %#v", meta2)
+	}
+
+}
+
+func TestClient_Keys_DeleteRecurse(t *testing.T) {
+	c := makeClient(t)
+	kv := c.KV()
+
+	// Generate some test keys
+	prefix := testKey()
+	var keys []string
+	for i := 0; i < 100; i++ {
+		keys = append(keys, path.Join(prefix, testKey()))
+	}
+
+	// Set values
+	value := []byte("test")
+	for _, key := range keys {
+		p := &KVPair{Key: key, Value: value}
+		if _, err := kv.Put(p, nil); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	// List the values
+	out, meta, err := kv.Keys(prefix, "", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(out) != len(keys) {
+		t.Fatalf("got %d keys", len(out))
+	}
+	if meta.LastIndex == 0 {
+		t.Fatalf("unexpected value: %#v", meta)
+	}
+
+	// Delete all
+	if _, err := kv.DeleteTree(prefix, nil); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// List the values
+	out, _, err = kv.Keys(prefix, "", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("got %d keys", len(out))
+	}
+}
+
+func TestClient_AcquireRelease(t *testing.T) {
+	c := makeClient(t)
+	session := c.Session()
+	kv := c.KV()
+
+	// Make a session
+	id, _, err := session.CreateNoChecks(nil, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer session.Destroy(id, nil)
+
+	// Acquire the key
+	key := testKey()
+	value := []byte("test")
+	p := &KVPair{Key: key, Value: value, Session: id}
+	if work, _, err := kv.Acquire(p, nil); err != nil {
+		t.Fatalf("err: %v", err)
+	} else if !work {
+		t.Fatalf("Lock failure")
+	}
+
+	// Get should work
+	pair, meta, err := kv.Get(key, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if pair == nil {
+		t.Fatalf("expected value: %#v", pair)
+	}
+	if pair.LockIndex != 1 {
+		t.Fatalf("Expected lock: %v", pair)
+	}
+	if pair.Session != id {
+		t.Fatalf("Expected lock: %v", pair)
+	}
+	if meta.LastIndex == 0 {
+		t.Fatalf("unexpected value: %#v", meta)
+	}
+
+	// Release
+	if work, _, err := kv.Release(p, nil); err != nil {
+		t.Fatalf("err: %v", err)
+	} else if !work {
+		t.Fatalf("Release fail")
+	}
+
+	// Get should work
+	pair, meta, err = kv.Get(key, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if pair == nil {
+		t.Fatalf("expected value: %#v", pair)
+	}
+	if pair.LockIndex != 1 {
+		t.Fatalf("Expected lock: %v", pair)
+	}
+	if pair.Session != "" {
+		t.Fatalf("Expected unlock: %v", pair)
+	}
+	if meta.LastIndex == 0 {
+		t.Fatalf("unexpected value: %#v", meta)
+	}
+}

--- a/vendor/github.com/armon/consul-api/session.go
+++ b/vendor/github.com/armon/consul-api/session.go
@@ -1,0 +1,204 @@
+package consulapi
+
+import (
+	"time"
+)
+
+// SessionEntry represents a session in consul
+type SessionEntry struct {
+	CreateIndex uint64
+	ID          string
+	Name        string
+	Node        string
+	Checks      []string
+	LockDelay   time.Duration
+	Behavior    string
+	TTL         string
+}
+
+// Session can be used to query the Session endpoints
+type Session struct {
+	c *Client
+}
+
+// Session returns a handle to the session endpoints
+func (c *Client) Session() *Session {
+	return &Session{c}
+}
+
+// CreateNoChecks is like Create but is used specifically to create
+// a session with no associated health checks.
+func (s *Session) CreateNoChecks(se *SessionEntry, q *WriteOptions) (string, *WriteMeta, error) {
+	body := make(map[string]interface{})
+	body["Checks"] = []string{}
+	if se != nil {
+		if se.Name != "" {
+			body["Name"] = se.Name
+		}
+		if se.Node != "" {
+			body["Node"] = se.Node
+		}
+		if se.LockDelay != 0 {
+			body["LockDelay"] = durToMsec(se.LockDelay)
+		}
+		if se.Behavior != "" {
+			body["Behavior"] = se.Behavior
+		}
+		if se.TTL != "" {
+			body["TTL"] = se.TTL
+		}
+	}
+	return s.create(body, q)
+
+}
+
+// Create makes a new session. Providing a session entry can
+// customize the session. It can also be nil to use defaults.
+func (s *Session) Create(se *SessionEntry, q *WriteOptions) (string, *WriteMeta, error) {
+	var obj interface{}
+	if se != nil {
+		body := make(map[string]interface{})
+		obj = body
+		if se.Name != "" {
+			body["Name"] = se.Name
+		}
+		if se.Node != "" {
+			body["Node"] = se.Node
+		}
+		if se.LockDelay != 0 {
+			body["LockDelay"] = durToMsec(se.LockDelay)
+		}
+		if len(se.Checks) > 0 {
+			body["Checks"] = se.Checks
+		}
+		if se.Behavior != "" {
+			body["Behavior"] = se.Behavior
+		}
+		if se.TTL != "" {
+			body["TTL"] = se.TTL
+		}
+	}
+	return s.create(obj, q)
+}
+
+func (s *Session) create(obj interface{}, q *WriteOptions) (string, *WriteMeta, error) {
+	r := s.c.newRequest("PUT", "/v1/session/create")
+	r.setWriteOptions(q)
+	r.obj = obj
+	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if err != nil {
+		return "", nil, err
+	}
+	defer resp.Body.Close()
+
+	wm := &WriteMeta{RequestTime: rtt}
+	var out struct{ ID string }
+	if err := decodeBody(resp, &out); err != nil {
+		return "", nil, err
+	}
+	return out.ID, wm, nil
+}
+
+// Destroy invalides a given session
+func (s *Session) Destroy(id string, q *WriteOptions) (*WriteMeta, error) {
+	r := s.c.newRequest("PUT", "/v1/session/destroy/"+id)
+	r.setWriteOptions(q)
+	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	wm := &WriteMeta{RequestTime: rtt}
+	return wm, nil
+}
+
+// Renew renews the TTL on a given session
+func (s *Session) Renew(id string, q *WriteOptions) (*SessionEntry, *WriteMeta, error) {
+	r := s.c.newRequest("PUT", "/v1/session/renew/"+id)
+	r.setWriteOptions(q)
+	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	wm := &WriteMeta{RequestTime: rtt}
+
+	var entries []*SessionEntry
+	if err := decodeBody(resp, &entries); err != nil {
+		return nil, wm, err
+	}
+
+	if len(entries) > 0 {
+		return entries[0], wm, nil
+	}
+	return nil, wm, nil
+}
+
+// Info looks up a single session
+func (s *Session) Info(id string, q *QueryOptions) (*SessionEntry, *QueryMeta, error) {
+	r := s.c.newRequest("GET", "/v1/session/info/"+id)
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var entries []*SessionEntry
+	if err := decodeBody(resp, &entries); err != nil {
+		return nil, nil, err
+	}
+
+	if len(entries) > 0 {
+		return entries[0], qm, nil
+	}
+	return nil, qm, nil
+}
+
+// List gets sessions for a node
+func (s *Session) Node(node string, q *QueryOptions) ([]*SessionEntry, *QueryMeta, error) {
+	r := s.c.newRequest("GET", "/v1/session/node/"+node)
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var entries []*SessionEntry
+	if err := decodeBody(resp, &entries); err != nil {
+		return nil, nil, err
+	}
+	return entries, qm, nil
+}
+
+// List gets all active sessions
+func (s *Session) List(q *QueryOptions) ([]*SessionEntry, *QueryMeta, error) {
+	r := s.c.newRequest("GET", "/v1/session/list")
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var entries []*SessionEntry
+	if err := decodeBody(resp, &entries); err != nil {
+		return nil, nil, err
+	}
+	return entries, qm, nil
+}

--- a/vendor/github.com/armon/consul-api/session_test.go
+++ b/vendor/github.com/armon/consul-api/session_test.go
@@ -1,0 +1,190 @@
+package consulapi
+
+import (
+	"testing"
+)
+
+func TestSession_CreateDestroy(t *testing.T) {
+	c := makeClient(t)
+	session := c.Session()
+
+	id, meta, err := session.Create(nil, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if meta.RequestTime == 0 {
+		t.Fatalf("bad: %v", meta)
+	}
+
+	if id == "" {
+		t.Fatalf("invalid: %v", id)
+	}
+
+	meta, err = session.Destroy(id, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if meta.RequestTime == 0 {
+		t.Fatalf("bad: %v", meta)
+	}
+}
+
+func TestSession_CreateRenewDestroy(t *testing.T) {
+	c := makeClient(t)
+	session := c.Session()
+
+	se := &SessionEntry{
+		TTL: "10s",
+	}
+
+	id, meta, err := session.Create(se, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer session.Destroy(id, nil)
+
+	if meta.RequestTime == 0 {
+		t.Fatalf("bad: %v", meta)
+	}
+
+	if id == "" {
+		t.Fatalf("invalid: %v", id)
+	}
+
+	if meta.RequestTime == 0 {
+		t.Fatalf("bad: %v", meta)
+	}
+
+	renew, meta, err := session.Renew(id, nil)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if meta.RequestTime == 0 {
+		t.Fatalf("bad: %v", meta)
+	}
+
+	if renew == nil {
+		t.Fatalf("should get session")
+	}
+
+	if renew.ID != id {
+		t.Fatalf("should have matching id")
+	}
+
+	if renew.TTL != "10s" {
+		t.Fatalf("should get session with TTL")
+	}
+}
+
+func TestSession_Info(t *testing.T) {
+	c := makeClient(t)
+	session := c.Session()
+
+	id, _, err := session.Create(nil, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer session.Destroy(id, nil)
+
+	info, qm, err := session.Info(id, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if qm.LastIndex == 0 {
+		t.Fatalf("bad: %v", qm)
+	}
+	if !qm.KnownLeader {
+		t.Fatalf("bad: %v", qm)
+	}
+
+	if info == nil {
+		t.Fatalf("should get session")
+	}
+	if info.CreateIndex == 0 {
+		t.Fatalf("bad: %v", info)
+	}
+	if info.ID != id {
+		t.Fatalf("bad: %v", info)
+	}
+	if info.Name != "" {
+		t.Fatalf("bad: %v", info)
+	}
+	if info.Node == "" {
+		t.Fatalf("bad: %v", info)
+	}
+	if len(info.Checks) == 0 {
+		t.Fatalf("bad: %v", info)
+	}
+	if info.LockDelay == 0 {
+		t.Fatalf("bad: %v", info)
+	}
+	if info.Behavior != "release" {
+		t.Fatalf("bad: %v", info)
+	}
+	if info.TTL != "" {
+		t.Fatalf("bad: %v", info)
+	}
+}
+
+func TestSession_Node(t *testing.T) {
+	c := makeClient(t)
+	session := c.Session()
+
+	id, _, err := session.Create(nil, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer session.Destroy(id, nil)
+
+	info, qm, err := session.Info(id, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	sessions, qm, err := session.Node(info.Node, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(sessions) != 1 {
+		t.Fatalf("bad: %v", sessions)
+	}
+
+	if qm.LastIndex == 0 {
+		t.Fatalf("bad: %v", qm)
+	}
+	if !qm.KnownLeader {
+		t.Fatalf("bad: %v", qm)
+	}
+}
+
+func TestSession_List(t *testing.T) {
+	c := makeClient(t)
+	session := c.Session()
+
+	id, _, err := session.Create(nil, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer session.Destroy(id, nil)
+
+	sessions, qm, err := session.List(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(sessions) != 1 {
+		t.Fatalf("bad: %v", sessions)
+	}
+
+	if qm.LastIndex == 0 {
+		t.Fatalf("bad: %v", qm)
+	}
+	if !qm.KnownLeader {
+		t.Fatalf("bad: %v", qm)
+	}
+}

--- a/vendor/github.com/armon/consul-api/status.go
+++ b/vendor/github.com/armon/consul-api/status.go
@@ -1,0 +1,43 @@
+package consulapi
+
+// Status can be used to query the Status endpoints
+type Status struct {
+	c *Client
+}
+
+// Status returns a handle to the status endpoints
+func (c *Client) Status() *Status {
+	return &Status{c}
+}
+
+// Leader is used to query for a known leader
+func (s *Status) Leader() (string, error) {
+	r := s.c.newRequest("GET", "/v1/status/leader")
+	_, resp, err := requireOK(s.c.doRequest(r))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var leader string
+	if err := decodeBody(resp, &leader); err != nil {
+		return "", err
+	}
+	return leader, nil
+}
+
+// Peers is used to query for a known raft peers
+func (s *Status) Peers() ([]string, error) {
+	r := s.c.newRequest("GET", "/v1/status/peers")
+	_, resp, err := requireOK(s.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var peers []string
+	if err := decodeBody(resp, &peers); err != nil {
+		return nil, err
+	}
+	return peers, nil
+}

--- a/vendor/github.com/armon/consul-api/status_test.go
+++ b/vendor/github.com/armon/consul-api/status_test.go
@@ -1,0 +1,31 @@
+package consulapi
+
+import (
+	"testing"
+)
+
+func TestStatusLeader(t *testing.T) {
+	c := makeClient(t)
+	status := c.Status()
+
+	leader, err := status.Leader()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if leader == "" {
+		t.Fatalf("Expected leader")
+	}
+}
+
+func TestStatusPeers(t *testing.T) {
+	c := makeClient(t)
+	status := c.Status()
+
+	peers, err := status.Peers()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(peers) == 0 {
+		t.Fatalf("Expected peers ")
+	}
+}


### PR DESCRIPTION
Supersedes https://github.com/github/orchestrator/pull/320, this PR introduces support for key-value stores:

- internal
- Consul
- ZooKeeper

the immediate objective is to write cluster's master identities to KV, as well as update such entires upon failover.

Users may then use functionalities such as `consul-template` to update/populate their proxy configs or client configs with identities of masters.