### PR TITLE
check FailMasterPromotionIfSQLThreadNotUpToDate in checkAndRecoverDeadCoMaster

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1239,6 +1239,10 @@ func checkAndRecoverDeadCoMaster(analysisEntry inst.ReplicationAnalysis, candida
 	}
 	topologyRecovery.LostReplicas.AddInstances(lostReplicas)
 	if promotedReplica != nil {
+		if config.Config.FailMasterPromotionIfSQLThreadNotUpToDate && !promotedReplica.SQLThreadUpToDate() {
+			return false, nil, log.Errorf("Promoted replica %+v: sql thread is not up to date (relay logs still unapplied). Aborting promotion", promotedReplica.Key)
+		}
+
 		// success
 		recoverDeadCoMasterSuccessCounter.Inc(1)
 


### PR DESCRIPTION
Related issue: https://github.com/github/orchestrator/issues/534

### Description

This PR adds check for `FailMasterPromotionIfSQLThreadNotUpToDate` to `checkAndRecoverDeadCoMaster` function. Same check was added to `checkAndRecoverDeadMaster` here: https://github.com/github/orchestrator/pull/104.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`
