### PR TITLE
added config.Config.AuditToBackendDB (default: false)

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -147,6 +147,7 @@ type Configuration struct {
 	CandidateInstanceExpireMinutes             uint     // Minutes after which a suggestion to use an instance as a candidate replica (to be preferably promoted on master failover) is expired.
 	AuditLogFile                               string   // Name of log file for audit operations. Disabled when empty.
 	AuditToSyslog                              bool     // If true, audit messages are written to syslog
+	AuditToBackendDB                           bool     // If true, audit messages are written to the backend DB's `audit` table (default: true)
 	RemoveTextFromHostnameDisplay              string   // Text to strip off the hostname on cluster/clusters pages
 	ReadOnly                                   bool
 	AuthenticationMethod                       string // Type of autherntication to use, if any. "" for none, "basic" for BasicAuth, "multi" for advanced BasicAuth, "proxy" for forwarded credentials via reverse proxy, "token" for token based access
@@ -308,6 +309,7 @@ func newConfiguration() *Configuration {
 		CandidateInstanceExpireMinutes:             60,
 		AuditLogFile:                               "",
 		AuditToSyslog:                              false,
+		AuditToBackendDB:                           false,
 		RemoveTextFromHostnameDisplay:              "",
 		ReadOnly:                                   false,
 		AuthenticationMethod:                       "",


### PR DESCRIPTION
The following boolean configuration variable is introduced: `AuditToBackendDB`, default `false`.

When `true`, audit is written to the `audit` table. When `false` (default), `audit` table does not get written to.

After some years of working with `orchestrator` I noticed I rarely go to the `audit` table. Moreover, on large or busy setups, the table gets bloated real fast.

`orchestrator` already provides alternate routes:
- It audits to the `orchestrator` log file
- It supports `AuditLogFile`, where only audit data is printed
- `AuditToSyslog`