### PR TITLE
limit more precisely when special binlog filtering is used

### DIFF
--- a/go/inst/instance_binlog_dao.go
+++ b/go/inst/instance_binlog_dao.go
@@ -620,6 +620,7 @@ func formatEventCleanly(event BinlogEvent, length *int) string {
 
 // Only do special filtering if instance is MySQL-5.7 and other
 // is MySQL-5.6 and in pseudo-gtid mode.
+// returns applyInstanceSpecialFiltering, applyOtherSpecialFiltering, err
 func special56To57filterProcessing(instance *Instance, other *Instance) (bool, bool, error) {
 	// be paranoid
 	if instance == nil || other == nil {
@@ -633,17 +634,20 @@ func special56To57filterProcessing(instance *Instance, other *Instance) (bool, b
 	// to check the instance's master.  To avoid this do some
 	// preliminary checks first to avoid the "master" access
 	// unless absolutely needed.
-
 	if instance.LogBinEnabled || // instance writes binlogs (not relay logs)
 		instance.FlavorNameAndMajorVersion() != "MySQL-5.7" || // instance NOT 5.7 replica
-		other.FlavorNameAndMajorVersion() != "MySQL-5.7" { // new master is NOT  5.7
+		other.FlavorNameAndMajorVersion() != "MySQL-5.7" { // new master is NOT 5.7
 		return filterInstance, false /* good exit status avoiding checking master */, nil
 	}
 
 	// We need to check if the master is 5.6
-	master, err := GetInstanceMaster(instance)
+	// - Do not call GetInstanceMaster() as that requires the
+	//   master to be available, and this code may be called
+	//   during a master/intermediate master failover when the
+	//   master may not actually be reachable.
+	master, _, err := ReadInstance(&instance.MasterKey)
 	if err != nil {
-		return false, false, log.Errorf("special56To57filterProcessing: can not GetInstanceMaster() for %+v. error=%+v", instance.Key, err)
+		return false, false, log.Errorf("special56To57filterProcessing: ReadInstance(%+v) fails: %+v", instance.MasterKey, err)
 	}
 
 	filterOther := master.FlavorNameAndMajorVersion() == "MySQL-5.6" // master(instance) == 5.6


### PR DESCRIPTION
The routines for doing special binlog filtering are required when the 2 servers run a mix of 5.6 and 5.7 due to some events which are in the 5.7 binlogs but not the 5.6 binlogs.

This patch tightens up the checks by doing the following:
* the code would call `GetInstanceMaster()` which tries to talk to the instance's master but this code may be called when the intermediate master is dead so will fail. Instead call `ReadInstance()` which uses the orchestrator backend to get version information of the instance's master.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code running on my own system