### PR TITLE
graceful and forced failover: better anlaysis including GTID fix

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1376,7 +1376,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 		}
 	case registerCliCommand("replication-analysis", "Recovery", `Request an analysis of potential crash incidents in all known topologies`):
 		{
-			analysis, err := inst.GetReplicationAnalysis("", false, false)
+			analysis, err := inst.GetReplicationAnalysis("", &inst.ReplicationAnalysisHints{})
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -2632,7 +2632,7 @@ func (this *HttpAPI) ReloadConfiguration(params martini.Params, r render.Render,
 
 // ReplicationAnalysis retuens list of issues
 func (this *HttpAPI) replicationAnalysis(clusterName string, instanceKey *inst.InstanceKey, params martini.Params, r render.Render, req *http.Request) {
-	analysis, err := inst.GetReplicationAnalysis(clusterName, true, false)
+	analysis, err := inst.GetReplicationAnalysis(clusterName, &inst.ReplicationAnalysisHints{IncludeDowntimed: true})
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Cannot get analysis: %+v", err)})
 		return

--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -84,6 +84,12 @@ func (instanceAnalysis *InstanceAnalysis) String() string {
 // Key of this map is a InstanceAnalysis.String()
 type PeerAnalysisMap map[string]int
 
+type ReplicationAnalysisHints struct {
+	IncludeDowntimed bool
+	IncludeNoProblem bool
+	AuditAnalysis    bool
+}
+
 // ReplicationAnalysis notes analysis on replication chain status, per instance
 type ReplicationAnalysis struct {
 	AnalyzedInstanceKey                       InstanceKey

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -52,7 +52,7 @@ func initializeAnalysisDaoPostConfiguration() {
 }
 
 // GetReplicationAnalysis will check for replication problems (dead master; unreachable master; etc)
-func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnalysis bool) ([]ReplicationAnalysis, error) {
+func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints) ([]ReplicationAnalysis, error) {
 	result := []ReplicationAnalysis{}
 
 	args := sqlutils.Args(ValidSecondsFromSeenToLastAttemptedCheck(), clusterName)
@@ -395,7 +395,7 @@ func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnal
 		//		}
 
 		appendAnalysis := func(analysis *ReplicationAnalysis) {
-			if a.Analysis == NoProblem && len(a.StructureAnalysis) == 0 {
+			if a.Analysis == NoProblem && len(a.StructureAnalysis) == 0 && !hints.IncludeNoProblem {
 				return
 			}
 			for _, filter := range config.Config.RecoveryIgnoreHostnameFilters {
@@ -422,7 +422,7 @@ func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnal
 					a.SkippableDueToDowntime = true
 				}
 			}
-			if a.SkippableDueToDowntime && !includeDowntimed {
+			if a.SkippableDueToDowntime && !hints.IncludeDowntimed {
 				return
 			}
 			result = append(result, a)
@@ -450,7 +450,7 @@ func GetReplicationAnalysis(clusterName string, includeDowntimed bool, auditAnal
 		}
 		appendAnalysis(&a)
 
-		if a.CountReplicas > 0 && auditAnalysis {
+		if a.CountReplicas > 0 && hints.AuditAnalysis {
 			// Interesting enough for analysis
 			go auditInstanceAnalysisInChangelog(&a.AnalyzedInstanceKey, a.Analysis)
 		}


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/508

While this PR was originated to fix https://github.com/github/orchestrator/issues/508, it actually fixes more than that.

With `graceful-master-takeover` and `force-master-failover`, we impose a failover scenario on `orchestrator` even though it may not recognize one (indeed, in a `graceful` scenario there _is no failure_ per se).

The _analysis_ in those two scenarios was imposed on `orchestrator`. But as such, it lacked context and extra info. Namely, the one described in https://github.com/github/orchestrator/issues/508: lack of GTID context. Possibly also https://github.com/github/orchestrator/issues/421 is related.

With this PR we force the full analysis on the master on both these operations, and get the full context, including GTID state of the replicas.

cc @almeida-pythian @ManjotS 