### PR TITLE
Better handling of downtimed analysis

### DIFF
--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -123,6 +123,7 @@ type ReplicationAnalysis struct {
 	ProcessingNodeToken                       string
 	CountAdditionalAgreeingNodes              int
 	StartActivePeriod                         string
+	SkippableDueToDowntime                    bool
 }
 
 type AnalysisMap map[string](*ReplicationAnalysis)

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1473,7 +1473,7 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 
 // CheckAndRecover is the main entry point for the recovery mechanism
 func CheckAndRecover(specificInstance *inst.InstanceKey, candidateInstanceKey *inst.InstanceKey, skipProcesses bool) (recoveryAttempted bool, promotedReplicaKey *inst.InstanceKey, err error) {
-	// Allow the analysis to run evern if we don't want to recover
+	// Allow the analysis to run even if we don't want to recover
 	replicationAnalysis, err := inst.GetReplicationAnalysis("", true, true)
 	if err != nil {
 		return false, nil, log.Errore(err)
@@ -1491,7 +1491,7 @@ func CheckAndRecover(specificInstance *inst.InstanceKey, candidateInstanceKey *i
 				continue
 			}
 		}
-		if analysisEntry.IsDowntimed && specificInstance == nil {
+		if analysisEntry.SkippableDueToDowntime && specificInstance == nil {
 			// Only recover a downtimed server if explicitly requested
 			continue
 		}


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/394

With this PR:

- Better handling of analysis where all replicas are downtimed
- Skip detection handling (skip processes) where all replicas are downtimed in:
  - `MasterSingleSlaveDead`
  - `DeadIntermediateMasterWithSingleSlave`
  - `DeadIntermediateMasterWithSingleSlaveFailingToConnect`
  - `DeadIntermediateMasterAndSlaves`
  - `DeadIntermediateMasterAndSomeSlaves`

