### PR TITLE
fixed typo in command help for "clusters"

### DIFF
--- a/go/app/command_help.go
+++ b/go/app/command_help.go
@@ -460,7 +460,7 @@ func init() {
   List all clusters known to orchestrator. A cluster (aka topology, aka chain) is identified by its
   master (or one of its master if more than one exists). Example:
 
-  orchesrtator -c clusters
+  orchestrator -c clusters
       -i not given, implicitly assumed local hostname
 	`
 	CommandHelp["all-clusters-masters"] = `


### PR DESCRIPTION
Related issue: https://github.com/github/orchestrator/issues/511

### Description

This PR fixes a typo in the example for the 'clusters' command help. 

> In case this PR introduced Go code changes:

- [ x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`

I did not check the last three checkboxes but the change is just swapping the order of two letters in 'orchestrator' on a help string, so the format is the same, and this shouldn't impact the build process or break any tests. 