### PR TITLE
Raft snapshots: storing minimal instance

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -1961,27 +1961,29 @@ func ReadAllInstanceKeys() ([]InstanceKey, error) {
 }
 
 // ReadAllInstanceKeysMasterKeys
-func ReadAllInstanceKeysMasterKeys() ([]InstanceKeyMasterKey, error) {
-	res := []InstanceKeyMasterKey{}
+func ReadAllMinimalInstances() ([]MinimalInstance, error) {
+	res := []MinimalInstance{}
 	query := `
 		select
-			hostname, port, master_host, master_port
+			hostname, port, master_host, master_port, cluster_name
 		from
 			database_instance
 			`
 	err := db.QueryOrchestrator(query, sqlutils.Args(), func(m sqlutils.RowMap) error {
-		instanceKey := InstanceKey{
+		minimalInstance := MinimalInstance{}
+		minimalInstance.Key = InstanceKey{
 			Hostname: m.GetString("hostname"),
 			Port:     m.GetInt("port"),
 		}
-		masterKey := InstanceKey{
+		minimalInstance.MasterKey = InstanceKey{
 			Hostname: m.GetString("master_host"),
 			Port:     m.GetInt("master_port"),
 		}
+		minimalInstance.ClusterName = m.GetString("cluster_name")
 
-		if !InstanceIsForgotten(&instanceKey) {
+		if !InstanceIsForgotten(&minimalInstance.Key) {
 			// only if not in "forget" cache
-			res = append(res, InstanceKeyMasterKey{Key: instanceKey, MasterKey: masterKey})
+			res = append(res, minimalInstance)
 		}
 		return nil
 	})

--- a/go/inst/instance_utils.go
+++ b/go/inst/instance_utils.go
@@ -26,6 +26,11 @@ var (
 	DowntimeLostInRecoveryMessage = "lost-in-recovery"
 )
 
+type InstanceKeyMasterKey struct {
+	Key       InstanceKey
+	MasterKey InstanceKey
+}
+
 type InstancesSorterByExec struct {
 	instances  [](*Instance)
 	dataCenter string

--- a/go/inst/instance_utils.go
+++ b/go/inst/instance_utils.go
@@ -26,11 +26,6 @@ var (
 	DowntimeLostInRecoveryMessage = "lost-in-recovery"
 )
 
-type InstanceKeyMasterKey struct {
-	Key       InstanceKey
-	MasterKey InstanceKey
-}
-
 type InstancesSorterByExec struct {
 	instances  [](*Instance)
 	dataCenter string

--- a/go/inst/minimal_instance.go
+++ b/go/inst/minimal_instance.go
@@ -1,0 +1,17 @@
+package inst
+
+import ()
+
+type MinimalInstance struct {
+	Key         InstanceKey
+	MasterKey   InstanceKey
+	ClusterName string
+}
+
+func (this *MinimalInstance) ToInstance() *Instance {
+	return &Instance{
+		Key:         this.Key,
+		MasterKey:   this.MasterKey,
+		ClusterName: this.ClusterName,
+	}
+}

--- a/go/inst/minimal_instance.go
+++ b/go/inst/minimal_instance.go
@@ -1,7 +1,5 @@
 package inst
 
-import ()
-
 type MinimalInstance struct {
 	Key         InstanceKey
 	MasterKey   InstanceKey

--- a/go/logic/snapshot_data.go
+++ b/go/logic/snapshot_data.go
@@ -77,6 +77,7 @@ func CreateSnapshotData() *SnapshotData {
 	snapshotData := NewSnapshotData()
 
 	// keys
+	snapshotData.Keys, _ = inst.ReadAllInstanceKeys()
 	snapshotData.MinimalInstances, _ = inst.ReadAllMinimalInstances()
 	snapshotData.RecoveryDisabled, _ = IsRecoveryDisabled()
 

--- a/go/logic/snapshot_data.go
+++ b/go/logic/snapshot_data.go
@@ -148,7 +148,6 @@ func (this *SnapshotDataCreatorApplier) Restore(rc io.ReadCloser) error {
 		existingKeys, _ := inst.ReadAllInstanceKeys()
 		for _, existingKey := range existingKeys {
 			if !snapshotInstanceKeyMap.HasKey(existingKey) {
-				log.Infof("..............forgetting key: %+v", existingKey)
 				inst.ForgetInstance(&existingKey)
 				discardedKeys++
 			}
@@ -164,7 +163,6 @@ func (this *SnapshotDataCreatorApplier) Restore(rc io.ReadCloser) error {
 		// v2: read keys + master keys
 		for _, minimalInstance := range snapshotData.MinimalInstances {
 			if !existingKeysMap.HasKey(minimalInstance.Key) {
-				log.Infof("..............writing minimalInstance: %+v", minimalInstance)
 				if err := inst.WriteInstance(minimalInstance.ToInstance(), false, nil); err == nil {
 					discoveredKeys++
 				} else {
@@ -178,7 +176,6 @@ func (this *SnapshotDataCreatorApplier) Restore(rc io.ReadCloser) error {
 				if !existingKeysMap.HasKey(snapshotKey) {
 					snapshotKey := snapshotKey
 					go func() {
-						log.Infof("..............discovering key: %+v", snapshotKey)
 						snapshotDiscoveryKeys <- snapshotKey
 					}()
 					discoveredKeys++


### PR DESCRIPTION
Raft snapshots don't write down entire `Instance` contents. Reason: too much content, which is likely outdated after restart. Instead, they just give minimal context for `orchestrator` to pick up.

The instances context is relevant when the `orchestrator` node starting up has lost its data.

Up till now, the only context would be the instance key. `orchestrator` would then discover the instances, each by its key, and repopulate its backend.

However, this is a problem when an instance is out for the moment. It cannot be discovered (which is legit, things happen); but orchestrator also lost the identity of its master. Not good, because `orchestrator` needs the replication graph to better analyze errors.

This PR adds the `MasterKey` to the snapshot data. Instances could still be missing, but `orchestrator` is able to still maintain the correct graph.