### PR TITLE
Doc & fix to single node orchestrator/raft

### DIFF
--- a/docs/configuration-raft.md
+++ b/docs/configuration-raft.md
@@ -68,3 +68,26 @@ to explicitly specify where a node, assuming it were the leader, would be access
 ### Backend DB
 
 A `raft` setup supports either `MySQL` or `SQLite` backend DB. See [backend](configuration-backend.md) configuration for either. Read [high-availability](high-availability.md) page for scenarios, possibilities and reasons to using either.
+
+### Single raft node setups
+
+In production, you will want using multiple `raft` nodes, such as `3` or `5`.
+
+In a testing environment you may run a `orchestrator/raft` setup composed of a single node. This node will implicitly be the leader, and will advertise raft messages to itself.
+
+To run a single-node `orchestrator/raft`, configure an empty `RaftNodes`:
+
+```json
+  "RaftNodes": [],
+```
+
+or, alternatively, specify a single node, which is identical to `RaftBind` or `RaftAdvertise`:
+
+```json
+  "RaftEnabled": true,
+  "RaftBind": "127.0.0.1",
+  "DefaultRaftPort": 10008,
+  "RaftNodes": [
+    "127.0.0.1"
+  ],
+```

--- a/docs/raft.md
+++ b/docs/raft.md
@@ -2,7 +2,7 @@
 
 ![orchestrator HA via raft](images/orchestrator-ha--raft.png)
 
-`orchestratpr/raft` is a deployment setup where several `orchestrator` nodes communicate with each other via `raft` consensus protocol.
+`orchestrator/raft` is a deployment setup where several `orchestrator` nodes communicate with each other via `raft` consensus protocol.
 
 `orchestrator/raft` deployments solve both high-availability for `orchestrator` itself as well as solve issues with network isolation, and in particular cross-data-center network partitioning/fencing.
 

--- a/go/raft/raft.go
+++ b/go/raft/raft.go
@@ -128,6 +128,11 @@ func Setup(applier CommandApplier, snapshotCreatorApplier SnapshotCreatorApplier
 		}
 		peerNodes = append(peerNodes, peerNode)
 	}
+	if len(peerNodes) == 1 && peerNodes[0] == raftAdvertise {
+		// To run in single node setup we will either specify an empty RaftNodes, or a single
+		// raft node that is exactly RaftAdvertise
+		peerNodes = []string{}
+	}
 	if err := store.Open(peerNodes); err != nil {
 		return log.Errorf("failed to open raft store: %s", err.Error())
 	}


### PR DESCRIPTION
Fixes #439 

In this PR:

- Documentation clarifying how to set up single-node `orchestrator/raft` setup
- Supportin single-node by specifying the exact same `RaftAdvertise` (or `RaftBind`) in `RaftNodes`

cc @davygeek 