### PR TITLE
Ascii topology tabulated

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1089,7 +1089,16 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	case registerCliCommand("topology", "Information", `Show an ascii-graph of a replication topology, given a member of that topology`):
 		{
 			clusterName := getClusterName(clusterAlias, instanceKey)
-			output, err := inst.ASCIITopology(clusterName, pattern)
+			output, err := inst.ASCIITopology(clusterName, pattern, false)
+			if err != nil {
+				log.Fatale(err)
+			}
+			fmt.Println(output)
+		}
+	case registerCliCommand("topology-tabulated", "Information", `Show an ascii-graph of a replication topology, given a member of that topology`):
+		{
+			clusterName := getClusterName(clusterAlias, instanceKey)
+			output, err := inst.ASCIITopology(clusterName, pattern, true)
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1368,7 +1368,7 @@ func (this *HttpAPI) AsciiTopology(params martini.Params, r render.Render, req *
 		return
 	}
 
-	asciiOutput, err := inst.ASCIITopology(clusterName, "")
+	asciiOutput, err := inst.ASCIITopology(clusterName, "", true)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1373,9 +1373,6 @@ func (this *HttpAPI) asciiTopology(params martini.Params, r render.Render, req *
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return
 	}
-	if !tabulated {
-		asciiOutput = strings.Replace(asciiOutput, " ", "\u00a0", -1)
-	}
 
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Topology for cluster %s", clusterName), Details: asciiOutput})
 }

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1373,7 +1373,9 @@ func (this *HttpAPI) asciiTopology(params martini.Params, r render.Render, req *
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return
 	}
-	asciiOutput = strings.Replace(asciiOutput, " ", "\u00a0", -1)
+	if !tabulated {
+		asciiOutput = strings.Replace(asciiOutput, " ", "\u00a0", -1)
+	}
 
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Topology for cluster %s", clusterName), Details: asciiOutput})
 }

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1361,14 +1361,14 @@ func (this *HttpAPI) KillQuery(params martini.Params, r render.Render, req *http
 }
 
 // AsciiTopology returns an ascii graph of cluster's instances
-func (this *HttpAPI) AsciiTopology(params martini.Params, r render.Render, req *http.Request) {
+func (this *HttpAPI) asciiTopology(params martini.Params, r render.Render, req *http.Request, tabulated bool) {
 	clusterName, err := figureClusterName(getClusterHint(params))
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return
 	}
 
-	asciiOutput, err := inst.ASCIITopology(clusterName, "", true)
+	asciiOutput, err := inst.ASCIITopology(clusterName, "", tabulated)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return
@@ -1376,6 +1376,16 @@ func (this *HttpAPI) AsciiTopology(params martini.Params, r render.Render, req *
 	asciiOutput = strings.Replace(asciiOutput, " ", "\u00a0", -1)
 
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Topology for cluster %s", clusterName), Details: asciiOutput})
+}
+
+// AsciiTopology returns an ascii graph of cluster's instances
+func (this *HttpAPI) AsciiTopology(params martini.Params, r render.Render, req *http.Request) {
+	this.asciiTopology(params, r, req, false)
+}
+
+// AsciiTopology returns an ascii graph of cluster's instances
+func (this *HttpAPI) AsciiTopologyTabulated(params martini.Params, r render.Render, req *http.Request) {
+	this.asciiTopology(params, r, req, true)
 }
 
 // Cluster provides list of instances in given cluster
@@ -3083,6 +3093,8 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerRequest(m, "downtimed/:clusterHint", this.Downtimed)
 	this.registerRequest(m, "topology/:clusterHint", this.AsciiTopology)
 	this.registerRequest(m, "topology/:host/:port", this.AsciiTopology)
+	this.registerRequest(m, "topology-tabulated/:clusterHint", this.AsciiTopologyTabulated)
+	this.registerRequest(m, "topology-tabulated/:host/:port", this.AsciiTopologyTabulated)
 
 	// Key-value:
 	this.registerRequest(m, "submit-masters-to-kv-stores", this.SubmitMastersToKvStores)

--- a/go/inst/instance_test.go
+++ b/go/inst/instance_test.go
@@ -395,3 +395,35 @@ func TestRemoveInstance(t *testing.T) {
 		test.S(t).ExpectEquals(len(instances), 0)
 	}
 }
+
+func TestHumanReadableDescription(t *testing.T) {
+	i57 := Instance{Version: "5.7.8-log"}
+	{
+		desc := i57.HumanReadableDescription()
+		test.S(t).ExpectEquals(desc, "[unknown,invalid,5.7.8-log,rw,nobinlog]")
+	}
+	{
+		i57.UsingPseudoGTID = true
+		i57.LogBinEnabled = true
+		i57.Binlog_format = "ROW"
+		i57.LogSlaveUpdatesEnabled = true
+		desc := i57.HumanReadableDescription()
+		test.S(t).ExpectEquals(desc, "[unknown,invalid,5.7.8-log,rw,ROW,>>,P-GTID]")
+	}
+}
+
+func TestTabulatedDescription(t *testing.T) {
+	i57 := Instance{Version: "5.7.8-log"}
+	{
+		desc := i57.TabulatedDescription("|")
+		test.S(t).ExpectEquals(desc, "unknown|invalid|5.7.8-log|rw|nobinlog|")
+	}
+	{
+		i57.UsingPseudoGTID = true
+		i57.LogBinEnabled = true
+		i57.Binlog_format = "ROW"
+		i57.LogSlaveUpdatesEnabled = true
+		desc := i57.TabulatedDescription("|")
+		test.S(t).ExpectEquals(desc, "unknown|invalid|5.7.8-log|rw|ROW|>>,P-GTID")
+	}
+}

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -259,6 +259,12 @@ function ascii_topology() {
   print_details | jq -r '.'
 }
 
+function ascii_topology_tabulated() {
+  assert_nonempty "instance|alias" "${alias:-$instance}"
+  api "topology-tabulated/${alias:-$instance}"
+  print_details | jq -r '.'
+}
+
 function search() {
   assert_nonempty "instance" "$instance"
   api "search?s=$(urlencode "$instance")"
@@ -578,6 +584,7 @@ function run_command() {
     "forget-cluster") forget_cluster ;;                         # Forget about a cluster
 
     "topology") ascii_topology ;;                               # Show an ascii-graph of a replication topology, given a member of that topology
+    "topology-tabulated") ascii_topology_tabulated ;;           # Show an ascii-graph of a replication topology, given a member of that topology, in tabulated format
     "clusters") clusters ;;                                     # List all clusters known to orchestrator
     "clusters-alias") clusters_alias ;;                         # List all clusters known to orchestrator
     "search") search ;;                                         # Search for instances matching given substring

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -256,13 +256,13 @@ function discover() {
 function ascii_topology() {
   assert_nonempty "instance|alias" "${alias:-$instance}"
   api "topology/${alias:-$instance}"
-  print_details | jq -r '.'
+  echo "$api_response" | jq -r '.Details'
 }
 
 function ascii_topology_tabulated() {
   assert_nonempty "instance|alias" "${alias:-$instance}"
   api "topology-tabulated/${alias:-$instance}"
-  print_details | jq -r '.'
+  echo "$api_response" | jq -r '.Details'
 }
 
 function search() {

--- a/tests/integration/instance-status/expect_output
+++ b/tests/integration/instance-status/expect_output
@@ -1,0 +1,1 @@
+[unknown,unchecked,5.6.28-log,rw,STATEMENT,>>,P-GTID]

--- a/tests/integration/instance-status/extra_args
+++ b/tests/integration/instance-status/extra_args
@@ -1,0 +1,1 @@
+-c instance-status -i testhost:22294

--- a/tests/integration/topology-tabulated/create.sql
+++ b/tests/integration/topology-tabulated/create.sql
@@ -1,0 +1,7 @@
+UPDATE database_instance SET
+  last_checked=current_timestamp,
+  last_attempted_check=current_timestamp,
+  last_seen=current_timestamp,
+  seconds_behind_master=7,
+  slave_lag_seconds=7
+where port in (22294, 22297);

--- a/tests/integration/topology-tabulated/expect_output
+++ b/tests/integration/topology-tabulated/expect_output
@@ -1,0 +1,5 @@
+testhost:22293    |unknown|unchecked|5.6.28-log|rw|STATEMENT|>>,P-GTID
++ testhost:22294  |     7s|ok       |5.6.28-log|rw|STATEMENT|>>,P-GTID
+  - testhost:22295|unknown|unchecked|5.6.28-log|rw|STATEMENT|>>,P-GTID
+- testhost:22296  |unknown|unchecked|5.6.28    |rw|nobinlog |P-GTID
++ testhost:22297  |     7s|ok       |5.6.28-log|rw|STATEMENT|>>,P-GTID

--- a/tests/integration/topology-tabulated/extra_args
+++ b/tests/integration/topology-tabulated/extra_args
@@ -1,0 +1,1 @@
+-c topology-tabulated -i testhost:22294

--- a/tests/integration/topology/expect_output
+++ b/tests/integration/topology/expect_output
@@ -1,0 +1,5 @@
+testhost:22293     [unknown,unchecked,5.6.28-log,rw,STATEMENT,>>,P-GTID]
+- testhost:22294   [unknown,unchecked,5.6.28-log,rw,STATEMENT,>>,P-GTID]
+  - testhost:22295 [unknown,unchecked,5.6.28-log,rw,STATEMENT,>>,P-GTID]
+- testhost:22296   [unknown,unchecked,5.6.28,rw,nobinlog,P-GTID]
+- testhost:22297   [unknown,unchecked,5.6.28-log,rw,STATEMENT,>>,P-GTID]

--- a/tests/integration/topology/extra_args
+++ b/tests/integration/topology/extra_args
@@ -1,0 +1,1 @@
+-c topology -i testhost:22294

--- a/vendor/github.com/openark/golib/util/text_test.go
+++ b/vendor/github.com/openark/golib/util/text_test.go
@@ -1,0 +1,88 @@
+/*
+   Copyright 2014 Outbrain Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	test "github.com/openark/golib/tests"
+)
+
+func init() {
+}
+
+func TestTabulate(t *testing.T) {
+	{
+		text := strings.TrimSpace(`
+a,b,c
+d,e,f
+g,h,i
+	`)
+
+		tabulated := Tabulate(strings.Split(text, "\n"), ",", ",")
+		expected := strings.Split(text, "\n")
+		test.S(t).ExpectTrue(reflect.DeepEqual(tabulated, expected))
+	}
+	{
+		text := strings.TrimSpace(`
+a,b,c
+d,e,f
+g,h,i
+	`)
+
+		tabulated := Tabulate(strings.Split(text, "\n"), ",", "|")
+		expected := []string{
+			"a|b|c",
+			"d|e|f",
+			"g|h|i",
+		}
+		test.S(t).ExpectTrue(reflect.DeepEqual(tabulated, expected))
+	}
+	{
+		text := strings.TrimSpace(`
+a,20,c
+d,e,100
+0000,h,i
+	`)
+
+		tabulated := Tabulate(strings.Split(text, "\n"), ",", "|")
+		expected := []string{
+			"a   |20|c  ",
+			"d   |e |100",
+			"0000|h |i  ",
+		}
+		test.S(t).ExpectTrue(reflect.DeepEqual(tabulated, expected))
+	}
+	{
+		text := strings.TrimSpace(`
+a,20,c
+d,1,100
+0000,3,i
+	`)
+
+		tabulated := Tabulate(strings.Split(text, "\n"), ",", "|", TabulateLeft, TabulateRight, TabulateRight)
+		expected := []string{
+			"a   |20|  c",
+			"d   | 1|100",
+			"0000| 3|  i",
+		}
+
+		test.S(t).ExpectTrue(reflect.DeepEqual(tabulated, expected))
+	}
+}


### PR DESCRIPTION
WIP support for tabulated ascii topology, in the form of:

```
testhost:22293    |unknown|unchecked|5.6.28-log|rw|STATEMENT|>>,P-GTID
+ testhost:22294  |     7s|ok       |5.6.28-log|rw|STATEMENT|>>,P-GTID
  - testhost:22295|unknown|unchecked|5.6.28-log|rw|STATEMENT|>>,P-GTID
- testhost:22296  |unknown|unchecked|5.6.28    |rw|nobinlog |P-GTID
+ testhost:22297  |     7s|ok       |5.6.28-log|rw|STATEMENT|>>,P-GTID
```
This replaces some mega-scripting parsing and tabulating the `-c topology` output.