### PR TITLE
Miscellaneous documentation typos

### DIFF
--- a/docs/configuration-discovery-classifying.md
+++ b/docs/configuration-discovery-classifying.md
@@ -21,7 +21,7 @@ By default, `orchestrator` uses `SHOW SLAVE STATUS` and takes a 1-second granula
 
 ### Cluster alias
 
-At your company the different clusters have common names. "Main", "Analytics", "Shard031" etc. However the MySQL clusters themselves are unaware of such names.  
+At your company the different clusters have common names. "Main", "Analytics", "Shard031" etc. However the MySQL clusters themselves are unaware of such names.
 
 `DetectClusterAliasQuery` is a query by which you will let `orchestrator` know the name of your cluster.
 
@@ -50,7 +50,7 @@ Perhaps your host naming conventions will disclose the cluster name and you only
 
 ### Data center
 
-`oechestrator` is data-center aware. Not only will it color them nicely on the web interface; but it will take DC into consideration when running failovers.
+`orchestrator` is data-center aware. Not only will it color them nicely on the web interface; but it will take DC into consideration when running failovers.
 
 You will configure data center awareness in one of two methods:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -103,7 +103,7 @@ If you're not using GTID, you'll be happy to know `orchestrator` can utilize Pse
 
 Read more on the [Pseudo-GTID](pseudo-gtid.md) documentation page.
 
-`orchestrator` can inject Pseudo-GTID entires for you. Your clusters will magically have GTID-like superpowers. Follow [Automated Pseudo-GTID](configuration-discovery-pseudo-gtid.md#automated-pseudo-gtid-injection)
+`orchestrator` can inject Pseudo-GTID entries for you. Your clusters will magically have GTID-like superpowers. Follow [Automated Pseudo-GTID](configuration-discovery-pseudo-gtid.md#automated-pseudo-gtid-injection)
 
 ### Populating meta data
 

--- a/docs/pseudo-gtid-manual-injection.md
+++ b/docs/pseudo-gtid-manual-injection.md
@@ -117,7 +117,7 @@ propagates through replication stream. As opposed to previous example, it will n
 
 While the statement is visible in the binary logs, it is not visible in the data itself. A second statement registers the latest update in table data. It is not strictly required, but helps to make sure pseudo-gtid is running. The `DetectPseudoGTIDQuery` config allows `orchestrator` to actually check if Pseudo-GTID was recently injected.
 
-The logic above also makes sure injected pseudo-gtid entires are in Ascending lexical order. The `PseudoGTIDMonotonicHint` config relates to the `asc:` hint in the query. Ascending order allows orchestrator to perform further optimizations when searching for a given Pseudo-GTID entry on a server's binary logs.
+The logic above also makes sure injected pseudo-gtid entries are in Ascending lexical order. The `PseudoGTIDMonotonicHint` config relates to the `asc:` hint in the query. Ascending order allows orchestrator to perform further optimizations when searching for a given Pseudo-GTID entry on a server's binary logs.
 
 `orchestrator` will only enable Pseudo-GTID mode if the `PseudoGTIDPattern` configuration variable is non-empty, but can only validate its correctness during runtime.
 

--- a/go/inst/instance_binlog.go
+++ b/go/inst/instance_binlog.go
@@ -125,7 +125,7 @@ func (this *BinlogEventCursor) nextEvent(numEmptyEventsEvents int) (*BinlogEvent
 		}
 		this.currentEventIndex = -1
 		// While this seems recursive do note that recursion level is at most 1, since we either have
-		// entires in the next binlog (no further recursion) or we don't (immediate termination)
+		// entries in the next binlog (no further recursion) or we don't (immediate termination)
 		return this.nextEvent(numEmptyEventsEvents + 1)
 	}
 	if this.currentEventIndex+1 < len(this.cachedEvents) {
@@ -143,7 +143,7 @@ func (this *BinlogEventCursor) nextEvent(numEmptyEventsEvents int) (*BinlogEvent
 		}
 		this.currentEventIndex = -1
 		// While this seems recursive do note that recursion level is at most 1, since we either have
-		// entires in the next binlog (no further recursion) or we don't (immediate termination)
+		// entries in the next binlog (no further recursion) or we don't (immediate termination)
 		return this.nextEvent(numEmptyEventsEvents + 1)
 	}
 }

--- a/go/logic/topology_recovery_dao.go
+++ b/go/logic/topology_recovery_dao.go
@@ -502,7 +502,7 @@ func writeResolveRecovery(topologyRecovery *TopologyRecovery) error {
 	return log.Errore(err)
 }
 
-// readRecoveries reads recovery entry/audit entires from topology_recovery
+// readRecoveries reads recovery entry/audit entries from topology_recovery
 func readRecoveries(whereCondition string, limit string, args []interface{}) ([]TopologyRecovery, error) {
 	res := []TopologyRecovery{}
 	query := fmt.Sprintf(`
@@ -586,7 +586,7 @@ func readRecoveries(whereCondition string, limit string, args []interface{}) ([]
 	return res, log.Errore(err)
 }
 
-// ReadActiveRecoveries reads active recovery entry/audit entires from topology_recovery
+// ReadActiveRecoveries reads active recovery entry/audit entries from topology_recovery
 func ReadActiveClusterRecovery(clusterName string) ([]TopologyRecovery, error) {
 	whereClause := `
 		where
@@ -644,7 +644,7 @@ func ReadRecentlyActiveInstanceRecovery(instanceKey *inst.InstanceKey) ([]Topolo
 	return readRecoveries(whereClause, ``, sqlutils.Args(instanceKey.Hostname, instanceKey.Port))
 }
 
-// ReadActiveRecoveries reads active recovery entry/audit entires from topology_recovery
+// ReadActiveRecoveries reads active recovery entry/audit entries from topology_recovery
 func ReadActiveRecoveries() ([]TopologyRecovery, error) {
 	return readRecoveries(`
 		where
@@ -653,7 +653,7 @@ func ReadActiveRecoveries() ([]TopologyRecovery, error) {
 		``, sqlutils.Args())
 }
 
-// ReadCompletedRecoveries reads completed recovery entry/audit entires from topology_recovery
+// ReadCompletedRecoveries reads completed recovery entry/audit entries from topology_recovery
 func ReadCompletedRecoveries(page int) ([]TopologyRecovery, error) {
 	limit := `
 		limit ?
@@ -661,13 +661,13 @@ func ReadCompletedRecoveries(page int) ([]TopologyRecovery, error) {
 	return readRecoveries(`where end_recovery is not null`, limit, sqlutils.Args(config.AuditPageSize, page*config.AuditPageSize))
 }
 
-// ReadRecovery reads completed recovery entry/audit entires from topology_recovery
+// ReadRecovery reads completed recovery entry/audit entries from topology_recovery
 func ReadRecovery(recoveryId int64) ([]TopologyRecovery, error) {
 	whereClause := `where recovery_id = ?`
 	return readRecoveries(whereClause, ``, sqlutils.Args(recoveryId))
 }
 
-// ReadRecoveryByUID reads completed recovery entry/audit entires from topology_recovery
+// ReadRecoveryByUID reads completed recovery entry/audit entries from topology_recovery
 func ReadRecoveryByUID(recoveryUID string) ([]TopologyRecovery, error) {
 	whereClause := `where uid = ?`
 	return readRecoveries(whereClause, ``, sqlutils.Args(recoveryUID))
@@ -695,7 +695,7 @@ func ReadRecentRecoveries(clusterName string, unacknowledgedOnly bool, page int)
 	return readRecoveries(whereClause, limit, args)
 }
 
-// readRecoveries reads recovery entry/audit entires from topology_recovery
+// readRecoveries reads recovery entry/audit entries from topology_recovery
 func readFailureDetections(whereCondition string, limit string, args []interface{}) ([]TopologyRecovery, error) {
 	res := []TopologyRecovery{}
 	query := fmt.Sprintf(`


### PR DESCRIPTION
Correcting two typos found in the documentation:
- `oechestrator` -> `orchestrator`
- `entires` -> `entries`