### PR TITLE
Init KV on command line execution

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -209,6 +209,8 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	if !skipDatabaseCommands && !*config.RuntimeCLIFlags.SkipContinuousRegistration {
 		process.ContinuousRegistration(string(process.OrchestratorExecutionCliMode), command)
 	}
+	kv.InitKVStores()
+
 	// begin commands
 	switch command {
 	// smart mode

--- a/go/kv/kv.go
+++ b/go/kv/kv.go
@@ -49,10 +49,7 @@ func InitKVStores() {
 	kvMutex.Lock()
 	defer kvMutex.Unlock()
 
-	fmt.Println("............0")
-
 	kvInitOnce.Do(func() {
-		fmt.Println("............1")
 		kvStores = []KVStore{
 			NewInternalKVStore(),
 			NewConsulStore(),

--- a/go/kv/kv.go
+++ b/go/kv/kv.go
@@ -40,17 +40,25 @@ type KVStore interface {
 }
 
 var kvMutex sync.Mutex
+var kvInitOnce sync.Once
 var kvStores = []KVStore{}
 
+// InitKVStores initializes the KV stores (duh), once in the lifetime of this app.
+// Configuration reload does not affect a running instance.
 func InitKVStores() {
 	kvMutex.Lock()
 	defer kvMutex.Unlock()
 
-	kvStores = []KVStore{
-		NewInternalKVStore(),
-		NewConsulStore(),
-		NewZkStore(),
-	}
+	fmt.Println("............0")
+
+	kvInitOnce.Do(func() {
+		fmt.Println("............1")
+		kvStores = []KVStore{
+			NewInternalKVStore(),
+			NewConsulStore(),
+			NewZkStore(),
+		}
+	})
 }
 
 func getKVStores() (stores []KVStore) {


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/497

KV were only initialized when running `orchestrator` as a service. They were not initialized on CLI (command line) execution, by mistake.

This PR makes sure CLI execution initializes the KV stores.

cc @TylerLubeck  @choadrocker 