### PR TITLE
Forcing, validating and documenting RaftDataDir

### DIFF
--- a/docs/configuration-raft.md
+++ b/docs/configuration-raft.md
@@ -6,6 +6,7 @@ Assuming you will run `orchestrator/raft` on a `3` node setup, you will configur
 
 ```json
   "RaftEnabled": true,
+  "RaftDataDir": "<path.to.orchestrator.data.directory>",
   "RaftBind": "<ip.or.fqdn.of.this.orchestrator.node>",
   "DefaultRaftPort": 10008,
   "RaftNodes": [
@@ -18,6 +19,7 @@ Assuming you will run `orchestrator/raft` on a `3` node setup, you will configur
 Some breakdown:
 
 - `RaftEnabled` must be set to `true`, otherwise `orchestrator` runs in shared-backend mode.
+- `RaftDataDir` must be set to a directory writable to `orchestrator.` `orchestrator` will attempt to create the directory if not exists.
 - `RaftBind` must be set, use the IP address or full hostname of local host. This IP or hostname will also be listed as one of the `RaftNodes` variable.
 - `DefaultRaftPort` can be set to any port, but must be consistent across all deployments.
 - `RaftNodes` should list all nodes of the raft cluster. This list will consist of either IP addresses or host names, and will include the value of this host itself as presented in `RaftBind`.
@@ -26,6 +28,7 @@ As example, the following might be a working setup:
 
 ```json
   "RaftEnabled": true,
+  "RaftDataDir": "/var/lib/orchestrator",
   "RaftBind": "10.0.0.2",
   "DefaultRaftPort": 10008,
   "RaftNodes": [
@@ -38,6 +41,7 @@ As example, the following might be a working setup:
 as well as this:
 ```json
   "RaftEnabled": true,
+  "RaftDataDir": "/var/lib/orchestrator",
   "RaftBind": "node-full-hostname-2.here.com",
   "DefaultRaftPort": 10008,
   "RaftNodes": [

--- a/docs/raft.md
+++ b/docs/raft.md
@@ -24,6 +24,7 @@ At this time `orchestrator` nodes to not join dynamically into the cluster. The 
 
 ```json
   "RaftEnabled": true,
+  "RaftDataDir": "/var/lib/orchestrator",
   "RaftBind": "<ip.or.fqdn.of.this.orchestrator.node>",
   "DefaultRaftPort": 10008,
   "RaftNodes": [

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -516,6 +516,9 @@ func (this *Configuration) postReadAdjustments() error {
 	if this.RaftAdvertise == "" {
 		this.RaftAdvertise = this.RaftBind
 	}
+	if this.RaftEnabled && this.RaftDataDir == "" {
+		return fmt.Errorf("RaftDataDir must be defined since raft is enabled (RaftEnabled)")
+	}
 	if this.KVClusterMasterPrefix != "/" {
 		// "/" remains "/"
 		// "prefix" turns to "prefix/"

--- a/go/raft/store.go
+++ b/go/raft/store.go
@@ -83,6 +83,19 @@ func (store *Store) Open(peerNodes []string) error {
 		config.DisableBootstrapAfterElect = false
 	}
 
+	if _, err := os.Stat(store.raftDir); err != nil {
+		if os.IsNotExist(err) {
+			// path does not exist
+			log.Debugf("raft: creating data dir %s", store.raftDir)
+			if err := os.MkdirAll(store.raftDir, os.ModePerm); err != nil {
+				return log.Errorf("RaftDataDir (%s) does not exist and cannot be created: %+v", store.raftDir, err)
+			}
+		} else {
+			// Other error
+			return log.Errorf("RaftDataDir (%s) error: %+v", store.raftDir, err)
+		}
+	}
+
 	// Create the snapshot store. This allows the Raft to truncate the log.
 	snapshots, err := NewFileSnapshotStore(store.raftDir, retainSnapshotCount, os.Stderr)
 	if err != nil {


### PR DESCRIPTION
Context: https://github.com/github/orchestrator/issues/354

`RaftDataDir` is now a mandatory configuration variable for `orchestrator/raft`. It is now:

- Validated
- Documented

Previously it was assumed the default empty value is valid. This was a bad assumption. From now on, when `RaftEnabled` is `true`, `RaftDataDir` must be set to a non-empty path.