### PR TITLE
GTID visual indications

### DIFF
--- a/resources/public/css/orchestrator.css
+++ b/resources/public/css/orchestrator.css
@@ -128,6 +128,11 @@ body {
     color: #606060;
 }
 
+.instance h3 .pull-right > .glyphicon.text-muted {
+    color: #999999;
+}
+
+
 .instance h3 .glyphicon {
     position: inherit;
     cursor: default;


### PR DESCRIPTION
With this PR GTID is better presented in GUI:
- If server _supports_ GTID but doesn't actually use it, the _globe_ glyph is muted (grayed out)
- Modal dialog differentiates between GTID-supported to GTID-in-use

Related: https://github.com/github/orchestrator/issues/485

Noting that a Oracle/Percona server can be configured with `gtid_mode=ON`, for example, and yet run with `Auto_position: 0`, meaning it uses `file:pos` coordinates.

cc @cjmudd