### PR TITLE
KV store: master breakdown to hostname, port, ipv4, ipv6

### DIFF
--- a/docs/configuration-kv.md
+++ b/docs/configuration-kv.md
@@ -17,7 +17,20 @@
 `KVClusterMasterPrefix` is the prefix to use for master discovery entries. As example, your cluster alias is `mycluster` and the master host is `some.host-17.com` then you will expect an entry where:
 
 - The Key is `mysql/master/mycluster`
-- The Value is `some.host-17.com`
+- The Value is `some.host-17.com:3306`
+
+#### Breakdown entries
+
+In addition to the above, `orchestrator` also breaks down the master entries and adds the follows (illustrating via example above):
+
+- `mysql/master/mycluster/hostname`, value is `some.host-17.com`
+- `mysql/master/mycluster/port`, value is `3306`
+- `mysql/master/mycluster/ipv4`, value is `192.168.0.1`
+- `mysql/master/mycluster/ipv6`, value is `<whatever>`
+
+The `/hostname`, `/port`, `/ipv4` and `/ipv6` extensions are automatically added for any master entry.
+
+### Stores
 
 If specified, `ConsulAddress` indicates an address where a Consul HTTP service is available. If unspecified, no Consul access is attempted.
 

--- a/go/inst/cluster.go
+++ b/go/inst/cluster.go
@@ -46,11 +46,16 @@ func GetClusterMasterKVPairs(clusterAlias string, masterKey *InstanceKey) (kvPai
 	}
 	kvPairs = append(kvPairs, masterKVPair)
 
-	kvPairs = append(kvPairs, kv.NewKVPair(fmt.Sprintf("%s/hostname", masterKVPair.Key), masterKey.Hostname))
-	kvPairs = append(kvPairs, kv.NewKVPair(fmt.Sprintf("%s/port", masterKVPair.Key), fmt.Sprintf("%d", masterKey.Port)))
+	addPair := func(keySuffix, value string) {
+		key := fmt.Sprintf("%s/%s", masterKVPair.Key, keySuffix)
+		kvPairs = append(kvPairs, kv.NewKVPair(key, value))
+	}
+
+	addPair("hostname", masterKey.Hostname)
+	addPair("port", fmt.Sprintf("%d", masterKey.Port))
 	if ipv4, ipv6, err := readHostnameIPs(masterKey.Hostname); err == nil {
-		kvPairs = append(kvPairs, kv.NewKVPair(fmt.Sprintf("%s/ipv4", masterKVPair.Key), ipv4))
-		kvPairs = append(kvPairs, kv.NewKVPair(fmt.Sprintf("%s/ipv6", masterKVPair.Key), ipv6))
+		addPair("ipv4", ipv4)
+		addPair("ipv6", ipv6)
 	}
 	return kvPairs
 }

--- a/go/inst/cluster.go
+++ b/go/inst/cluster.go
@@ -39,6 +39,8 @@ func getClusterMasterKVPair(clusterAlias string, masterKey *InstanceKey) *kv.KVP
 	return kv.NewKVPair(GetClusterMasterKVKey(clusterAlias), masterKey.StringCode())
 }
 
+// GetClusterMasterKVPairs returns all KV pairs associated with a master. This includes the
+// full identity of the master as well as a breakdown by hostname, port, ipv4, ipv6
 func GetClusterMasterKVPairs(clusterAlias string, masterKey *InstanceKey) (kvPairs [](*kv.KVPair)) {
 	masterKVPair := getClusterMasterKVPair(clusterAlias, masterKey)
 	if masterKVPair == nil {

--- a/go/inst/cluster_test.go
+++ b/go/inst/cluster_test.go
@@ -76,3 +76,8 @@ func TestGetClusterMasterKVPairs(t *testing.T) {
 		test.S(t).ExpectEquals(kvPair.Value, fmt.Sprintf("%d", masterKey.Port))
 	}
 }
+
+func TestGetClusterMasterKVPairs2(t *testing.T) {
+	kvPairs := GetClusterMasterKVPairs("", &masterKey)
+	test.S(t).ExpectEquals(len(kvPairs), 0)
+}

--- a/go/inst/cluster_test.go
+++ b/go/inst/cluster_test.go
@@ -39,17 +39,17 @@ func TestGetClusterMasterKVKey(t *testing.T) {
 
 func TestGetClusterMasterKVPair(t *testing.T) {
 	{
-		kvPair := GetClusterMasterKVPair("myalias", &masterKey)
+		kvPair := getClusterMasterKVPair("myalias", &masterKey)
 		test.S(t).ExpectNotNil(kvPair)
 		test.S(t).ExpectEquals(kvPair.Key, "test/master/myalias")
 		test.S(t).ExpectEquals(kvPair.Value, masterKey.StringCode())
 	}
 	{
-		kvPair := GetClusterMasterKVPair("", &masterKey)
+		kvPair := getClusterMasterKVPair("", &masterKey)
 		test.S(t).ExpectTrue(kvPair == nil)
 	}
 	{
-		kvPair := GetClusterMasterKVPair("myalias", nil)
+		kvPair := getClusterMasterKVPair("myalias", nil)
 		test.S(t).ExpectTrue(kvPair == nil)
 	}
 }

--- a/go/inst/cluster_test.go
+++ b/go/inst/cluster_test.go
@@ -17,6 +17,8 @@
 package inst
 
 import (
+	"fmt"
+
 	"github.com/github/orchestrator/go/config"
 	"github.com/openark/golib/log"
 	test "github.com/openark/golib/tests"
@@ -51,5 +53,26 @@ func TestGetClusterMasterKVPair(t *testing.T) {
 	{
 		kvPair := getClusterMasterKVPair("myalias", nil)
 		test.S(t).ExpectTrue(kvPair == nil)
+	}
+}
+
+func TestGetClusterMasterKVPairs(t *testing.T) {
+	kvPairs := GetClusterMasterKVPairs("myalias", &masterKey)
+	test.S(t).ExpectTrue(len(kvPairs) >= 2)
+
+	{
+		kvPair := kvPairs[0]
+		test.S(t).ExpectEquals(kvPair.Key, "test/master/myalias")
+		test.S(t).ExpectEquals(kvPair.Value, masterKey.StringCode())
+	}
+	{
+		kvPair := kvPairs[1]
+		test.S(t).ExpectEquals(kvPair.Key, "test/master/myalias/hostname")
+		test.S(t).ExpectEquals(kvPair.Value, masterKey.Hostname)
+	}
+	{
+		kvPair := kvPairs[2]
+		test.S(t).ExpectEquals(kvPair.Key, "test/master/myalias/port")
+		test.S(t).ExpectEquals(kvPair.Value, fmt.Sprintf("%d", masterKey.Port))
 	}
 }

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -1889,9 +1889,8 @@ func GetMastersKVPairs(clusterName string) (kvPairs [](*kv.KVPair), err error) {
 		return kvPairs, err
 	}
 	for _, master := range masters {
-		if kvPair := GetClusterMasterKVPair(clusterAliasMap[master.ClusterName], &master.Key); kvPair != nil {
-			kvPairs = append(kvPairs, kvPair)
-		}
+		clusterPairs := GetClusterMasterKVPairs(clusterAliasMap[master.ClusterName], &master.Key)
+		kvPairs = append(kvPairs, clusterPairs...)
 	}
 
 	return kvPairs, err


### PR DESCRIPTION
Master entries are now listed in KV as follows:

```
mysql/master/mycluster:master.host.com:3306
```
^ as before, and then adding:
```
mysql/master/mycluster/hostname:master.host.com
mysql/master/mycluster/port:3306
mysql/master/mycluster/ipv4:192.168.0.1
mysql/master/mycluster/ipv6:<whatever>
```

This breakdown allows the user to pick their own preferred representation of the master. For example, HAProxy has better be populated with the IP address of the master rather than its hostname.

- [x] deploy, test
- [x] documentation