### PR TITLE
Visual indicators for semi-sync enabled instances

### DIFF
--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -821,6 +821,12 @@ function renderInstanceElement(popoverElement, instance, renderType) {
     if (instance.HasReplicationFilters) {
       popoverElement.find("h3 div.pull-right").prepend('<span class="glyphicon glyphicon-filter" title="Using replication filters"></span> ');
     }
+    if (instance.SemiSyncMasterEnabled) {
+      popoverElement.find("h3 div.pull-right").prepend('<span class="glyphicon glyphicon-check" title="Semi sync enabled (master side)"></span> ');
+    }
+    if (instance.SemiSyncReplicaEnabled) {
+      popoverElement.find("h3 div.pull-right").prepend('<span class="glyphicon glyphicon-saved" title="Semi sync enabled (replica side)"></span> ');
+    }
     if (instance.LogBinEnabled && instance.LogSlaveUpdatesEnabled) {
       popoverElement.find("h3 div.pull-right").prepend('<span class="glyphicon glyphicon-forward" title="Logs slave updates"></span> ');
     }


### PR DESCRIPTION
Adding glyphs to indicate whether semi-sync is enabled on master/replica.

<img width="674" alt="screen shot 2018-01-28 at 10 10 20" src="https://user-images.githubusercontent.com/2607934/35480290-8527c15e-0413-11e8-8bd4-d6c0acfacd59.png">
