### PR TITLE
Auto Pseudo-GTID: detect via performance_schema

### DIFF
--- a/docs/configuration-discovery-pseudo-gtid.md
+++ b/docs/configuration-discovery-pseudo-gtid.md
@@ -33,6 +33,18 @@ Those statements will do nothing but will serve as magic markers in the binary l
 REVOKE DROP ON _pseudo_gtid_.* FROM 'orchestrator'@'orch_host';
 ```
 
+#### In versions > 3.0.6:
+
+It is also advisable that you grant:
+```sql
+GRANT SELECT ON `performance_schema`.`events_statements_current` TO 'orchestrator'@'orch_host';
+```
+
+The above will allow `orchestrator` to query and confirm the existence of Pseudo-GTID when probing instances.
+You will be pleased to know that this only allows `orchestrator` to see its own queries,
+
+#### Notes on Auto Pseudo-GTID
+
 Automated Pseudo-GTID injection is a newer development which supersedes the need for you to run your own Pseudo-GTID injection.
 
 If you wish to enable auto-Pseudo-GTID injection having run manual Pseudo-GTID injection, you'll be happy to note that:

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -56,7 +56,6 @@ const (
 	PseudoGTIDIntervalSeconds                    = 5
 	PseudoGTIDExpireMinutes                      = 60
 	CheckAutoPseudoGTIDGrantsIntervalSeconds     = 60
-	SelectTrueQuery                              = "select 1"
 	AutoPseudoGTIDPattern                        = "drop view if exists `_pseudo_gtid_`"
 	AutoPseudoGTIDDetectSeconds                  = 14400
 )
@@ -573,8 +572,7 @@ func (this *Configuration) postReadAdjustments() error {
 		this.PseudoGTIDPattern = AutoPseudoGTIDPattern
 		this.PseudoGTIDPatternIsFixedSubstring = true
 		this.PseudoGTIDMonotonicHint = "asc:"
-		this.DetectPseudoGTIDQuery = SelectTrueQuery
-		log.Infof(DetectAutoPseudoGTIDInPS)
+		this.DetectPseudoGTIDQuery = DetectAutoPseudoGTIDInPS
 		this.PseudoGTIDPreferIndependentMultiMatch = true
 	}
 	return nil

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -87,7 +87,7 @@ var DetectAutoPseudoGTIDInPS = fmt.Sprintf(`
 				0
 			) as pseudo_gtid_is_found
 		from
-			performance_schema.events_statements_history
+			performance_schema.events_statements_current
 		where
 			sql_text like '%s%s'
 	`, AutoPseudoGTIDDetectSeconds, AutoPseudoGTIDPattern, "%%")

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -641,9 +641,12 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 		instance.UsingPseudoGTID = false
 		func() {
 			if config.Config.AutoPseudoGTID {
-				if found, _ := isAutoPseudoGTIDFoundInPS(db, instanceKey); found {
-					instance.UsingPseudoGTID = true
-					return
+				if !instance.IsSmallerMajorVersionByString("5.6") {
+					// P_S table on exists as of 5.6
+					if found, _ := isAutoPseudoGTIDFoundInPS(db, instanceKey); found {
+						instance.UsingPseudoGTID = true
+						return
+					}
 				}
 				var err error
 				instance.UsingPseudoGTID, err = isInjectedPseudoGTID(instance.ClusterName)

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -641,7 +641,6 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 			if config.Config.AutoPseudoGTID {
 				if found, _ := isAutoPseudoGTIDFoundInPS(db); found {
 					instance.UsingPseudoGTID = true
-					log.Infof(".................... hey hey found it!")
 					return
 				}
 				var err error
@@ -2750,6 +2749,6 @@ func isInjectedPseudoGTID(clusterName string) (injected bool, err error) {
 }
 
 func isAutoPseudoGTIDFoundInPS(db *sql.DB) (found bool, err error) {
-	err = db.QueryRow(config.DetectAutoPseudoGTIDInPS).Scan(&found)
+	err = db.QueryRow(config.Config.DetectPseudoGTIDQuery).Scan(&found)
 	return found, err
 }


### PR DESCRIPTION
Continued work on [auto Pseudo-GTID](https://github.com/github/orchestrator/blob/master/docs/configuration-discovery-pseudo-gtid.md#automated-pseudo-gtid-injection) (followup to https://github.com/github/orchestrator/pull/384).

This PR improves the heuristic by which `orchestrator` detects existence of Pseudo-GTID on a server. For MySQL >= `5.6`, `orchestrator` is now able to query `performance_schema.events_statements_current`, as in the following query:

```sql
select
  ifnull(
    min(
      timestampdiff(
        second, from_unixtime(
          conv(
            substring_index(
              substring_index(sql_text,':',-3),
              ':',1),
            16,10
          )
        ),
        now()
      )
    ) <= 14400,
    0
  ) as pseudo_gtid_is_found
from
  performance_schema.events_statements_current
where
  sql_text like 'drop view if exists `_pseudo_gtid_`%'
;
```

If possible, `orchestrator` runs this query. If query is successful and confirms the existence of a Pseudo-GTID injection, we can safely conclude that the instance does indeed run with Pseudo-GTID.
If found, the result is cached for `1hr` to avoid needless querying of `performance_schema`.
