### PR TITLE
Supporting PostGracefulTakeoverProcesses

### DIFF
--- a/conf/orchestrator-sample.conf.json
+++ b/conf/orchestrator-sample.conf.json
@@ -120,6 +120,9 @@
   "PostIntermediateMasterFailoverProcesses": [
     "echo 'Recovered from {failureType} on {failureCluster}. Failed: {failedHost}:{failedPort}; Successor: {successorHost}:{successorPort}' >> /tmp/recovery.log"
   ],
+  "PostGracefulTakeoverProcesses": [
+    "echo 'Planned takeover complete' >> /tmp/recovery.log"
+  ],
   "CoMasterRecoveryMustPromoteOtherCoMaster": true,
   "DetachLostSlavesAfterMasterFailover": true,
   "ApplyMySQLPromotionAfterMasterFailover": false,

--- a/conf/orchestrator-simple.conf.json
+++ b/conf/orchestrator-simple.conf.json
@@ -78,6 +78,9 @@
   "PostIntermediateMasterFailoverProcesses": [
     "echo 'Recovered from {failureType} on {failureCluster}. Failed: {failedHost}:{failedPort}; Successor: {successorHost}:{successorPort}' >> /tmp/recovery.log"
   ],
+  "PostGracefulTakeoverProcesses": [
+    "echo 'Planned takeover complete' >> /tmp/recovery.log"
+  ],
   "DetachLostSlavesAfterMasterFailover": true,
   "ApplyMySQLPromotionAfterMasterFailover": false,
   "MasterFailoverDetachSlaveMasterHost": false,

--- a/docs/configuration-recovery.md
+++ b/docs/configuration-recovery.md
@@ -56,6 +56,7 @@ These hooks are available for recoveries:
 - `PostIntermediateMasterFailoverProcesses`: executed at the end of a successful intermediate master recovery.
 - `PostFailoverProcesses`: executed at the end of any successful recovery (including and adding to the above two).
 - `PostUnsuccessfulFailoverProcesses`: executed at the end of any unsuccessful recovery.
+- `PostGracefulTakeoverProcesses`: executed on planned, graceful master takeover, after the old master is positioned under the newly promoted master.
 
 All of the above are lists of commands which `orchestrator` executes sequentially, in order of definition.
 
@@ -77,6 +78,9 @@ A naive implementation might look like:
     "echo 'Recovered from {failureType} on {failureCluster}. Failed: {failedHost}:     {failedPort}; Promoted: {successorHost}:{successorPort}' >> /tmp/recovery.log"
   ],
   "PostIntermediateMasterFailoverProcesses": [],
+  "PostGracefulTakeoverProcesses": [
+    "echo 'Planned takeover complete' >> /tmp/recovery.log"
+  ],
 }
 ```
 

--- a/docs/configuration-sample.md
+++ b/docs/configuration-sample.md
@@ -134,7 +134,9 @@ The following is a production configuration file, with some details redacted.
     "/redacted/do-something # e.g. kick pt-heartbeat on promoted master"
   ],
   "PostIntermediateMasterFailoverProcesses": [
-
+  ],
+  "PostGracefulTakeoverProcesses": [
+    "echo 'Planned takeover complete' >> /tmp/recovery.log"
   ],
   "CoMasterRecoveryMustPromoteOtherCoMaster": true,
   "DetachLostSlavesAfterMasterFailover": true,

--- a/docs/topology-recovery.md
+++ b/docs/topology-recovery.md
@@ -170,3 +170,4 @@ Note that manual recovery (e.g. `orchestrator-client -c recover`) overrides down
 - `PostIntermediateMasterFailoverProcesses`
 - `PostFailoverProcesses`
 - `PostUnsuccessfulFailoverProcesses`
+- `PostGracefulTakeoverProcesses`: executed on planned, graceful master takeover, after the old master is positioned under the newly promoted master.

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -227,6 +227,7 @@ type Configuration struct {
 	PostUnsuccessfulFailoverProcesses          []string          // Processes to execute after a not-completely-successful failover (order of execution undefined). May and should use some of these placeholders: {failureType}, {failureDescription}, {command}, {failedHost}, {failureCluster}, {failureClusterAlias}, {failureClusterDomain}, {failedPort}, {successorHost}, {successorPort}, {successorAlias}, {countReplicas}, {replicaHosts}, {isDowntimed}, {isSuccessful}, {lostReplicas}
 	PostMasterFailoverProcesses                []string          // Processes to execute after doing a master failover (order of execution undefined). Uses same placeholders as PostFailoverProcesses
 	PostIntermediateMasterFailoverProcesses    []string          // Processes to execute after doing a master failover (order of execution undefined). Uses same placeholders as PostFailoverProcesses
+	PostGracefulTakeoverProcesses              []string          // Processes to execute after runnign a graceful master takeover. Uses same placeholders as PostFailoverProcesses
 	UnreachableMasterWithStaleSlavesProcesses  []string          // Processes to execute when detecting an UnreachableMasterWithStaleSlaves scenario.
 	CoMasterRecoveryMustPromoteOtherCoMaster   bool              // When 'false', anything can get promoted (and candidates are prefered over others). When 'true', orchestrator will promote the other co-master or else fail
 	DetachLostSlavesAfterMasterFailover        bool              // synonym to DetachLostReplicasAfterMasterFailover
@@ -387,6 +388,7 @@ func newConfiguration() *Configuration {
 		PostIntermediateMasterFailoverProcesses:    []string{},
 		PostFailoverProcesses:                      []string{},
 		PostUnsuccessfulFailoverProcesses:          []string{},
+		PostGracefulTakeoverProcesses:              []string{},
 		UnreachableMasterWithStaleSlavesProcesses:  []string{},
 		CoMasterRecoveryMustPromoteOtherCoMaster:   true,
 		DetachLostSlavesAfterMasterFailover:        true,

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1728,6 +1728,7 @@ func GracefulMasterTakeover(clusterName string, designatedKey *inst.InstanceKey)
 			err = enableSSLErr
 		}
 	}
+	executeProcesses(config.Config.PostGracefulTakeoverProcesses, "PostGracefulTakeoverProcesses", topologyRecovery, false)
 
 	return topologyRecovery, promotedMasterCoordinates, err
 }


### PR DESCRIPTION
Closes https://github.com/github/orchestrator/issues/453

This PR introduces `PostGracefulTakeoverProcesses`, the counterpart of `PreGracefulTakeoverProcesses` (https://github.com/github/orchestrator/pull/469).

`PostGracefulTakeoverProcesses` are executed once a graceful takeover is fully complete, and the old master is in position under the newly promoted master.

cc @igroene 