### PR TITLE
suggested cluster alias: evaluated by all cluster servers

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -794,6 +794,7 @@ func ReadClusterAliasOverride(instance *Instance) (err error) {
 func ReadInstanceClusterAttributes(instance *Instance) (err error) {
 	var masterMasterKey InstanceKey
 	var masterClusterName string
+	var masterSuggestedClusterAlias string
 	var masterReplicationDepth uint
 	masterDataFound := false
 
@@ -801,6 +802,7 @@ func ReadInstanceClusterAttributes(instance *Instance) (err error) {
 	query := `
 			select
 					cluster_name,
+					suggested_cluster_alias,
 					replication_depth,
 					master_host,
 					master_port
@@ -811,6 +813,7 @@ func ReadInstanceClusterAttributes(instance *Instance) (err error) {
 
 	err = db.QueryOrchestrator(query, args, func(m sqlutils.RowMap) error {
 		masterClusterName = m.GetString("cluster_name")
+		masterSuggestedClusterAlias = m.GetString("suggested_cluster_alias")
 		masterReplicationDepth = m.GetUint("replication_depth")
 		masterMasterKey.Hostname = m.GetString("master_host")
 		masterMasterKey.Port = m.GetInt("master_port")
@@ -849,6 +852,7 @@ func ReadInstanceClusterAttributes(instance *Instance) (err error) {
 		} // While the other stays "1"
 	}
 	instance.ClusterName = clusterName
+	instance.SuggestedClusterAlias = masterSuggestedClusterAlias
 	instance.ReplicationDepth = replicationDepth
 	instance.IsCoMaster = isCoMaster
 	return nil

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -699,16 +699,18 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 	}
 
 	ReadClusterAliasOverride(instance)
-	if instance.SuggestedClusterAlias == "" && instance.ReplicationDepth == 0 && !isMaxScale {
-		// Only need to do on masters
-		if config.Config.DetectClusterAliasQuery != "" {
-			clusterAlias := ""
-			err := db.QueryRow(config.Config.DetectClusterAliasQuery).Scan(&clusterAlias)
-			if err != nil {
-				clusterAlias = ""
-				logReadTopologyInstanceError(instanceKey, "DetectClusterAliasQuery", err)
+	if !isMaxScale {
+		if instance.SuggestedClusterAlias == "" {
+			// Only need to do on masters
+			if config.Config.DetectClusterAliasQuery != "" {
+				clusterAlias := ""
+				err := db.QueryRow(config.Config.DetectClusterAliasQuery).Scan(&clusterAlias)
+				if err != nil {
+					clusterAlias = ""
+					logReadTopologyInstanceError(instanceKey, "DetectClusterAliasQuery", err)
+				}
+				instance.SuggestedClusterAlias = clusterAlias
 			}
-			instance.SuggestedClusterAlias = clusterAlias
 		}
 		if instance.SuggestedClusterAlias == "" {
 			// Not found by DetectClusterAliasQuery...

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -704,12 +704,11 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 			// Only need to do on masters
 			if config.Config.DetectClusterAliasQuery != "" {
 				clusterAlias := ""
-				err := db.QueryRow(config.Config.DetectClusterAliasQuery).Scan(&clusterAlias)
-				if err != nil {
-					clusterAlias = ""
+				if err := db.QueryRow(config.Config.DetectClusterAliasQuery).Scan(&clusterAlias); err != nil {
 					logReadTopologyInstanceError(instanceKey, "DetectClusterAliasQuery", err)
+				} else {
+					instance.SuggestedClusterAlias = clusterAlias
 				}
-				instance.SuggestedClusterAlias = clusterAlias
 			}
 		}
 		if instance.SuggestedClusterAlias == "" {


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/459


Previously, suggested cluster alias was only evaluated by the master of a topology. the line of thought was:
- The same cluster alias applies to all servers in a cluster anyway
- It's a waste of resources to evaluate this on all servers
- A replica inherits the cluster alias from its master

However, when a master goes down there is a period where the cluster alias cannot be evaluated and is in fact erased.

This PR fixes the situation as follows:

- If an instance has a master and said master already has a computed alias, the instance inherits it
- if the instance does not have a master, or its master has no alias, suggested-cluster-alias is evaluated by instance

If the master is alive, replicas will inherits its alias (potentially they will evaluate the alias once in the service's lifetime). In the event the master goes away, its direct replicas can still evaluate the alias.