### PR TITLE
Avoid failing the service on TLS error

### DIFF
--- a/go/db/tls.go
+++ b/go/db/tls.go
@@ -98,7 +98,7 @@ func SetupMySQLTopologyTLS(uri string) (string, error) {
 		// Drop to TLS 1.0 for talking to MySQL
 		tlsConfig.MinVersion = tls.VersionTLS10
 		if err != nil {
-			return "", log.Fatalf("Can't create TLS configuration for Topology connection %s: %s", uri, err)
+			return "", log.Errorf("Can't create TLS configuration for Topology connection %s: %s", uri, err)
 		}
 		tlsConfig.InsecureSkipVerify = config.Config.MySQLTopologySSLSkipVerify
 


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/539

`orchestrator` would sometimes fail/fatal on a TLS setup error when attempting to connect to TLS enabled MySQL servers. This PR avoids fataling out and reduces to a logged error.

cc @cezmunsta