### PR TITLE
Removed status simple check; normal check caches response

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -190,7 +190,6 @@ type Configuration struct {
 	SSLCAFile                                  string            // Name of the Certificate Authority file, applies only when UseSSL = true
 	SSLValidOUs                                []string          // Valid organizational units when using mutual TLS
 	StatusEndpoint                             string            // Override the status endpoint.  Defaults to '/api/status'
-	StatusSimpleHealth                         bool              // If true, calling the status endpoint will use the simplified health check
 	StatusOUVerify                             bool              // If true, try to verify OUs when Mutual TLS is on.  Defaults to false
 	AgentPollMinutes                           uint              // Minutes between agent polling
 	UnseenAgentForgetHours                     uint              // Number of hours after which an unseen agent is forgotten
@@ -263,7 +262,6 @@ func newConfiguration() *Configuration {
 		ListenSocket:                               "",
 		AgentsServerPort:                           ":3001",
 		StatusEndpoint:                             "/api/status",
-		StatusSimpleHealth:                         true,
 		StatusOUVerify:                             false,
 		BackendDB:                                  "mysql",
 		SQLite3DataFile:                            "",

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -2360,14 +2360,7 @@ func (this *HttpAPI) LeaderCheck(params martini.Params, r render.Render, req *ht
 // It might be a good idea to deprecate the current Health() behavior and roll this in at some
 // point
 func (this *HttpAPI) StatusCheck(params martini.Params, r render.Render, req *http.Request) {
-	// SimpleHealthTest just checks to see if we can connect to the database.  Lighter weight if you intend to call it a lot
-	var health *process.HealthStatus
-	var err error
-	if config.Config.StatusSimpleHealth {
-		health, err = process.SimpleHealthTest()
-	} else {
-		health, err = process.HealthTest()
-	}
+	health, err := process.HealthTest()
 	if err != nil {
 		r.JSON(500, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Application node is unhealthy %+v", err), Details: health})
 		return

--- a/go/process/health.go
+++ b/go/process/health.go
@@ -100,7 +100,6 @@ func RegisterNode(nodeHealth *NodeHealth) (healthy bool, err error) {
 
 // HealthTest attempts to write to the backend database and get a result
 func HealthTest() (health *HealthStatus, err error) {
-	log.Debugf(".....................0")
 	cacheKey := ProcessToken.Hash
 	if healthStatus, found := lastHealthCheckCache.Get(cacheKey); found {
 		return healthStatus.(*HealthStatus), nil

--- a/go/process/health.go
+++ b/go/process/health.go
@@ -100,6 +100,7 @@ func RegisterNode(nodeHealth *NodeHealth) (healthy bool, err error) {
 
 // HealthTest attempts to write to the backend database and get a result
 func HealthTest() (health *HealthStatus, err error) {
+	log.Debugf(".....................0")
 	cacheKey := ProcessToken.Hash
 	if healthStatus, found := lastHealthCheckCache.Get(cacheKey); found {
 		return healthStatus.(*HealthStatus), nil
@@ -124,7 +125,6 @@ func HealthTest() (health *HealthStatus, err error) {
 			return health, log.Errore(err)
 		}
 	}
-
 	health.AvailableNodes, err = ReadAvailableNodes(true)
 
 	return health, nil

--- a/go/process/health_dao.go
+++ b/go/process/health_dao.go
@@ -192,22 +192,3 @@ func TokenBelongsToHealthyHttpService(token string) (result bool, err error) {
 	})
 	return result, log.Errore(err)
 }
-
-// Just check to make sure we can connect to the database
-func SimpleHealthTest() (*HealthStatus, error) {
-	health := HealthStatus{Healthy: false, Hostname: ThisHostname, Token: ProcessToken.Hash}
-
-	db, err := db.OpenOrchestrator()
-	if err != nil {
-		health.Error = err
-		return &health, log.Errore(err)
-	}
-
-	if err = db.Ping(); err != nil {
-		health.Error = err
-		return &health, log.Errore(err)
-	} else {
-		health.Healthy = true
-		return &health, nil
-	}
-}


### PR DESCRIPTION
Solves https://github.com/github/orchestrator/issues/145

`StatusSimpleHealth` is deprecated and has no impact whatever the value is. Health checks are always complete and full. However, they cache response for one second making call to `/api/status` more lightweight.


