### PR TITLE
Checking raft response as error

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -2970,7 +2970,7 @@ func (this *HttpAPI) AcknowledgeClusterRecoveries(params martini.Params, r rende
 	if orcraft.IsRaftEnabled() {
 		ack := logic.NewRecoveryAcknowledgement(userId, comment)
 		ack.ClusterName = clusterName
-		orcraft.PublishCommand("ack-recovery", ack)
+		_, err = orcraft.PublishCommand("ack-recovery", ack)
 	} else {
 		_, err = logic.AcknowledgeClusterRecoveries(clusterName, userId, comment)
 	}
@@ -3007,7 +3007,7 @@ func (this *HttpAPI) AcknowledgeInstanceRecoveries(params martini.Params, r rend
 	if orcraft.IsRaftEnabled() {
 		ack := logic.NewRecoveryAcknowledgement(userId, comment)
 		ack.Key = instanceKey
-		orcraft.PublishCommand("ack-recovery", ack)
+		_, err = orcraft.PublishCommand("ack-recovery", ack)
 	} else {
 		_, err = logic.AcknowledgeInstanceRecoveries(&instanceKey, userId, comment)
 	}

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -790,7 +790,8 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 			go orcraft.PublishCommand("async-snapshot", "")
 		} else {
 			for _, kvPair := range kvPairs {
-				kv.PutKVPair(kvPair)
+				err := kv.PutKVPair(kvPair)
+				log.Errore(err)
 			}
 		}
 

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -784,7 +784,8 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("Writing KV %+v", kvPairs))
 		if orcraft.IsRaftEnabled() {
 			for _, kvPair := range kvPairs {
-				orcraft.PublishCommand("put-key-value", kvPair)
+				_, err := orcraft.PublishCommand("put-key-value", kvPair)
+				log.Errore(err)
 			}
 			// since we'll be affecting 3rd party tools here, we _prefer_ to mitigate re-applying
 			// of the put-key-value event upon startup. We _recommend_ a snapshot in the near future.
@@ -1425,7 +1426,8 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 	registrationSuccess, _, err := checkAndExecuteFailureDetectionProcesses(analysisEntry, skipProcesses)
 	if registrationSuccess {
 		if orcraft.IsRaftEnabled() {
-			orcraft.PublishCommand("register-failure-detection", analysisEntry)
+			_, err := orcraft.PublishCommand("register-failure-detection", analysisEntry)
+			log.Errore(err)
 		}
 	}
 	if err != nil {

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -223,14 +223,12 @@ func AuditTopologyRecovery(topologyRecovery *TopologyRecovery, message string) e
 	}
 
 	recoveryStep := NewTopologyRecoveryStep(topologyRecovery.UID, message)
-	if err := writeTopologyRecoveryStep(recoveryStep); err != nil {
-		return err
-	}
 	if orcraft.IsRaftEnabled() {
 		_, err := orcraft.PublishCommand("write-recovery-step", recoveryStep)
 		return err
+	} else {
+		return writeTopologyRecoveryStep(recoveryStep)
 	}
-	return nil
 }
 
 func resolveRecovery(topologyRecovery *TopologyRecovery, successorInstance *inst.Instance) error {

--- a/go/logic/topology_recovery_dao.go
+++ b/go/logic/topology_recovery_dao.go
@@ -243,8 +243,7 @@ func AttemptRecoveryRegistration(analysisEntry *inst.ReplicationAnalysis, failIf
 		return nil, log.Errore(err)
 	}
 	if orcraft.IsRaftEnabled() {
-		_, err := orcraft.PublishCommand("write-recovery", topologyRecovery)
-		if err != nil {
+		if _, err := orcraft.PublishCommand("write-recovery", topologyRecovery); err != nil {
 			return nil, log.Errore(err)
 		}
 	}

--- a/go/raft/store.go
+++ b/go/raft/store.go
@@ -146,5 +146,10 @@ func (store *Store) genericCommand(op string, bytes []byte) (response interface{
 		return nil, err
 	}
 	r := f.Response()
+	if err, ok := r.(error); ok && err != nil {
+		// This code checks whether the response itself was an error object. If so, it should
+		// indicate failure of the operation.
+		return r, err
+	}
 	return r, nil
 }


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/503 and may have grander impact. Checks whether the `raft` response object is an `error`, and if so escalates.

This lets us propagate app-logic errors through the `raft` mechanism.