### PR TITLE
Fix detection of Go 1.10.x

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ function precheck() {
     ok=1
   fi
 
-  if [[ $(go version | egrep "go1[.][01234]") ]]; then
+  if [[ $(go version | egrep "go1[.][01234][.]") ]]; then
     echo "go version is too low. Must use 1.5 or above"
     ok=1
   fi

--- a/build.sh
+++ b/build.sh
@@ -56,8 +56,8 @@ function precheck() {
     ok=1
   fi
 
-  if [[ $(go version | egrep "go1[.][01234][.]") ]]; then
-    echo "go version is too low. Must use 1.5 or above"
+  if [[ ! $(go version | egrep "go(1[.]8|1[.]9|1[.]10)") ]]; then
+    echo "go version is too low. Must use 1.8 or above"
     ok=1
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ function precheck() {
     ok=1
   fi
 
-  if ! go version | egrep -q "go(1[.]8|1[.]9|1[.]10)" ; then
+  if ! go version | egrep -q 'go(1[.]8|1[.]9|1[.]10)' ; then
     echo "go version is too low. Must use 1.8 or above"
     ok=1
   fi

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ function precheck() {
     ok=1
   fi
 
-  if [[ ! $(go version | egrep "go(1[.]8|1[.]9|1[.]10)") ]]; then
+  if ! go version | egrep -q "go(1[.]8|1[.]9|1[.]10)" ; then
     echo "go version is too low. Must use 1.8 or above"
     ok=1
   fi


### PR DESCRIPTION
Fedora 28 ships with go 1.10.x which build.sh detects as too old, while it isn't too old.
This PR fixes that by a more restrictive regex.

```
$ go version
go version go1.10.1 linux/amd64
```