### PR TITLE
orchestrator-client: retries with incremental sleep

### DIFF
--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -184,10 +184,18 @@ function api() {
   uri="$leader_api/$path"
   # echo $uri
   set -o pipefail
-  api_response=$(curl -b "${basic_auth}" -s "$uri" | jq '.')
-  if [ $? -ne 0 ] ; then
+
+  api_call_result=0
+  for sleep_time in 0.1 0.2 0.5 1 2 5 10 0 ; do
+    api_response=$(curl -b "${basic_auth}" -s "$uri" | jq '.')
+    api_call_result=$?
+    [ $api_call_result -eq 0 ] && break
+    sleep $sleep_time
+  done
+  if [ $api_call_result -ne 0 ] ; then
     fail "Cannot access orchestrator at ${leader_api}.  Check ORCHESTRATOR_API is configured correctly and orchestrator is running"
   fi
+
   if [ "$(echo $api_response | jq -r 'type')" == "array" ] ; then
     return
   fi


### PR DESCRIPTION
`orchestrator` can go down for deployment/restart. or there could be a network hiccup. It's a shame to fail flows just because `orchestrator` was unavailable at a particular point in time.

`orchestrator-client` now retries contacting `orchestrator` with incremental sleep time: from `0.1s` to `10s` sleep intervals, totaling `8` attempts at `< 20s`.
