### PR TITLE
Resolving and persisting host IPs

### DIFF
--- a/go/db/generate_base.go
+++ b/go/db/generate_base.go
@@ -816,4 +816,13 @@ var generateSQLBase = []string{
 			PRIMARY KEY (cluster_name)
 		) ENGINE=InnoDB DEFAULT CHARSET=ascii
 	`,
+	`
+		CREATE TABLE IF NOT EXISTS hostname_ips (
+			hostname varchar(128) CHARACTER SET ascii NOT NULL,
+			ipv4 varchar(128) CHARACTER SET ascii NOT NULL,
+			ipv6 varchar(128) CHARACTER SET ascii NOT NULL,
+			last_updated timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (hostname)
+		) ENGINE=InnoDB DEFAULT CHARSET=ascii
+	`,
 }

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -427,6 +427,7 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 		err = fmt.Errorf("ReadTopologyInstance: empty hostname (%+v). Bailing out", *instanceKey)
 		goto Cleanup
 	}
+	go ResolveHostnameIPs(instance.Key.Hostname)
 	if config.Config.DataCenterPattern != "" {
 		if pattern, err := regexp.Compile(config.Config.DataCenterPattern); err == nil {
 			match := pattern.FindStringSubmatch(instance.Key.Hostname)

--- a/go/inst/resolve.go
+++ b/go/inst/resolve.go
@@ -72,7 +72,7 @@ func NewHostnameDeregistration(instanceKey *InstanceKey) *HostnameRegistration {
 var hostnameResolvesLightweightCache *cache.Cache
 var hostnameResolvesLightweightCacheInit = &sync.Mutex{}
 var hostnameResolvesLightweightCacheLoadedOnceFromDB bool = false
-var hostnameIPsCache = cache.New(10*time.Minute, time.Second)
+var hostnameIPsCache = cache.New(10*time.Minute, time.Minute)
 
 func init() {
 	if config.Config.ExpiryHostnameResolvesMinutes < 1 {


### PR DESCRIPTION
With this PR `orchestrator` resolves hostnames to IPv4 and IPv6 where possible, and persists the information at the new `hostname_ips` table.

There is at most one IPv4 and one IPv6 address stored for each host.