### PR TITLE
Make it explicit which backend host is being talked to

### DIFF
--- a/go/db/db.go
+++ b/go/db/db.go
@@ -172,7 +172,9 @@ func OpenOrchestrator() (db *sql.DB, err error) {
 		if maxIdleConns < 10 {
 			maxIdleConns = 10
 		}
-		log.Infof("Connecting to backend: maxConnections: %d, maxIdleConns: %d",
+		log.Infof("Connecting to backend %s:%d: maxConnections: %d, maxIdleConns: %d",
+			config.Config.MySQLOrchestratorHost,
+			config.Config.MySQLOrchestratorPort,
 			config.Config.MySQLOrchestratorMaxPoolConnections,
 			maxIdleConns)
 		db.SetMaxIdleConns(maxIdleConns)


### PR DESCRIPTION
A change in name in the backend orchestrator host was not applied on a server and it gave an error, but didn't explain the problem:

```
$ sudo orchestrator -c relocate -d dest-host.example.com
2018-04-27 10:07:03 ERROR Error reading dest-host.example.com:3306
2018-04-27 10:07:03 FATAL 2018-04-27 10:07:03 ERROR Error reading dst-host.example.com:3306
$ sudo orchestrator --verbose -c relocate -d dst-host.example.com
2018-04-27 10:07:12 INFO starting orchestrator, version: 3.0.1.8, git commit: 208e53de7aa0f0c0a4f6192942f3c3c0e73e6cec
2018-04-27 10:07:12 INFO Read config: /etc/orchestrator.conf.json
2018-04-27 10:07:12 INFO Connecting to backend: maxConnections: 1000, maxIdleConns: 250
2018-04-27 10:07:12 ERROR Error reading dst-host.example.com:3306
2018-04-27 10:07:12 FATAL 2018-04-27 10:07:12 ERROR Error reading dst-host.example.com:3306
```

The problem was the backend hostname held in `config.Config.MySQLOrchestratorHost` had changed. This was not recorded in the logging.

This change simply adds this info to the logging which should help identify the real problem.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
