### PR TITLE
Supporting `can-replicate-from` command

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -749,26 +749,25 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if instanceKey == nil {
 				log.Fatalf("Unresolved instance")
 			}
-			instance, err := inst.ReadTopologyInstance(instanceKey)
-			if err != nil {
-				log.Fatale(err)
-			}
-			if instance == nil {
-				log.Fatalf("Instance not found: %+v", *instanceKey)
-			}
+			instance := validateInstanceIsFound(instanceKey)
 			if destinationKey == nil {
 				log.Fatal("Cannot deduce target instance:", destination)
 			}
-			otherInstance, err := inst.ReadTopologyInstance(destinationKey)
-			if err != nil {
-				log.Fatale(err)
-			}
-			if otherInstance == nil {
-				log.Fatalf("Instance not found: %+v", *destinationKey)
-			}
+			otherInstance := validateInstanceIsFound(destinationKey)
 
 			if canReplicate, _ := instance.CanReplicateFrom(otherInstance); canReplicate {
 				fmt.Println(destinationKey.DisplayString())
+			}
+		}
+	case registerCliCommand("is-replicating", "Replication information", `Is an instance (-i) actively replicating right now`):
+		{
+			instanceKey, _ = inst.FigureInstanceKey(instanceKey, thisInstanceKey)
+			if instanceKey == nil {
+				log.Fatalf("Unresolved instance")
+			}
+			instance := validateInstanceIsFound(instanceKey)
+			if instance.ReplicaRunning() {
+				fmt.Println(instance.Key.DisplayString())
 			}
 		}
 		// Instance

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -742,6 +742,34 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				fmt.Println(statement)
 			}
 		}
+		// Replication, information
+	case registerCliCommand("can-replicate-from", "Replication information", `Can an instance (-i) replicate from another (-d) according to replication rules? Prints 'true|false'`):
+		{
+			instanceKey, _ = inst.FigureInstanceKey(instanceKey, thisInstanceKey)
+			if instanceKey == nil {
+				log.Fatalf("Unresolved instance")
+			}
+			instance, err := inst.ReadTopologyInstance(instanceKey)
+			if err != nil {
+				log.Fatale(err)
+			}
+			if instance == nil {
+				log.Fatalf("Instance not found: %+v", *instanceKey)
+			}
+			if destinationKey == nil {
+				log.Fatal("Cannot deduce target instance:", destination)
+			}
+			otherInstance, err := inst.ReadTopologyInstance(destinationKey)
+			if err != nil {
+				log.Fatale(err)
+			}
+			if otherInstance == nil {
+				log.Fatalf("Instance not found: %+v", *destinationKey)
+			}
+
+			canReplicate, _ := instance.CanReplicateFrom(otherInstance)
+			fmt.Println(fmt.Sprintf("%t", canReplicate))
+		}
 		// Instance
 	case registerCliCommand("set-read-only", "Instance", `Turn an instance read-only, via SET GLOBAL read_only := 1`):
 		{

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -767,8 +767,9 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatalf("Instance not found: %+v", *destinationKey)
 			}
 
-			canReplicate, _ := instance.CanReplicateFrom(otherInstance)
-			fmt.Println(fmt.Sprintf("%t", canReplicate))
+			if canReplicate, _ := instance.CanReplicateFrom(otherInstance); canReplicate {
+				fmt.Println(destinationKey.DisplayString())
+			}
 		}
 		// Instance
 	case registerCliCommand("set-read-only", "Instance", `Turn an instance read-only, via SET GLOBAL read_only := 1`):

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1367,7 +1367,7 @@ func (this *HttpAPI) CanReplicateFrom(params martini.Params, r render.Render, re
 		return
 	}
 
-	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("%t", canReplicate), Details: canReplicate})
+	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("%t", canReplicate), Details: belowKey})
 }
 
 // setSemiSyncMaster

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -280,6 +280,15 @@ function restart_replica_statements() {
   print_response | print_details
 }
 
+function general_boolean_command() {
+  path="${1:-$command}"
+
+  assert_nonempty "instance" "$instance_hostport"
+  assert_nonempty "destination" "$destination_hostport"
+  api "${path}/$instance_hostport/$destination_hostport"
+  print_response | print_details
+}
+
 function last_pseudo_gtid() {
   assert_nonempty "instance" "$instance_hostport"
   api "last-pseudo-gtid/$instance_hostport"
@@ -682,6 +691,8 @@ function run_command() {
     "enable-semi-sync-replica") general_instance_command ;;     # Enable semi-sync (replica-side)
     "disable-semi-sync-replica") general_instance_command ;;    # Disable semi-sync (replica-side)
     "restart-replica-statements") restart_replica_statements ;; # Given `-q "<query>"` that requires replication restart to apply, wrap query with stop/start slave statements as required to restore instance to same replication state. Print out set of statements
+
+    "can-replicate-from") general_boolean_command ;; # Check if an instance can potentially replicate from another, according to replication rules
 
     "set-read-only") general_instance_command ;;     # Turn an instance read-only, via SET GLOBAL read_only := 1
     "set-writeable") general_instance_command ;;     # Turn an instance writeable, via SET GLOBAL read_only := 0

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -281,15 +281,20 @@ function restart_replica_statements() {
 }
 
 function can_replicate_from() {
-  path="${1:-$command}"
-
   assert_nonempty "instance" "$instance_hostport"
   assert_nonempty "destination" "$destination_hostport"
-  api "${path}/$instance_hostport/$destination_hostport"
+  api "can-replicate-from/$instance_hostport/$destination_hostport"
 
   if print_response | jq -r '.Message' | grep -q "true" ; then
     print_response | print_details | print_key
   fi
+}
+
+function is_replicating() {
+  assert_nonempty "instance" "$instance_hostport"
+  api "instance/$instance_hostport"
+
+  print_response | jq '. | select(.Slave_SQL_Running==true and .Slave_IO_Running==true)' | filter_key | print_key
 }
 
 function last_pseudo_gtid() {
@@ -696,6 +701,7 @@ function run_command() {
     "restart-replica-statements") restart_replica_statements ;; # Given `-q "<query>"` that requires replication restart to apply, wrap query with stop/start slave statements as required to restore instance to same replication state. Print out set of statements
 
     "can-replicate-from") can_replicate_from ;; # Check if an instance can potentially replicate from another, according to replication rules
+    "is-replicating") is_replicating ;;         # Check if an instance is replicating at this time (both SQL and IO threads running)
 
     "set-read-only") general_instance_command ;;     # Turn an instance read-only, via SET GLOBAL read_only := 1
     "set-writeable") general_instance_command ;;     # Turn an instance writeable, via SET GLOBAL read_only := 0

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -280,13 +280,16 @@ function restart_replica_statements() {
   print_response | print_details
 }
 
-function general_boolean_command() {
+function can_replicate_from() {
   path="${1:-$command}"
 
   assert_nonempty "instance" "$instance_hostport"
   assert_nonempty "destination" "$destination_hostport"
   api "${path}/$instance_hostport/$destination_hostport"
-  print_response | print_details
+
+  if print_response | jq -r '.Message' | grep -q "true" ; then
+    print_response | print_details | print_key
+  fi
 }
 
 function last_pseudo_gtid() {
@@ -692,7 +695,7 @@ function run_command() {
     "disable-semi-sync-replica") general_instance_command ;;    # Disable semi-sync (replica-side)
     "restart-replica-statements") restart_replica_statements ;; # Given `-q "<query>"` that requires replication restart to apply, wrap query with stop/start slave statements as required to restore instance to same replication state. Print out set of statements
 
-    "can-replicate-from") general_boolean_command ;; # Check if an instance can potentially replicate from another, according to replication rules
+    "can-replicate-from") can_replicate_from ;; # Check if an instance can potentially replicate from another, according to replication rules
 
     "set-read-only") general_instance_command ;;     # Turn an instance read-only, via SET GLOBAL read_only := 1
     "set-writeable") general_instance_command ;;     # Turn an instance writeable, via SET GLOBAL read_only := 0


### PR DESCRIPTION
Example: 
```shell
$ orchestrator-client -c can-replicate-from -i some.instance:3306 -d from.other.instance:3306
true
```

Prints out `true|false` if 1st instance can replicate from 2nd instance according to replication rules (binlog format, versions,binary logs exist etc.), same way `orchestrator` validates internally.
Either `true` or `false`, exit code is `0`. Non-zero code is reserved to errors (e.g. cannot figure out which server is involved).