### PR TITLE
Auto pseudo-gtid: raft considerations

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -54,6 +54,7 @@ const (
 	DebugMetricsIntervalSeconds                  = 10
 	PseudoGTIDSchema                             = "_pseudo_gtid_"
 	PseudoGTIDIntervalSeconds                    = 5
+	PseudoGTIDExpireMinutes                      = 60
 	CheckAutoPseudoGTIDGrantsIntervalSeconds     = 60
 	SelectTrueQuery                              = "select 1"
 )

--- a/go/db/generate_base.go
+++ b/go/db/generate_base.go
@@ -809,4 +809,12 @@ var generateSQLBase = []string{
 			PRIMARY KEY (store_key)
 		) ENGINE=InnoDB DEFAULT CHARSET=ascii
 	`,
+	`
+		CREATE TABLE IF NOT EXISTS database_instance_injected_pseudo_gtid (
+			hostname varchar(128) NOT NULL,
+			port smallint(5) unsigned NOT NULL,
+			time_injected timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (hostname, port)
+		) ENGINE=InnoDB DEFAULT CHARSET=ascii
+	`,
 }

--- a/go/db/generate_base.go
+++ b/go/db/generate_base.go
@@ -810,11 +810,10 @@ var generateSQLBase = []string{
 		) ENGINE=InnoDB DEFAULT CHARSET=ascii
 	`,
 	`
-		CREATE TABLE IF NOT EXISTS database_instance_injected_pseudo_gtid (
-			hostname varchar(128) NOT NULL,
-			port smallint(5) unsigned NOT NULL,
+		CREATE TABLE IF NOT EXISTS cluster_injected_pseudo_gtid (
+			cluster_name varchar(128) NOT NULL,
 			time_injected timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			PRIMARY KEY (hostname, port)
+			PRIMARY KEY (cluster_name)
 		) ENGINE=InnoDB DEFAULT CHARSET=ascii
 	`,
 }

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -990,10 +990,7 @@ func injectPseudoGTID(instance *Instance) (hint string, err error) {
 	randomHash := process.RandomHash()[0:16]
 	hint = fmt.Sprintf("%.8x:%.8x:%s", now.Unix(), instance.ServerID, randomHash)
 	query := fmt.Sprintf("drop view if exists `%s`.`_asc:%s`", config.PseudoGTIDSchema, hint)
-	if _, err = ExecInstance(&instance.Key, query); err == nil {
-		pseudoGTIDInjectedClusters.Set(instance.ClusterName, true, cache.DefaultExpiration)
-	}
-
+	_, err = ExecInstance(&instance.Key, query)
 	return hint, log.Errore(err)
 }
 
@@ -1066,7 +1063,7 @@ func InjectPseudoGTIDOnWriters() error {
 			if _, err := injectPseudoGTID(instance); err != nil {
 				return log.Errore(err)
 			}
-			if err := RegisterInjectedPseudoGTID(&instance.Key); err != nil {
+			if err := RegisterInjectedPseudoGTID(instance.ClusterName); err != nil {
 				return log.Errore(err)
 			}
 			return nil

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -998,7 +998,7 @@ func injectPseudoGTID(instance *Instance) (hint string, err error) {
 }
 
 // canInjectPseudoGTID checks orchestrator's grants to determine whether is has the
-// privilige of auto-injecting pseudo-GTID
+// privilege of auto-injecting pseudo-GTID
 func canInjectPseudoGTID(instanceKey *InstanceKey) (canInject bool, err error) {
 	if canInject, found := supportedAutoPseudoGTIDWriters.Get(instanceKey.StringCode()); found {
 		return canInject.(bool), nil
@@ -1064,6 +1064,9 @@ func InjectPseudoGTIDOnWriters() error {
 				return nil
 			}
 			if _, err := injectPseudoGTID(instance); err != nil {
+				return log.Errore(err)
+			}
+			if err := RegisterInjectedPseudoGTID(&instance.Key); err != nil {
 				return log.Errore(err)
 			}
 			return nil

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -45,6 +45,8 @@ func (applier *CommandApplier) ApplyCommand(op string, value []byte) interface{}
 		return applier.registerNode(value)
 	case "discover":
 		return applier.discover(value)
+	case "injected-pseudo-gtid":
+		return applier.injectedPseudoGTID(value)
 	case "forget":
 		return applier.forget(value)
 	case "forget-cluster":
@@ -94,6 +96,19 @@ func (applier *CommandApplier) discover(value []byte) interface{} {
 		return log.Errore(err)
 	}
 	discoverInstance(instanceKey)
+	return nil
+}
+
+func (applier *CommandApplier) injectedPseudoGTID(value []byte) interface{} {
+	var clusterName string
+	if err := json.Unmarshal(value, &clusterName); err != nil {
+		return log.Errore(err)
+	}
+	log.Infof("................injectedPseudoGTID  %+v", clusterName)
+	if !orcraft.IsLeader() {
+		log.Infof("................injectedPseudoGTID register %+v", clusterName)
+		inst.RegisterInjectedPseudoGTID(clusterName)
+	}
 	return nil
 }
 

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -105,10 +105,7 @@ func (applier *CommandApplier) injectedPseudoGTID(value []byte) interface{} {
 		return log.Errore(err)
 	}
 	log.Infof("................injectedPseudoGTID  %+v", clusterName)
-	if !orcraft.IsLeader() {
-		log.Infof("................injectedPseudoGTID register %+v", clusterName)
-		inst.RegisterInjectedPseudoGTID(clusterName)
-	}
+	inst.RegisterInjectedPseudoGTID(clusterName)
 	return nil
 }
 

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -356,6 +356,9 @@ func onHealthTick() {
 	}
 }
 
+// publishDiscoverMasters will publish to raft a discovery request for all known masters.
+// This makes for a best-effort keep-in-sync between raft nodes, where some may have
+// inconsistent data due to hosts being forgotten, for example.
 func publishDiscoverMasters() error {
 	instances, err := inst.ReadWriteableClustersMasters()
 	if err == nil {
@@ -452,6 +455,7 @@ func ContinuousDiscovery() {
 					go inst.ExpirePoolInstances()
 					go inst.FlushNontrivialResolveCacheToDatabase()
 					go inst.ExpireInstanceBinlogFileHistory()
+					go inst.ExpireRegisteredInjectedPseudoGTID()
 					go process.ExpireNodesHistory()
 					go process.ExpireAccessTokens()
 					go process.ExpireAvailableNodes()

--- a/go/logic/snapshot_data.go
+++ b/go/logic/snapshot_data.go
@@ -39,6 +39,7 @@ type SnapshotData struct {
 	HostAttributes,
 	AccessToken,
 	PoolInstances,
+	InjectedPseudoGTIDInstances,
 	HostnameResolves,
 	HostnameUnresolves,
 	DowntimedInstances,
@@ -92,6 +93,7 @@ func CreateSnapshotData() *SnapshotData {
 	readTableData("kv_store", &snapshotData.KVStore)
 	readTableData("topology_recovery", &snapshotData.Recovery)
 	readTableData("topology_recovery_steps", &snapshotData.RecoverySteps)
+	readTableData("database_instance_injected_pseudo_gtid", &snapshotData.InjectedPseudoGTIDInstances)
 
 	log.Debugf("raft snapshot data created")
 	return snapshotData
@@ -179,6 +181,7 @@ func (this *SnapshotDataCreatorApplier) Restore(rc io.ReadCloser) error {
 	writeTableData("topology_recovery", &snapshotData.Recovery)
 	writeTableData("topology_failure_detection", &snapshotData.Detections)
 	writeTableData("topology_recovery_steps", &snapshotData.RecoverySteps)
+	writeTableData("database_instance_injected_pseudo_gtid", &snapshotData.InjectedPseudoGTIDInstances)
 
 	// recovery disable
 	{


### PR DESCRIPTION
Followup to https://github.com/github/orchestrator/pull/384, with this PR:

- raft members are properly updating info about pseugo-GTID auto-injected by raft leader
- pseudo-GTID injection status is stored in backend table, persisted
- a reasonable caching is used
- a reasonable heuristic for existence of pseudo-GTID on instances is used.