### PR TITLE
Fixes to 3.0.7: blocking recovery link; ack flow on web interface; others

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -884,12 +884,12 @@ func (this *HttpAPI) LastPseudoGTID(params martini.Params, r render.Render, req 
 		return
 	}
 
-	instance, err := inst.ReadTopologyInstance(&instanceKey)
+	instance, found, err := inst.ReadInstance(&instanceKey)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	if instance == nil {
+	if instance == nil || !found {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Instance not found: %+v", instanceKey)})
 		return
 	}

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1371,6 +1371,7 @@ func (this *HttpAPI) setSemiSyncReplica(params martini.Params, r render.Render, 
 func (this *HttpAPI) EnableSemiSyncReplica(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	this.setSemiSyncReplica(params, r, req, user, true)
 }
+
 func (this *HttpAPI) DisableSemiSyncReplica(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	this.setSemiSyncReplica(params, r, req, user, false)
 }

--- a/go/logic/snapshot_data.go
+++ b/go/logic/snapshot_data.go
@@ -41,7 +41,7 @@ type SnapshotData struct {
 	HostAttributes,
 	AccessToken,
 	PoolInstances,
-	InjectedPseudoGTIDInstances,
+	InjectedPseudoGTIDClusters,
 	HostnameResolves,
 	HostnameUnresolves,
 	DowntimedInstances,
@@ -99,7 +99,7 @@ func CreateSnapshotData() *SnapshotData {
 	readTableData("kv_store", &snapshotData.KVStore)
 	readTableData("topology_recovery", &snapshotData.Recovery)
 	readTableData("topology_recovery_steps", &snapshotData.RecoverySteps)
-	readTableData("database_instance_injected_pseudo_gtid", &snapshotData.InjectedPseudoGTIDInstances)
+	readTableData("cluster_injected_pseudo_gtid", &snapshotData.InjectedPseudoGTIDClusters)
 
 	log.Debugf("raft snapshot data created")
 	return snapshotData
@@ -204,7 +204,7 @@ func (this *SnapshotDataCreatorApplier) Restore(rc io.ReadCloser) error {
 	writeTableData("topology_recovery", &snapshotData.Recovery)
 	writeTableData("topology_failure_detection", &snapshotData.Detections)
 	writeTableData("topology_recovery_steps", &snapshotData.RecoverySteps)
-	writeTableData("database_instance_injected_pseudo_gtid", &snapshotData.InjectedPseudoGTIDInstances)
+	writeTableData("cluster_injected_pseudo_gtid", &snapshotData.InjectedPseudoGTIDClusters)
 
 	// recovery disable
 	{

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -283,7 +283,7 @@ function restart_replica_statements() {
 function last_pseudo_gtid() {
   assert_nonempty "instance" "$instance_hostport"
   api "last-pseudo-gtid/$instance_hostport"
-  print_response | print_details | jq -r
+  print_response | print_details | jq -r '.'
 }
 
 function instance() {

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -280,6 +280,12 @@ function restart_replica_statements() {
   print_response | print_details
 }
 
+function last_pseudo_gtid() {
+  assert_nonempty "instance" "$instance_hostport"
+  api "last-pseudo-gtid/$instance_hostport"
+  print_response | print_details | jq -r
+}
+
 function instance() {
   assert_nonempty "instance" "$instance_hostport"
   api "instance/$instance_hostport"
@@ -667,6 +673,7 @@ function run_command() {
     "set-read-only") general_instance_command ;;     # Turn an instance read-only, via SET GLOBAL read_only := 1
     "set-writeable") general_instance_command ;;     # Turn an instance writeable, via SET GLOBAL read_only := 0
     "flush-binary-logs") general_instance_command ;; # Flush binary logs on an instance
+    "last-pseudo-gtid") last_pseudo_gtid ;;          # Dump last injected Pseudo-GTID entry on a server
 
     "recover") recover ;;                                     # Do auto-recovery given a dead instance, assuming orchestrator agrees there's a problem. Override blocking.
     "graceful-master-takeover") graceful_master_takeover ;;   # Gracefully discard master and promote another (direct child) instance instead, even if everything is running well

--- a/resources/public/js/audit-recovery.js
+++ b/resources/public/js/audit-recovery.js
@@ -23,7 +23,7 @@ $(document).ready(function() {
       info += "<li>" + audit.AcknowledgedComment + "</li>";
       info += '</ul></div>';
     } else {
-      info += '<div><button class="btn btn-primary ack-recovery" data-recovery-id="'+audit.Id+'">Acknowlede</button>';
+      info += '<div><button class="btn btn-primary ack-recovery" data-recovery-id="'+audit.Id+'">Acknowledge</button>';
       info += ' This recovery is unacknowledged.';
       info += '</div>';
     }
@@ -215,15 +215,7 @@ $(document).ready(function() {
         placeholder: "comment",
         callback: function(result) {
           if (result !== null) {
-            showLoader();
-            $.get(appUrl("/api/ack-recovery/" + recoveryId + "?comment=" + encodeURIComponent(result)), function(operationResult) {
-              hideLoader();
-              if (operationResult.Code == "ERROR") {
-                addAlert(operationResult.Message)
-              } else {
-                location.reload();
-              }
-            }, "json");
+            apiCommand("/api/ack-recovery/" + recoveryId + "?comment=" + encodeURIComponent(result));
           }
         }
       });

--- a/resources/public/js/cluster.js
+++ b/resources/public/js/cluster.js
@@ -1771,7 +1771,7 @@ function Cluster() {
     getData("/api/blocked-recoveries/cluster/" + currentClusterName(), function(blockedRecoveries) {
       // Result is an array: either empty (no active recovery) or with multiple entries
       blockedRecoveries.forEach(function(blockedRecovery) {
-        addAlert('A <strong>' + blockedRecovery.Analysis + '</strong> on ' + getInstanceTitle(blockedRecovery.FailedInstanceKey.Hostname, blockedRecovery.FailedInstanceKey.Port) + ' is blocked due to a <a href="' + appUrl('/web/audit-recovery/cluster/' + blockedRecovery.ClusterName) + '">previous recovery</a>');
+        addAlert('A <strong>' + blockedRecovery.Analysis + '</strong> on ' + getInstanceTitle(blockedRecovery.FailedInstanceKey.Hostname, blockedRecovery.FailedInstanceKey.Port) + ' is blocked due to a <a href="' + appUrl('/web/audit-recovery/id/' + blockedRecovery.BlockingRecoveryId) + '">previous recovery</a>');
       });
     });
 

--- a/resources/public/js/clusters-analysis.js
+++ b/resources/public/js/clusters-analysis.js
@@ -14,7 +14,7 @@ $(document).ready(function() {
     blockedRecoveries = blockedRecoveries || [];
     // Result is an array: either empty (no active recovery) or with multiple entries
     blockedRecoveries.forEach(function(blockedRecovery) {
-      addAlert('A <strong>' + blockedRecovery.Analysis + '</strong> on ' + getInstanceTitle(blockedRecovery.FailedInstanceKey.Hostname, blockedRecovery.FailedInstanceKey.Port) + ' is blocked due to a <a href="' + appUrl('/web/audit-recovery/cluster/' + blockedRecovery.ClusterName) + '">previous recovery</a>');
+      addAlert('A <strong>' + blockedRecovery.Analysis + '</strong> on ' + getInstanceTitle(blockedRecovery.FailedInstanceKey.Hostname, blockedRecovery.FailedInstanceKey.Port) + ' is blocked due to a <a href="' + appUrl('/web/audit-recovery/id/' + blockedRecovery.BlockingRecoveryId) + '">previous recovery</a>');
     });
   });
 

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -190,6 +190,7 @@ function apiCommand(uri, hint) {
 }
 
 function reloadWithMessage(msg, details, hint) {
+  msg = msg || '';
   var hostname = "";
   var port = "";
   if (details) {

--- a/resources/public/js/status.js
+++ b/resources/public/js/status.js
@@ -14,10 +14,8 @@ function addStatusActionButton(name, uri) {
 	);
 	var button = $('#orchestratorStatus .panel-footer button:last');
 	button.click(function(){
-    	apiCommand("/api/"+uri);
-    });
-
-	console.log(button)
+		apiCommand("/api/"+uri);
+	});
 }
 
 $(document).ready(function () {


### PR DESCRIPTION
This PR follows the `3.0.7` release and fixes issues noted by users:

- Closes https://github.com/github/orchestrator/issues/417

  - Fixed typo
  - Showing error response when submitting empty acknowledgement comment
  - "... blocked due to a ... previous recovery" links to the exact blocking recovery, not to general cluster listing.

- Fixes raft persistence of `cluster_injected_pseudo_gtid`