### PR TITLE
Support for 'ack-all-recoveries'

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1379,6 +1379,17 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				fmt.Println(fmt.Sprintf("%s (cluster %s): %s", entry.AnalyzedInstanceKey.DisplayString(), entry.ClusterDetails.ClusterName, entry.AnalysisString()))
 			}
 		}
+	case registerCliCommand("ack-all-recoveries", "Recovery", `Acknowledge all recoveries; this unblocks pending future recoveries`):
+		{
+			if reason == "" {
+				log.Fatal("--reason option required (comment your ack)")
+			}
+			countRecoveries, err := logic.AcknowledgeAllRecoveries(inst.GetMaintenanceOwner(), reason)
+			if err != nil {
+				log.Fatale(err)
+			}
+			fmt.Println(fmt.Sprintf("%d recoveries acknowldged", countRecoveries))
+		}
 	case registerCliCommand("ack-cluster-recoveries", "Recovery", `Acknowledge recoveries for a given cluster; this unblocks pending future recoveries`):
 		{
 			if reason == "" {

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -163,6 +163,9 @@ func (applier *CommandApplier) ackRecovery(value []byte) interface{} {
 	if err != nil {
 		return log.Errore(err)
 	}
+	if ack.AllRecoveries {
+		_, err = AcknowledgeAllRecoveries(ack.Owner, ack.Comment)
+	}
 	if ack.ClusterName != "" {
 		_, err = AcknowledgeClusterRecoveries(ack.ClusterName, ack.Owner, ack.Comment)
 	}

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -47,10 +47,11 @@ type RecoveryAcknowledgement struct {
 	Owner     string
 	Comment   string
 
-	Key         inst.InstanceKey
-	ClusterName string
-	Id          int64
-	UID         string
+	Key           inst.InstanceKey
+	ClusterName   string
+	Id            int64
+	UID           string
+	AllRecoveries bool
 }
 
 func NewRecoveryAcknowledgement(owner string, comment string) *RecoveryAcknowledgement {

--- a/go/logic/topology_recovery_dao.go
+++ b/go/logic/topology_recovery_dao.go
@@ -391,6 +391,12 @@ func acknowledgeRecoveries(owner string, comment string, markEndRecovery bool, w
 	return rows, log.Errore(err)
 }
 
+// AcknowledgeAllRecoveries acknowledges all unacknowledged recoveries.
+func AcknowledgeAllRecoveries(owner string, comment string) (countAcknowledgedEntries int64, err error) {
+	whereClause := `1 = 1`
+	return acknowledgeRecoveries(owner, comment, false, whereClause, sqlutils.Args())
+}
+
 // AcknowledgeRecovery acknowledges a particular recovery.
 // This also implied clearing their active period, which in turn enables further recoveries on those topologies
 func AcknowledgeRecovery(recoveryId int64, owner string, comment string) (countAcknowledgedEntries int64, err error) {

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -528,13 +528,13 @@ function ack_cluster_recoveries() {
   assert_nonempty "instance|alias" "${alias:-$instance}"
   assert_nonempty "reason" "$reason"
   api "ack-recovery/cluster/${alias:-$instance}?comment=$(urlencode $reason)"
-  print_details
+  print_details | jq -r .
 }
 
 function ack_all_recoveries() {
   assert_nonempty "reason" "$reason"
   api "ack-all-recoveries?comment=$(urlencode $reason)"
-  print_details
+  print_details | jq -r .
 }
 
 function disable_global_recoveries() {

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -531,6 +531,12 @@ function ack_cluster_recoveries() {
   print_details
 }
 
+function ack_all_recoveries() {
+  assert_nonempty "reason" "$reason"
+  api "ack-all-recoveries?comment=$(urlencode $reason)"
+  print_details
+}
+
 function disable_global_recoveries() {
   api "disable-global-recoveries"
   print_details | jq -r .
@@ -679,6 +685,7 @@ function run_command() {
     "graceful-master-takeover") graceful_master_takeover ;;   # Gracefully discard master and promote another (direct child) instance instead, even if everything is running well
     "force-master-failover") force_master_failover ;;         # Forcibly discard master and initiate a failover, even if orchestrator doesn't see a problem. This command lets orchestrator choose the replacement master
     "ack-cluster-recoveries") ack_cluster_recoveries ;;       # Acknowledge recoveries for a given cluster; this unblocks pending future recoveries
+    "ack-all-recoveries") ack_all_recoveries ;;               # Acknowledge all recoveries
     "disable-global-recoveries") disable_global_recoveries ;; # Disallow orchestrator from performing recoveries globally
     "enable-global-recoveries") enable_global_recoveries ;;   # Allow orchestrator to perform recoveries globally
     "check-global-recoveries") check_global_recoveries ;;     # Show the global recovery configuration


### PR DESCRIPTION
Supporting a way to acknowledge all recoveries, thereby releasing all blocks from a pending recovery (aborting anti-flapping block time).

New command is supported via CLI, API, and `orchestrator-client`