### PR TITLE
Auto Pseudo-GTID: ANSI quotes grant detection

### DIFF
--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -1029,7 +1029,13 @@ func canInjectPseudoGTID(instanceKey *InstanceKey) (canInject bool, err error) {
 			if strings.Contains(grant, fmt.Sprintf("GRANT ALL PRIVILEGES ON `%s`.*", config.PseudoGTIDSchema)) {
 				foundAllOnSchema = true
 			}
+			if strings.Contains(grant, fmt.Sprintf(`GRANT ALL PRIVILEGES ON "%s".*`, config.PseudoGTIDSchema)) {
+				foundAllOnSchema = true
+			}
 			if strings.Contains(grant, `DROP`) && strings.Contains(grant, fmt.Sprintf(" ON `%s`.*", config.PseudoGTIDSchema)) {
+				foundDropOnSchema = true
+			}
+			if strings.Contains(grant, `DROP`) && strings.Contains(grant, fmt.Sprintf(` ON "%s".*`, config.PseudoGTIDSchema)) {
 				foundDropOnSchema = true
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/393

In this PR `orchestrator` considers the possibility of `ANSI_QUOTES` when parsing the grants necessary for auto Pseudo-GTID injection.
