### PR TITLE
raft: properly resolving recovery

### DIFF
--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -205,12 +205,12 @@ func (applier *CommandApplier) writeRecoveryStep(value []byte) interface{} {
 }
 
 func (applier *CommandApplier) resolveRecovery(value []byte) interface{} {
-	recoveryResolve := TopologyRecoveryResolve{}
-	if err := json.Unmarshal(value, &recoveryResolve); err != nil {
+	topologyRecovery := TopologyRecovery{}
+	if err := json.Unmarshal(value, &topologyRecovery); err != nil {
 		return log.Errore(err)
 	}
-	if err := writeResolveRecovery(recoveryResolve.Recovery, recoveryResolve.SuccessorInstance); err != nil {
-		return err
+	if err := writeResolveRecovery(&topologyRecovery); err != nil {
+		return log.Errore(err)
 	}
 	return nil
 }

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -67,6 +67,8 @@ func (applier *CommandApplier) ApplyCommand(op string, value []byte) interface{}
 		return applier.writeRecovery(value)
 	case "write-recovery-step":
 		return applier.writeRecoveryStep(value)
+	case "resolve-recovery":
+		return applier.resolveRecovery(value)
 	case "disable-global-recoveries":
 		return applier.disableGlobalRecoveries(value)
 	case "enable-global-recoveries":
@@ -187,7 +189,7 @@ func (applier *CommandApplier) writeRecovery(value []byte) interface{} {
 	if err := json.Unmarshal(value, &topologyRecovery); err != nil {
 		return log.Errore(err)
 	}
-	if _, err := writeTopologyRecovery(&topologyRecovery, true); err != nil {
+	if _, err := writeTopologyRecovery(&topologyRecovery); err != nil {
 		return err
 	}
 	return nil
@@ -200,6 +202,17 @@ func (applier *CommandApplier) writeRecoveryStep(value []byte) interface{} {
 	}
 	err := writeTopologyRecoveryStep(&topologyRecoveryStep)
 	return err
+}
+
+func (applier *CommandApplier) resolveRecovery(value []byte) interface{} {
+	recoveryResolve := TopologyRecoveryResolve{}
+	if err := json.Unmarshal(value, &recoveryResolve); err != nil {
+		return log.Errore(err)
+	}
+	if err := writeResolveRecovery(recoveryResolve.Recovery, recoveryResolve.SuccessorInstance); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (applier *CommandApplier) disableGlobalRecoveries(value []byte) interface{} {

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -187,8 +187,10 @@ func (applier *CommandApplier) writeRecovery(value []byte) interface{} {
 	if err := json.Unmarshal(value, &topologyRecovery); err != nil {
 		return log.Errore(err)
 	}
-	_, err := writeTopologyRecovery(&topologyRecovery)
-	return err
+	if _, err := writeTopologyRecovery(&topologyRecovery, true); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (applier *CommandApplier) writeRecoveryStep(value []byte) interface{} {

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -141,11 +141,6 @@ func NewTopologyRecoveryStep(uid string, message string) *TopologyRecoveryStep {
 	}
 }
 
-type TopologyRecoveryResolve struct {
-	Recovery          *TopologyRecovery
-	SuccessorInstance *inst.Instance
-}
-
 type MasterRecoveryType string
 
 const (
@@ -235,11 +230,16 @@ func AuditTopologyRecovery(topologyRecovery *TopologyRecovery, message string) e
 }
 
 func resolveRecovery(topologyRecovery *TopologyRecovery, successorInstance *inst.Instance) error {
+	if successorInstance != nil {
+		topologyRecovery.SuccessorKey = &successorInstance.Key
+		topologyRecovery.SuccessorAlias = successorInstance.InstanceAlias
+		topologyRecovery.IsSuccessful = (successorInstance != nil)
+	}
 	if orcraft.IsRaftEnabled() {
-		_, err := orcraft.PublishCommand("resolve-recovery", TopologyRecoveryResolve{topologyRecovery, successorInstance})
+		_, err := orcraft.PublishCommand("resolve-recovery", topologyRecovery)
 		return err
 	} else {
-		return writeResolveRecovery(topologyRecovery, successorInstance)
+		return writeResolveRecovery(topologyRecovery)
 	}
 }
 

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -233,7 +233,7 @@ func resolveRecovery(topologyRecovery *TopologyRecovery, successorInstance *inst
 	if successorInstance != nil {
 		topologyRecovery.SuccessorKey = &successorInstance.Key
 		topologyRecovery.SuccessorAlias = successorInstance.InstanceAlias
-		topologyRecovery.IsSuccessful = (successorInstance != nil)
+		topologyRecovery.IsSuccessful = true
 	}
 	if orcraft.IsRaftEnabled() {
 		_, err := orcraft.PublishCommand("resolve-recovery", topologyRecovery)


### PR DESCRIPTION
This PR fixes an issue where in a raft setup, a recovery done by the leader is propagated to all nodes, but is only marked as "successful" on the leader, while remains "failed" on the other nodes.