### PR TITLE
recovery poll is more aggressive, and non-reentrant for safety

### DIFF
--- a/conf/orchestrator-sample.conf.json
+++ b/conf/orchestrator-sample.conf.json
@@ -93,7 +93,6 @@
   "SkipBinlogEventsContaining": [],
   "ReduceReplicationAnalysisCount": true,
   "FailureDetectionPeriodBlockMinutes": 60,
-  "RecoveryPollSeconds": 10,
   "RecoveryPeriodBlockSeconds": 3600,
   "RecoveryIgnoreHostnameFilters": [],
   "RecoverMasterClusterFilters": [

--- a/conf/orchestrator-simple.conf.json
+++ b/conf/orchestrator-simple.conf.json
@@ -51,7 +51,6 @@
   "#": "Recovery related config:",
   "#": "-----",
   "FailureDetectionPeriodBlockMinutes": 60,
-  "RecoveryPollSeconds": 10,
   "RecoveryPeriodBlockSeconds": 3600,
   "RecoveryIgnoreHostnameFilters": [],
   "RecoverMasterClusterFilters": [

--- a/docs/configuration-failure-detection.md
+++ b/docs/configuration-failure-detection.md
@@ -6,12 +6,11 @@ Recovery is discussed in [configuration: recovery](configuration-recovery.md)
 
 ```json
 {
-  "RecoveryPollSeconds": 5,
   "FailureDetectionPeriodBlockMinutes": 60,
 }
 ```
 
-In the above `orchestrator` will run detection every `5` seconds.
+`orchestrator` runs detection every second.
 
 `FailureDetectionPeriodBlockMinutes` is an anti-spam mechanism that blocks `orchestrator` from notifying the same detection again and again and again.
 

--- a/docs/configuration-sample.md
+++ b/docs/configuration-sample.md
@@ -105,7 +105,6 @@ The following is a production configuration file, with some details redacted.
   ],
   "ReduceReplicationAnalysisCount": false,
   "FailureDetectionPeriodBlockMinutes": 60,
-  "RecoveryPollSeconds": 2,
   "RecoveryPeriodBlockSeconds": 600,
   "RecoveryIgnoreHostnameFilters": [
 
@@ -264,7 +263,6 @@ The following is a production configuration file, with some details redacted.
   ],
   "ReduceReplicationAnalysisCount": false,
   "FailureDetectionPeriodBlockMinutes": 60,
-  "RecoveryPollSeconds": 2,
   "RecoveryPeriodBlockSeconds": 600,
   "RecoveryIgnoreHostnameFilters": [
 

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -40,6 +40,7 @@ var configurationLoaded chan bool = make(chan bool)
 
 const (
 	HealthPollSeconds                            = 1
+	RecoveryPollSeconds                          = 1
 	ActiveNodeExpireSeconds                      = 5
 	BinlogFileHistoryDays                        = 1
 	MaintenanceOwner                             = "orchestrator"
@@ -204,7 +205,6 @@ type Configuration struct {
 	SkipBinlogEventsContaining                 []string          // When scanning/comparing binlogs for Pseudo-GTID, skip entries containing given texts. These are NOT regular expressions (would consume too much CPU while scanning binlogs), just substrings to find.
 	ReduceReplicationAnalysisCount             bool              // When true, replication analysis will only report instances where possibility of handled problems is possible in the first place (e.g. will not report most leaf nodes, that are mostly uninteresting). When false, provides an entry for every known instance
 	FailureDetectionPeriodBlockMinutes         int               // The time for which an instance's failure discovery is kept "active", so as to avoid concurrent "discoveries" of the instance's failure; this preceeds any recovery process, if any.
-	RecoveryPollSeconds                        int               // Interval between checks for a recovery scenario and initiation of a recovery process
 	RecoveryPeriodBlockMinutes                 int               // (supported for backwards compatibility but please use newer `RecoveryPeriodBlockSeconds` instead) The time for which an instance's recovery is kept "active", so as to avoid concurrent recoveries on smae instance as well as flapping
 	RecoveryPeriodBlockSeconds                 int               // (overrides `RecoveryPeriodBlockMinutes`) The time for which an instance's recovery is kept "active", so as to avoid concurrent recoveries on smae instance as well as flapping
 	RecoveryIgnoreHostnameFilters              []string          // Recovery analysis will completely ignore hosts matching given patterns
@@ -362,7 +362,6 @@ func newConfiguration() *Configuration {
 		SkipBinlogEventsContaining:                 []string{},
 		ReduceReplicationAnalysisCount:             true,
 		FailureDetectionPeriodBlockMinutes:         60,
-		RecoveryPollSeconds:                        10,
 		RecoveryPeriodBlockMinutes:                 60,
 		RecoveryPeriodBlockSeconds:                 3600,
 		RecoveryIgnoreHostnameFilters:              []string{},

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -47,7 +47,7 @@ func init() {
 func initializeAnalysisDaoPostConfiguration() {
 	config.WaitForConfigurationToBeLoaded()
 
-	recentInstantAnalysis = cache.New(time.Duration(config.Config.RecoveryPollSeconds*2)*time.Second, time.Second)
+	recentInstantAnalysis = cache.New(time.Duration(config.RecoveryPollSeconds*2)*time.Second, time.Second)
 }
 
 // GetReplicationAnalysis will check for replication problems (dead master; unreachable master; etc)

--- a/go/logic/topology_recovery_dao.go
+++ b/go/logic/topology_recovery_dao.go
@@ -354,7 +354,7 @@ func ExpireBlockedRecoveries() error {
 				from blocked_topology_recovery
 				where
 					last_blocked_timestamp < NOW() - interval ? second
-			`, (config.Config.RecoveryPollSeconds * 2),
+			`, (config.RecoveryPollSeconds * 2),
 	)
 	return log.Errore(err)
 }

--- a/tests/integration/orchestrator.conf.json
+++ b/tests/integration/orchestrator.conf.json
@@ -102,7 +102,6 @@
   "ReduceReplicationAnalysisCount": true,
   "FailureDetectionPeriodBlockMinutes": 60,
   "AutoRecoveryGloballyEnabled": false,
-  "RecoveryPollSeconds": 10,
   "RecoveryPeriodBlockMinutes": 60,
   "RecoveryPeriodBlockSeconds": 3600,
   "RecoveryIgnoreHostnameFilters": [],


### PR DESCRIPTION
In further reducing response time to failures, in this PR:
- `RecoveryPollSeconds` config variable is removed (and at this time silently ignored)
- It is implicitly set to `1sec`
- the recovery logic is thus invoked every `1sec`
- the recovery logic is non-reentrant, so that if it takes more than 1sec to execute, the next iteration will be skipped.
- The non-reentrance logic only applies to automated checks/failovers; a manual command will not block