### PR TITLE
raft event for recovery, recovery filtering

### DIFF
--- a/go/http/httpbase.go
+++ b/go/http/httpbase.go
@@ -158,6 +158,9 @@ func getClusterHint(params map[string]string) string {
 
 // figureClusterName is a convenience function to get a cluster name from hints
 func figureClusterName(hint string) (clusterName string, err error) {
+	if hint == "" {
+		return "", fmt.Errorf("Unable to determine cluster name by empty hint")
+	}
 	instanceKey, _ := inst.ParseRawInstanceKeyLoose(hint)
 	return inst.FigureClusterName(hint, instanceKey, nil)
 }

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -167,6 +167,12 @@ func (applier *CommandApplier) ackRecovery(value []byte) interface{} {
 	if ack.Key.IsValid() {
 		_, err = AcknowledgeInstanceRecoveries(&ack.Key, ack.Owner, ack.Comment)
 	}
+	if ack.Id > 0 {
+		_, err = AcknowledgeRecovery(ack.Id, ack.Owner, ack.Comment)
+	}
+	if ack.UID != "" {
+		_, err = AcknowledgeRecoveryByUID(ack.UID, ack.Owner, ack.Comment)
+	}
 	return err
 }
 

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -48,6 +48,8 @@ type RecoveryAcknowledgement struct {
 
 	Key         inst.InstanceKey
 	ClusterName string
+	Id          int64
+	UID         string
 }
 
 func NewRecoveryAcknowledgement(owner string, comment string) *RecoveryAcknowledgement {

--- a/go/logic/topology_recovery_dao.go
+++ b/go/logic/topology_recovery_dao.go
@@ -397,6 +397,13 @@ func AcknowledgeRecovery(recoveryId int64, owner string, comment string) (countA
 	return acknowledgeRecoveries(owner, comment, false, whereClause, sqlutils.Args(recoveryId))
 }
 
+// AcknowledgeRecovery acknowledges a particular recovery.
+// This also implied clearing their active period, which in turn enables further recoveries on those topologies
+func AcknowledgeRecoveryByUID(recoveryUID string, owner string, comment string) (countAcknowledgedEntries int64, err error) {
+	whereClause := `uid = ?`
+	return acknowledgeRecoveries(owner, comment, false, whereClause, sqlutils.Args(recoveryUID))
+}
+
 // AcknowledgeClusterRecoveries marks active recoveries for given cluster as acknowledged.
 // This also implied clearing their active period, which in turn enables further recoveries on those topologies
 func AcknowledgeClusterRecoveries(clusterName string, owner string, comment string) (countAcknowledgedEntries int64, err error) {


### PR DESCRIPTION
Two issues tackled in this PR:

- Closes https://github.com/github/orchestrator/issues/414 ; the web handler assigned a cluster name to the audited recoveries filtering ; web users could not see the entire recovery listing (happens on single cluster)
- Single instance recovery acknowledgement did not propagate through `raft`.