### PR TITLE
Fixing infinite auto-reload mayhem

### DIFF
--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -1,5 +1,6 @@
 var refreshIntervalSeconds = 60; // seconds
 var secondsTillRefresh = refreshIntervalSeconds;
+var isReloadingPage = false;
 var nodeModalVisible = false;
 
 reloadPageHint = {
@@ -45,8 +46,12 @@ function startRefreshTimer() {
     if (nodeModalVisible) {
       return;
     }
+    if (isReloadingPage) {
+      return;
+    }
     secondsTillRefresh = Math.max(secondsTillRefresh - 1, 0);
     if (secondsTillRefresh <= 0) {
+      isReloadingPage = true;
       $(".navbar-nav li[data-nav-page=refreshCountdown]").addClass("active");
       showLoader();
       location.reload(true);


### PR DESCRIPTION
A few pages on the web interface auto-reload after `60sec`.

If the browser is not quick enough to initiate the reload, the code introduces a new reload request, and a new one, and a new one... Either until the browser/network is quick enough or until the compueter's vent is screaming. 

This fixes the infinite reload loop by satisfying with a single reload request. If it fails, it fails. No further attempt is made if the first attempt is failed.