### PR TITLE
suggest-promoted-replacement -> internal-suggest-promoted-replacement

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1393,15 +1393,6 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			}
 			fmt.Println(fmt.Sprintf("%d recoveries acknowldged", countRecoveries))
 		}
-	case registerCliCommand("suggest-promoted-replacement", "Recovery", `Information command suggesting the best would-be replacement to master of given cluster`):
-		{
-			destination := validateInstanceIsFound(destinationKey)
-			replacement, _, err := logic.SuggestReplacementForPromotedReplica(&logic.TopologyRecovery{}, instanceKey, destination, nil)
-			if err != nil {
-				log.Fatale(err)
-			}
-			fmt.Println(replacement.Key.DisplayString())
-		}
 	// Instance meta
 	case registerCliCommand("register-candidate", "Instance, meta", `Indicate that a specific instance is a preferred candidate for master promotion`):
 		{
@@ -1531,6 +1522,15 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			config.RuntimeCLIFlags.ConfiguredVersion = ""
 			inst.ReadClusters()
 			fmt.Println("Redeployed internal db")
+		}
+	case registerCliCommand("internal-suggest-promoted-replacement", "Internal", `Internal only, used to test promotion logic in CI`):
+		{
+			destination := validateInstanceIsFound(destinationKey)
+			replacement, _, err := logic.SuggestReplacementForPromotedReplica(&logic.TopologyRecovery{}, instanceKey, destination, nil)
+			if err != nil {
+				log.Fatale(err)
+			}
+			fmt.Println(replacement.Key.DisplayString())
 		}
 	case registerCliCommand("custom-command", "Agent", "Execute a custom command on the agent as defined in the agent conf"):
 		{

--- a/tests/integration/suggest-promoted-replacement-candidate-different-dc/extra_args
+++ b/tests/integration/suggest-promoted-replacement-candidate-different-dc/extra_args
@@ -1,1 +1,1 @@
--c suggest-promoted-replacement -i testhost:22293 -d testhost:22294
+-c internal-suggest-promoted-replacement -i testhost:22293 -d testhost:22294

--- a/tests/integration/suggest-promoted-replacement-candidate-same-dc/extra_args
+++ b/tests/integration/suggest-promoted-replacement-candidate-same-dc/extra_args
@@ -1,1 +1,1 @@
--c suggest-promoted-replacement -i testhost:22293 -d testhost:22294
+-c internal-suggest-promoted-replacement -i testhost:22293 -d testhost:22294

--- a/tests/integration/suggest-promoted-replacement-different-dc/extra_args
+++ b/tests/integration/suggest-promoted-replacement-different-dc/extra_args
@@ -1,1 +1,1 @@
--c suggest-promoted-replacement -i testhost:22293 -d testhost:22294
+-c internal-suggest-promoted-replacement -i testhost:22293 -d testhost:22294

--- a/tests/integration/suggest-promoted-replacement-ignore-no-binlog/extra_args
+++ b/tests/integration/suggest-promoted-replacement-ignore-no-binlog/extra_args
@@ -1,1 +1,1 @@
--c suggest-promoted-replacement -i testhost:22293 -d testhost:22294
+-c internal-suggest-promoted-replacement -i testhost:22293 -d testhost:22294

--- a/tests/integration/suggest-promoted-replacement-is-candidate/extra_args
+++ b/tests/integration/suggest-promoted-replacement-is-candidate/extra_args
@@ -1,1 +1,1 @@
--c suggest-promoted-replacement -i testhost:22293 -d testhost:22294
+-c internal-suggest-promoted-replacement -i testhost:22293 -d testhost:22294

--- a/tests/integration/suggest-promoted-replacement-multiple-candidates-2/extra_args
+++ b/tests/integration/suggest-promoted-replacement-multiple-candidates-2/extra_args
@@ -1,1 +1,1 @@
--c suggest-promoted-replacement -i testhost:22293 -d testhost:22294
+-c internal-suggest-promoted-replacement -i testhost:22293 -d testhost:22294

--- a/tests/integration/suggest-promoted-replacement-multiple-candidates/extra_args
+++ b/tests/integration/suggest-promoted-replacement-multiple-candidates/extra_args
@@ -1,1 +1,1 @@
--c suggest-promoted-replacement -i testhost:22293 -d testhost:22294
+-c internal-suggest-promoted-replacement -i testhost:22293 -d testhost:22294

--- a/tests/integration/suggest-promoted-replacement-prefer-not-2/extra_args
+++ b/tests/integration/suggest-promoted-replacement-prefer-not-2/extra_args
@@ -1,1 +1,1 @@
--c suggest-promoted-replacement -i testhost:22293 -d testhost:22294
+-c internal-suggest-promoted-replacement -i testhost:22293 -d testhost:22294

--- a/tests/integration/suggest-promoted-replacement-prefer-not/extra_args
+++ b/tests/integration/suggest-promoted-replacement-prefer-not/extra_args
@@ -1,1 +1,1 @@
--c suggest-promoted-replacement -i testhost:22293 -d testhost:22294
+-c internal-suggest-promoted-replacement -i testhost:22293 -d testhost:22294

--- a/tests/integration/suggest-promoted-replacement-trivial/extra_args
+++ b/tests/integration/suggest-promoted-replacement-trivial/extra_args
@@ -1,1 +1,1 @@
--c suggest-promoted-replacement -i testhost:22293 -d testhost:22294
+-c internal-suggest-promoted-replacement -i testhost:22293 -d testhost:22294


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/381

The command `suggest-promoted-replacement` is for internal use only, and should no be used by users (rather, it provides no benefit to users).
As such, it has been renamed to `internal-suggest-promoted-replacement`.

```shell
$ orchestrator -c help

...
Meta:
	snapshot-topologies                     Take a snapshot of existing topologies.
	continuous                              Enter continuous mode, and actively poll for instances, diagnose problems, do maintenance
	active-nodes                            List currently active orchestrator nodes
	access-token                            Get a HTTP access token
	resolve                                 Resolve given hostname
	reset-hostname-resolve-cache            Clear the hostname resolve cache
	dump-config                             Print out configuration in JSON format
	show-resolve-hosts                      Show the content of the hostname_resolve table. Generally used for debugging
	show-unresolve-hosts                    Show the content of the hostname_unresolve table. Generally used for debugging
Meta, internal:
	redeploy-internal-db                    Force internal schema migration to current backend structure
Internal:
	internal-suggest-promoted-replacement   Internal only, used to test promotion logic in CI
Agent:
	custom-command                          Execute a custom command on the agent as defined in the agent conf
...
```
