### PR TITLE
Automated Pseudo-GTID injection

### DIFF
--- a/docs/configuration-discovery-pseudo-gtid.md
+++ b/docs/configuration-discovery-pseudo-gtid.md
@@ -19,7 +19,7 @@ You will further need to grant the following on your MySQL servers:
 GRANT DROP ON _pseudo_gtid_.* to 'orchestrator'@'orch_host';
 ```
 
-**NOTE**: the `_pseudo_gtid_` doesn't need to exist. There is no need to create it. `orchestrator` will run queries of the form:
+**NOTE**: the `_pseudo_gtid_` schema doesn't need to exist. There is no need to create it. `orchestrator` will run queries of the form:
 
 ```sql
 drop view if exists `_pseudo_gtid_`.`_asc:5a64a70e:00000001:c7b8154ff5c3c6d8`
@@ -42,7 +42,10 @@ If you wish to enable auto-Pseudo-GTID injection having run manual Pseudo-GTID i
 
 ### Manual Pseudo-GTID injection
 
+[Automated Pseudo-GTID](#automated-pseudo-gtid-injection) is the recommended method.
+
 If you wish to inject Pseudo-GTID yourself, we suggest you should configure as follows:
+
 ```json
 {
   "PseudoGTIDPattern": "drop view if exists `meta`.`_pseudo_gtid_hint__asc:",

--- a/docs/configuration-discovery-pseudo-gtid.md
+++ b/docs/configuration-discovery-pseudo-gtid.md
@@ -4,7 +4,45 @@
 
 See [Pseudo GTID](pseudo-gtid.md)
 
-If you wish to use Pseudo-GTID, we suggest you should configure as follows:
+### Automated Pseudo-GTID injection
+
+`orchestrator` can inject Pseudo-GTID entries for you and save you the trouble. You will configure:
+```json
+{
+  "AutoPseudoGTID": true,
+}
+```
+And you may ignore any other Pseudo-GTID related configuration (they will all be implicitly overriden by `orchestrator`).
+
+You will further need to grant the following on your MySQL servers:
+```sql
+GRANT DROP ON _pseudo_gtid_.* to 'orchestrator'@'orch_host';
+```
+
+**NOTE**: the `_pseudo_gtid_` doesn't need to exist. There is no need to create it. `orchestrator` will run queries of the form:
+
+```sql
+drop view if exists `_pseudo_gtid_`.`_asc:5a64a70e:00000001:c7b8154ff5c3c6d8`
+```
+
+Those statements will do nothing but will serve as magic markers in the binary logs.
+
+`orchestrator` will only attempt injecting Pseudo-GTID where it is allowed to do so. If you want to limit Pseudo-GTID injection to specific clusters, you may do so by only granting the privilege on those clusters you want `orchestrator` to inject Pseudo-GTID. You may disable Pseudo-GTID injection on a specific cluster via:
+
+```sql
+REVOKE DROP ON _pseudo_gtid_.* FROM 'orchestrator'@'orch_host';
+```
+
+Automated Pseudo-GTID injection is a newer development which supersedes the need for you to run your own Pseudo-GTID injection.
+
+If you wish to enable auto-Pseudo-GTID injection having run manual Pseudo-GTID injection, you'll be happy to note that:
+
+- You will no longer need to manage a pseudo-GTID service / event scheduler.
+- And in particular you will not need to disable/enable Pseudo-GTID on old/promoted master upon master failover.
+
+### Manual Pseudo-GTID injection
+
+If you wish to inject Pseudo-GTID yourself, we suggest you should configure as follows:
 ```json
 {
   "PseudoGTIDPattern": "drop view if exists `meta`.`_pseudo_gtid_hint__asc:",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -97,21 +97,13 @@ $ curl -s "http://my.orchestrator.service:80/api/begin-downtime/my.hostname/3306
 
 The `orchestrator-client` script runs this very API call, wrapping it up and encoding the URL path. It can also automatically detect the leader, in case you don't want to run through a proxy.
 
-### Using Pseudo-GTID
+### Pseudo-GTID
 
-If you're not using GTID, you can inject your own Pseudo-GTID entries, and `orchestrator` will be able to run GTID-like magic such as correlating two unrelated servers and making one replicate from the other.
+If you're not using GTID, you'll be happy to know `orchestrator` can utilize Pseudo-GTID to achieve similar benefits to GTID, such as correlating two unrelated servers and making one replicate from the other. This implies master and intermediate master failovers.
 
 Read more on the [Pseudo-GTID](pseudo-gtid.md) documentation page.
 
-On your masters, run the [pseudo-gtid](https://github.com/github/orchestrator/blob/master/resources/pseudo-gtid/bin/pseudo-gtid) script as a service. See `pupept` [example](https://github.com/github/orchestrator/blob/master/resources/pseudo-gtid/puppet).
-
-The service will inject Pseudo-GTID entries, to be replicated downstream.
-
-The script assumes the existence of a `meta.pseudo_gtid_status` table. Strictly speaking, this table doesn't have to exist, and you can strip away the code from the [pseudo-gtid](https://github.com/github/orchestrator/blob/master/resources/pseudo-gtid/bin/pseudo-gtid) script that writes to this table. However, the table comes handy in making the pseudo-GTID entries visible via SQL (they're otherwise only visible in the binary log).
-
-Code for this table creation is found in [pseudo-gtid.sql](https://github.com/github/orchestrator/blob/master/resources/pseudo-gtid/pseudo-gtid.sql). This SQL file also suggests an alternative to the `pseudo-gtid` service, in the form of `event_scheduler`. Choose your preferred method.
-
-It should be noted that as part of failovers, you should make sure to disable pseudo-GTID on demoted master and enable it on promoted master.
+`orchestrator` can inject Pseudo-GTID entires for you. Your clusters will magically have GTID-like superpowers. Follow [Automated Pseudo-GTID](configuration-discovery-pseudo-gtid.md#automated-pseudo-gtid-injection)
 
 ### Populating meta data
 

--- a/docs/pseudo-gtid-manual-injection.md
+++ b/docs/pseudo-gtid-manual-injection.md
@@ -119,8 +119,6 @@ While the statement is visible in the binary logs, it is not visible in the data
 
 The logic above also makes sure injected pseudo-gtid entires are in Ascending lexical order. The `PseudoGTIDMonotonicHint` config relates to the `asc:` hint in the query. Ascending order allows orchestrator to perform further optimizations when searching for a given Pseudo-GTID entry on a server's binary logs.
 
-The author of `orchestrator` uses this last method injection.
-
 `orchestrator` will only enable Pseudo-GTID mode if the `PseudoGTIDPattern` configuration variable is non-empty, but can only validate its correctness during runtime.
 
 If your pattern is incorrect (thus, `orchestrator` in unable to find pattern in the binary logs), you will not be able to move replicas in the topology via Pseudo-GTID, and you will only find this out upon attempting to.

--- a/docs/pseudo-gtid-manual-injection.md
+++ b/docs/pseudo-gtid-manual-injection.md
@@ -1,0 +1,128 @@
+### Manual Pseudo-GTID injection
+
+[Automated Pseudo-GTID](configuration-discovery-pseudo-gtid.md#automated-pseudo-gtid-injection) is a later addition which supersedes the need for manual Pseudo-GTID injection, and is recommended. However, you may still choose to inject your own Pseudo-GTID.
+
+To enable Pseudo GTID manually you need to:
+
+1. Frequently inject a unique entry into the binary logs
+2. Configure orchestrator to recognize such an entry
+3. Optionally hint to orchestrator that such entries are in ascending order
+
+Injecting an entry in the binary log is a matter of issuing a statement. Depending on whether you're using
+statement based replication or row based replication, such a statement could be an `INSERT`, `CREATE` or other.
+Please consult these blog entries:
+[Pseudo GTID](http://code.openark.org/blog/mysql/pseudo-gtid),
+[Pseudo GTID, Row Based Replication](http://code.openark.org/blog/mysql/pseudo-gtid-row-based-replication),
+[Refactoring replication topology with Pseudo GTID](http://code.openark.org/blog/mysql/refactoring-replication-topology-with-pseudo-gtid)
+for more detail.
+
+Injecting Pseudo GTID can be done via:
+- MySQL's [event_scheduler](https://dev.mysql.com/doc/refman/5.7/en/event-scheduler.html) (see examples below)
+- External injection, see [sample files](https://github.com/github/orchestrator/tree/master/resources/pseudo-gtid):
+  - script to inject pseudo-gtid
+  - start-stop script to serve as daemon on `/etc/init.d/pseudo-gtid`
+  - a puppet module.
+
+#### Ascending Pseudo GTID via DROP VIEW IF EXISTS & INSERT INTO ... ON DUPLICATE KEY UPDATE
+
+```sql
+create database if not exists meta;
+use meta;
+
+create table if not exists pseudo_gtid_status (
+    anchor                      int unsigned not null,
+    originating_mysql_host      varchar(128) charset ascii not null,
+    originating_mysql_port      int unsigned not null,
+    originating_server_id       int unsigned not null,
+    time_generated              timestamp not null default current_timestamp,
+    pseudo_gtid_uri             varchar(255) charset ascii not null,
+    pseudo_gtid_hint            varchar(255) charset ascii not null,
+    PRIMARY KEY (anchor)
+);
+
+drop event if exists create_pseudo_gtid_event;
+delimiter $$
+create event if not exists
+create_pseudo_gtid_event
+on schedule every 5 second starts current_timestamp
+on completion preserve
+enable
+do
+    main: begin
+    DECLARE lock_result INT;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+
+    IF @@global.read_only = 1 THEN
+        LEAVE main;
+    END IF;
+
+    SET lock_result = GET_LOCK('pseudo_gtid_status', 0);
+    IF lock_result = 1 THEN
+        set @connection_id := connection_id();
+        set @now := now();
+        set @rand := floor(rand()*(1 << 32));
+        set @pseudo_gtid_hint := concat_ws(':', lpad(hex(unix_timestamp(@now)), 8, '0'), lpad(hex(@connection_id), 16, '0'), lpad(hex(@rand), 8, '0'));
+        set @_create_statement := concat('drop ', 'view if exists `meta`.`_pseudo_gtid_', 'hint__asc:', @pseudo_gtid_hint, '`');
+        PREPARE st FROM @_create_statement;
+        EXECUTE st;
+        DEALLOCATE PREPARE st;
+
+        /*!50600
+        SET innodb_lock_wait_timeout = 1;
+         */
+        set @serverid := @@server_id;
+        set @hostname := @@hostname;
+        set @port := @@port;
+        set @pseudo_gtid := concat('pseudo-gtid://', @hostname, ':', @port, '/', @serverid, '/', date(@now), '/', time(@now), '/', @rand);
+        insert into pseudo_gtid_status (
+            anchor,
+            originating_mysql_host,
+            originating_mysql_port,
+            originating_server_id,
+            time_generated,
+            pseudo_gtid_uri,
+            pseudo_gtid_hint
+        )
+        values (1, @hostname, @port, @serverid, @now, @pseudo_gtid, @pseudo_gtid_hint)
+        on duplicate key update
+        originating_mysql_host = values(originating_mysql_host),
+        originating_mysql_port = values(originating_mysql_port),
+        originating_server_id = values(originating_server_id),
+        time_generated = values(time_generated),
+        pseudo_gtid_uri = values(pseudo_gtid_uri),
+        pseudo_gtid_hint = values(pseudo_gtid_hint)
+        ;
+        SET lock_result = RELEASE_LOCK('pseudo_gtid_status');
+    END IF;
+end main
+$$
+
+delimiter ;
+
+set global event_scheduler := 1;
+```
+
+   and the matching configuration entries:
+
+```json
+{
+  "PseudoGTIDPattern": "drop view if exists .*?`_pseudo_gtid_hint__",
+  "DetectPseudoGTIDQuery": "select count(*) as pseudo_gtid_exists from meta.pseudo_gtid_status where anchor = 1 and time_generated > now() - interval 2 day",
+  "PseudoGTIDMonotonicHint": "asc:",
+}
+```
+
+The above attempts to drop a view which does not actually exist. The statement does nothing in reality, and yet
+propagates through replication stream. As opposed to previous example, it will not use excessive locking.
+
+While the statement is visible in the binary logs, it is not visible in the data itself. A second statement registers the latest update in table data. It is not strictly required, but helps to make sure pseudo-gtid is running. The `DetectPseudoGTIDQuery` config allows `orchestrator` to actually check if Pseudo-GTID was recently injected.
+
+The logic above also makes sure injected pseudo-gtid entires are in Ascending lexical order. The `PseudoGTIDMonotonicHint` config relates to the `asc:` hint in the query. Ascending order allows orchestrator to perform further optimizations when searching for a given Pseudo-GTID entry on a server's binary logs.
+
+The author of `orchestrator` uses this last method injection.
+
+`orchestrator` will only enable Pseudo-GTID mode if the `PseudoGTIDPattern` configuration variable is non-empty, but can only validate its correctness during runtime.
+
+If your pattern is incorrect (thus, `orchestrator` in unable to find pattern in the binary logs), you will not be able to move replicas in the topology via Pseudo-GTID, and you will only find this out upon attempting to.
+
+If you manage more that one topology with `orchestrator`, you will need to use same Pseudo GTID injection method for all, as there is only a single `PseudoGTIDPattern` value.

--- a/docs/pseudo-gtid.md
+++ b/docs/pseudo-gtid.md
@@ -20,7 +20,7 @@ Pseudo-GTID is attractive to users not using GTID. Pseudo-GTID has most of GTID'
 
 ### Automated Pseudo-GTID injection
 
-`orchestrator` can inject Pseudo-GTID entries for you.
+`orchestrator` can inject Pseudo-GTID entries for you. See [Automated Pseudo-GTID](configuration-discovery-pseudo-gtid.md#automated-pseudo-gtid-injection)
 
 ### Manual Pseudo-GTID injection
 

--- a/docs/pseudo-gtid.md
+++ b/docs/pseudo-gtid.md
@@ -26,26 +26,7 @@ Pseudo-GTID is attractive to users not using GTID. Pseudo-GTID has most of GTID'
 
 Automated Pseudo-GTID is a later addition which supersedes the need for manual Pseudo-GTID injection, and is recommended. However, you may still choose to inject your own Pseudo-GTID.
 
-To enable Pseudo GTID manually you need to:
-
-1. Frequently inject a unique entry into the binary logs
-2. Configure orchestrator to recognize such an entry
-3. Optionally hint to orchestrator that such entries are in ascending order
-
-Injecting an entry in the binary log is a matter of issuing a statement. Depending on whether you're using
-statement based replication or row based replication, such a statement could be an `INSERT`, `CREATE` or other.
-Please consult these blog entries:
-[Pseudo GTID](http://code.openark.org/blog/mysql/pseudo-gtid),
-[Pseudo GTID, Row Based Replication](http://code.openark.org/blog/mysql/pseudo-gtid-row-based-replication),
-[Refactoring replication topology with Pseudo GTID](http://code.openark.org/blog/mysql/refactoring-replication-topology-with-pseudo-gtid)
-for more detail.
-
-Injecting Pseudo GTID can be done via:
-- MySQL's [event_scheduler](https://dev.mysql.com/doc/refman/5.7/en/event-scheduler.html) (see examples below)
-- External injection, see [sample files](https://github.com/github/orchestrator/tree/master/resources/pseudo-gtid):
-  - script to inject pseudo-gtid
-  - start-stop script to serve as daemon on `/etc/init.d/pseudo-gtid`
-  - a puppet module.
+See [Manual Pseudo-GTID injection](pseudo-gtid-manual-injection.md)
 
 ### Limitations
 - Active-Active master-master replication not supported
@@ -57,115 +38,20 @@ Injecting Pseudo GTID can be done via:
 - An edge case scenario is known when replicating from `5.6` to `5.7`: `5.7` adds `ANONYMOUS` statements to the binary logs, which `orchestrator` knows how to skip. However if `5.6`->`5.7` replication breaks (e.g. dead master) and an `ANONYMOUS` statement is the last statement in the binary log, `orchestrator` is unable at this time to align the servers.
 
 
-#### Ascending Pseudo GTID via DROP VIEW IF EXISTS & INSERT INTO ... ON DUPLICATE KEY UPDATE
-
-```sql
-create database if not exists meta;
-use meta;
-
-create table if not exists pseudo_gtid_status (
-    anchor                      int unsigned not null,
-    originating_mysql_host      varchar(128) charset ascii not null,
-    originating_mysql_port      int unsigned not null,
-    originating_server_id       int unsigned not null,
-    time_generated              timestamp not null default current_timestamp,
-    pseudo_gtid_uri             varchar(255) charset ascii not null,
-    pseudo_gtid_hint            varchar(255) charset ascii not null,
-    PRIMARY KEY (anchor)
-);
-
-drop event if exists create_pseudo_gtid_event;
-delimiter $$
-create event if not exists
-create_pseudo_gtid_event
-on schedule every 5 second starts current_timestamp
-on completion preserve
-enable
-do
-    main: begin
-    DECLARE lock_result INT;
-    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
-
-    IF @@global.read_only = 1 THEN
-        LEAVE main;
-    END IF;
-
-    SET lock_result = GET_LOCK('pseudo_gtid_status', 0);
-    IF lock_result = 1 THEN
-        set @connection_id := connection_id();
-        set @now := now();
-        set @rand := floor(rand()*(1 << 32));
-        set @pseudo_gtid_hint := concat_ws(':', lpad(hex(unix_timestamp(@now)), 8, '0'), lpad(hex(@connection_id), 16, '0'), lpad(hex(@rand), 8, '0'));
-        set @_create_statement := concat('drop ', 'view if exists `meta`.`_pseudo_gtid_', 'hint__asc:', @pseudo_gtid_hint, '`');
-        PREPARE st FROM @_create_statement;
-        EXECUTE st;
-        DEALLOCATE PREPARE st;
-
-        /*!50600
-        SET innodb_lock_wait_timeout = 1;
-         */
-        set @serverid := @@server_id;
-        set @hostname := @@hostname;
-        set @port := @@port;
-        set @pseudo_gtid := concat('pseudo-gtid://', @hostname, ':', @port, '/', @serverid, '/', date(@now), '/', time(@now), '/', @rand);
-        insert into pseudo_gtid_status (
-            anchor,
-            originating_mysql_host,
-            originating_mysql_port,
-            originating_server_id,
-            time_generated,
-            pseudo_gtid_uri,
-            pseudo_gtid_hint
-        )
-        values (1, @hostname, @port, @serverid, @now, @pseudo_gtid, @pseudo_gtid_hint)
-        on duplicate key update
-        originating_mysql_host = values(originating_mysql_host),
-        originating_mysql_port = values(originating_mysql_port),
-        originating_server_id = values(originating_server_id),
-        time_generated = values(time_generated),
-        pseudo_gtid_uri = values(pseudo_gtid_uri),
-        pseudo_gtid_hint = values(pseudo_gtid_hint)
-        ;
-        SET lock_result = RELEASE_LOCK('pseudo_gtid_status');
-    END IF;
-end main
-$$
-
-delimiter ;
-
-set global event_scheduler := 1;
-```
-
-   and the matching configuration entries:
-
-```json
-{
-  "PseudoGTIDPattern": "drop view if exists .*?`_pseudo_gtid_hint__",
-  "DetectPseudoGTIDQuery": "select count(*) as pseudo_gtid_exists from meta.pseudo_gtid_status where anchor = 1 and time_generated > now() - interval 2 day",
-  "PseudoGTIDMonotonicHint": "asc:",
-}
-```
-
-The above attempts to drop a view which does not actually exist. The statement does nothing in reality, and yet
-propagates through replication stream. As opposed to previous example, it will not use excessive locking.
-
-While the statement is visible in the binary logs, it is not visible in the data itself. A second statement registers the latest update in table data. It is not strictly required, but helps to make sure pseudo-gtid is running. The `DetectPseudoGTIDQuery` config allows `orchestrator` to actually check if Pseudo-GTID was recently injected.
-
-The logic above also makes sure injected pseudo-gtid entires are in Ascending lexical order. The `PseudoGTIDMonotonicHint` config relates to the `asc:` hint in the query. Ascending order allows orchestrator to perform further optimizations when searching for a given Pseudo-GTID entry on a server's binary logs.
-
-The author of `orchestrator` uses this last method injection.
-
 ### Deploying Pseudo-GTID
 
 Please follow [deployment, Pseudo-GTID](deployment.md#pseudo-gtid).
 
 #### Using Pseudo GTID
 
-`orchestrator` will only enable Pseudo-GTID mode if the `PseudoGTIDPattern` configuration variable is non-empty,
-but can only validate its correctness during runtime.
-
-If your pattern is incorrect (thus, `orchestrator` in unable to find pattern in the binary logs), you will not be able to move replicas in the topology via Pseudo-GTID, and you will only find this out upon attempting to.
-
-If you manage more that one topology with `orchestrator`, you will need to use same Pseudo GTID injection method for all, as there is only a single `PseudoGTIDPattern` value.
+Via web:
 
 ![Orchestrator pseudo GTID demo](images/orchestrator-pseudo-gtid-relocate-demo.gif)
+
+Via command line:
+
+```
+orchestrator-client -c relocate -i some.server.to.relocate -d under.some.other.server
+```
+
+The `relocate` command will auto-identify that Pseudo-GTID is enabled.

--- a/docs/pseudo-gtid.md
+++ b/docs/pseudo-gtid.md
@@ -3,10 +3,30 @@
 Pseudo GTID is the method of injecting unique entries into the binary logs, such that they can be used to
 match/sync replicas without direct connection, or replicas whose master is corrupted/dead.
 
-`Orchestrator` leverages Pseudo GTID, when applicable, and allows for complex re-matching of replicas, including
-semi-automated fail over onto a replica and the moving of its siblings as its replicas.
+Pseudo-GTID is attractive to users not using GTID. Pseudo-GTID has most of GTID's benefits, but without making the commitment GTID requires. With Pseudo-GTID you can keep your existing topologies, whichever version of MySQL you're running.
 
-To enable Pseudo GTID you need to:
+### Advantages of Pseudo-GTID
+
+- Enable master failovers.
+- Enable intermediate master failovers.
+- Arbitrary refactoring, relocating replicas from one place to another (even those replicas that don't have binary logging).
+- Vendor neutral; works on both Oracle and MariaDB, even both combined.
+- No configuration changes. Your replication setup remains as it is.
+- No commitment. You can choose to move away from Pseudo-GTID at any time; just stop writing P-GTID entries.
+- Pseudo-GTID implies crash-safe replication for replicas running with:
+  - `log-slave-updates`
+  - `sync_binlog=1`
+- As opposed to GTID on MySQL `5.6`, servers don't _have to_ run with `log-slave-updates`, though `log-slave-updates` is recommended.
+
+### Automated Pseudo-GTID injection
+
+`orchestrator` can inject Pseudo-GTID entries for you.
+
+### Manual Pseudo-GTID injection
+
+Automated Pseudo-GTID is a later addition which supersedes the need for manual Pseudo-GTID injection, and is recommended. However, you may still choose to inject your own Pseudo-GTID.
+
+To enable Pseudo GTID manually you need to:
 
 1. Frequently inject a unique entry into the binary logs
 2. Configure orchestrator to recognize such an entry
@@ -26,19 +46,6 @@ Injecting Pseudo GTID can be done via:
   - script to inject pseudo-gtid
   - start-stop script to serve as daemon on `/etc/init.d/pseudo-gtid`
   - a puppet module.
-
-### Advantages of Pseudo-GTID
-
-- Vendor neutral; works on both Oracle and MariaDB, even both combined.
-- No configuration changes. Your replication setup remains as it is.
-- No commitment. You can choose to move away from Pseudo-GTID at any time; just stop writing P-GTID entries.
-- Pseudo-GTID allows **arbitrary refactoring**, relocating replicas from one place to another
-- Pseudo-GTID enables master crash recovery by aligning all replicas and healing the topology
-- Pseudo-GTID enables intermediate master recovery by either aligning or relocating all orphaned replicas.
-- Pseudo-GTID implies crash-safe replication for replicas running with:
-  - `log-slave-updates`
-  - `sync_binlog=1`
-- As opposed to MySQL `5.6`, servers don't _have to_ run with `log-slave-updates`, though `log-slave-updates` is recommended.
 
 ### Limitations
 - Active-Active master-master replication not supported

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -54,6 +54,7 @@ const (
 	DebugMetricsIntervalSeconds                  = 10
 	PseudoGTIDSchema                             = "_pseudo_gtid_"
 	PseudoGTIDIntervalSeconds                    = 5
+	CheckAutoPseudoGTIDGrantsIntervalSeconds     = 60
 )
 
 var deprecatedConfigurationVariables = []string{

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -354,6 +354,7 @@ func newConfiguration() *Configuration {
 		UnseenAgentForgetHours:                     6,
 		StaleSeedFailMinutes:                       60,
 		SeedAcceptableBytesDiff:                    8192,
+		AutoPseudoGTID:                             false,
 		PseudoGTIDPattern:                          "",
 		PseudoGTIDPatternIsFixedSubstring:          false,
 		PseudoGTIDMonotonicHint:                    "",

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -55,6 +55,7 @@ const (
 	PseudoGTIDSchema                             = "_pseudo_gtid_"
 	PseudoGTIDIntervalSeconds                    = 5
 	CheckAutoPseudoGTIDGrantsIntervalSeconds     = 60
+	SelectTrueQuery                              = "select 1"
 )
 
 var deprecatedConfigurationVariables = []string{
@@ -535,7 +536,7 @@ func (this *Configuration) postReadAdjustments() error {
 		this.PseudoGTIDPattern = "drop view if exists `_pseudo_gtid_`"
 		this.PseudoGTIDPatternIsFixedSubstring = true
 		this.PseudoGTIDMonotonicHint = "asc:"
-		this.DetectPseudoGTIDQuery = ""
+		this.DetectPseudoGTIDQuery = SelectTrueQuery
 		this.PseudoGTIDPreferIndependentMultiMatch = true
 	}
 	return nil

--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -232,9 +232,19 @@ func (this *Instance) FlavorNameAndMajorVersion() string {
 	return this.FlavorName + "-" + this.MajorVersionString()
 }
 
-// IsReplica makes simple heuristics to decide whether this insatnce is a replica of another instance
+// IsReplica makes simple heuristics to decide whether this instance is a replica of another instance
 func (this *Instance) IsReplica() bool {
 	return this.MasterKey.Hostname != "" && this.MasterKey.Hostname != "_" && this.MasterKey.Port != 0 && (this.ReadBinlogCoordinates.LogFile != "" || this.UsingGTID())
+}
+
+// IsMaster makes simple heuristics to decide whether this instance is a master (not replicating from any other server)
+func (this *Instance) IsMaster() bool {
+	return !this.IsReplica()
+}
+
+// IsWritableMaster makes simple heuristics to decide whether this instance is a writable master (not replicating from any other server)
+func (this *Instance) IsWritableMaster() bool {
+	return this.IsMaster() && !this.ReadOnly
 }
 
 // ReplicaRunning returns true when this instance's status is of a replicating replica.

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -352,7 +352,9 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 		}
 
 		instance.UsingPseudoGTID = false
-		if config.Config.DetectPseudoGTIDQuery != "" {
+		if config.Config.AutoPseudoGTID {
+			instance.UsingPseudoGTID = true
+		} else if config.Config.DetectPseudoGTIDQuery != "" {
 			waitGroup.Add(1)
 			go func() {
 				defer waitGroup.Done()

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -352,7 +352,7 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 		}
 
 		instance.UsingPseudoGTID = false
-		if config.Config.AutoPseudoGTID {
+		if config.Config.DetectPseudoGTIDQuery == config.SelectTrueQuery {
 			instance.UsingPseudoGTID = true
 		} else if config.Config.DetectPseudoGTIDQuery != "" {
 			waitGroup.Add(1)

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -987,7 +987,7 @@ func injectPseudoGTID(instance *Instance) (hint string, err error) {
 	}
 
 	now := time.Now()
-	randomHash := process.NewToken().Hash[0:16]
+	randomHash := process.RandomHash()[0:16]
 	hint = fmt.Sprintf("%.8x:%.8x:%s", now.Unix(), instance.ServerID, randomHash)
 	query := fmt.Sprintf("drop view if exists `%s`.`_asc:%s`", config.PseudoGTIDSchema, hint)
 	_, err = ExecInstance(&instance.Key, query)
@@ -1038,6 +1038,8 @@ func canInjectPseudoGTID(instanceKey *InstanceKey) (canInject bool, err error) {
 	return canInject, nil
 }
 
+// InjectPseudoGTIDOnWriters will inject a PseudoGTID entry on all writable, accessible,
+// supported writers.
 func InjectPseudoGTIDOnWriters() error {
 	instances, err := ReadWriteableClustersMasters()
 	if err != nil {

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -426,7 +426,7 @@ func ContinuousDiscovery() {
 			}()
 		case <-autoPseudoGTIDTick:
 			go func() {
-				if config.Config.AutoPseudoGTID {
+				if config.Config.AutoPseudoGTID && IsLeaderOrActive() {
 					go inst.InjectPseudoGTIDOnWriters()
 				}
 			}()

--- a/go/process/token.go
+++ b/go/process/token.go
@@ -24,17 +24,21 @@ import (
 	"time"
 )
 
-func GetHash(input []byte) string {
+func toHash(input []byte) string {
 	hasher := sha256.New()
 	hasher.Write(input)
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
-func GetRandomData() []byte {
+func getRandomData() []byte {
 	size := 64
 	rb := make([]byte, size)
 	_, _ = rand.Read(rb)
 	return rb
+}
+
+func RandomHash() string {
+	return toHash(getRandomData())
 }
 
 // Token is used to identify and validate requests to this service
@@ -46,7 +50,7 @@ var ProcessToken *Token = NewToken()
 
 func NewToken() *Token {
 	return &Token{
-		Hash: GetHash(GetRandomData()),
+		Hash: RandomHash(),
 	}
 }
 

--- a/go/process/token_test.go
+++ b/go/process/token_test.go
@@ -1,0 +1,24 @@
+package process
+
+import (
+	test "github.com/openark/golib/tests"
+	"testing"
+)
+
+func init() {
+}
+
+func TestNewToken(t *testing.T) {
+	token1 := NewToken()
+
+	test.S(t).ExpectNotEquals(token1.Hash, "")
+	test.S(t).ExpectEquals(len(token1.Hash), 64)
+}
+
+func TestNewTokenRandom(t *testing.T) {
+	token1 := NewToken()
+	token2 := NewToken()
+
+	// The following test can fail once in a quadrazillion eons
+	test.S(t).ExpectNotEquals(token1.Hash, token2.Hash)
+}


### PR DESCRIPTION
This small PR takes a big conceptual step with automated injection of Pseudo-GTID, credit @sjmudd for suggesting this.

A new config variable is introduced: `AutoPseudoGTID`, default `false` for backwards compatibility.
When this variable is set to `true`:

- `orchestrator` will automatically inject Pseudo GTID entries on writable, accessible masters
- Users will need to `GRANT DROP ON _pseudo_gtid_.* TO <orchestrator user>`.
- There is no need to create the `_pseudo_gtid_` schema.
- The following config variables are implied and ignored, and thus the user does not need to specify them anymore:
  `PseudoGTIDPattern`, `PseudoGTIDPatternIsFixedSubstring`, `PseudoGTIDMonotonicHint`, `DetectPseudoGTIDQuery`, `PseudoGTIDPreferIndependentMultiMatch`
- `orchestrator` will inject pseudo-GTID on writable masters every `5sec`
- There is no need to inject pseudo-GTID from an external source. The user can & should cancel any daemon scripts or `event_scheduler` entries.

This PR is benefical for various reasons:

- Simpler setup
- There is much confusion about how `orchestrator` can perform failovers, and whether GTID is strictly required or whatnot. Now it will just be "yes it can"
- This removes a step from the failover process, as the user need not be concerned with starting/stopping external scripts for pseudo-GTID or enabling/disabling a `event_scheduler` event.