### PR TITLE
special push to packagecloud for centos6 packages

### DIFF
--- a/script/packagecloud-push.rb
+++ b/script/packagecloud-push.rb
@@ -60,9 +60,16 @@ def distro_names_for(filename)
     if filename.include?(".deb") and pattern .include?("debian")
       result.concat distros
     end
+
     if filename.include?(".rpm") and pattern .include?("centos")
-      result.concat distros
+      if filename.include?("centos6") and pattern.include?("centos/6")
+        result.concat distros
+      end
+      if !filename.include?("centos6") and !pattern.include?("centos/6")
+        result.concat distros
+      end
     end
+
     if filename.include?(pattern)
       result.concat distros
     end


### PR DESCRIPTION
Push to packagecloud script identifies `centos` substring and pushes to `el/6`; otherwise all `rpm`s are pushed to `el/7` and `fedora/*`.