### PR TITLE
Centos6 build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -135,8 +135,9 @@ function package() {
 
   echo "---"
   if cat /etc/centos-release | grep 'CentOS release 6' ; then
-    rm ${TOPDIR:-?}/orchestrator-*.deb
-    rm ${TOPDIR:-?}/orchestrator-*.tgz
+    rm ${TOPDIR:-?}/orchestrator*.deb
+    rm ${TOPDIR:-?}/orchestrator*.tar.gz
+    ls ${TOPDIR:-?}/*.rpm | while read f; do centos_file=$(echo $f | sed -r -e "s/^(.*)-${RELEASE_VERSION}(.*)/\1-centos6-${RELEASE_VERSION}\2/g") ; echo $centos_file ; done
   fi
   echo "Done. Find releases in $TOPDIR"
 }

--- a/build.sh
+++ b/build.sh
@@ -134,6 +134,10 @@ function package() {
   esac
 
   echo "---"
+  if cat /etc/centos-release | grep 'CentOS release 6' ; then
+    rm ${TOPDIR:-?}/orchestrator-*.deb
+    rm ${TOPDIR:-?}/orchestrator-*.tgz
+  fi
   echo "Done. Find releases in $TOPDIR"
 }
 

--- a/build.sh
+++ b/build.sh
@@ -137,7 +137,9 @@ function package() {
   if cat /etc/centos-release | grep 'CentOS release 6' ; then
     rm ${TOPDIR:-?}/orchestrator*.deb
     rm ${TOPDIR:-?}/orchestrator*.tar.gz
-    ls ${TOPDIR:-?}/*.rpm | while read f; do centos_file=$(echo $f | sed -r -e "s/^(.*)-${RELEASE_VERSION}(.*)/\1-centos6-${RELEASE_VERSION}\2/g") ; echo $centos_file ; done
+    # n CentOD 6 box: we only want the rpms for CentOS6
+    # Add "-centos6" to the file name.
+    ls ${TOPDIR:-?}/*.rpm | while read f; do centos_file=$(echo $f | sed -r -e "s/^(.*)-${RELEASE_VERSION}(.*)/\1-centos6-${RELEASE_VERSION}\2/g") ; mv $f $centos_file ; done
   fi
   echo "Done. Find releases in $TOPDIR"
 }


### PR DESCRIPTION
Utility PR: we only build on CentOS6 for purposes of generating a `glibc2.12` compatible binary.

With this PR the build process will recognize it's being executed on CentOS6, will purge irrelevant files, will rename `rpm` files to add `-centos6`.