### PR TITLE
Test for "Access denied for user" to trigger TLS

### DIFF
--- a/go/db/tls.go
+++ b/go/db/tls.go
@@ -33,6 +33,7 @@ import (
 )
 
 const Error3159 = "Error 3159:"
+const Error1045 = "Access denied for user"
 
 // Track if a TLS has already been configured for topology
 var topologyTLSConfigured bool = false
@@ -64,7 +65,7 @@ func requiresTLS(host string, port int, mysql_uri string) bool {
 
 	required := false
 	db, _, _ := sqlutils.GetDB(mysql_uri)
-	if err := db.Ping(); err != nil && strings.Contains(err.Error(), Error3159) {
+	if err := db.Ping(); err != nil && (strings.Contains(err.Error(), Error3159) || strings.Contains(err.Error(), Error1045)) {
 		required = true
 	}
 


### PR DESCRIPTION
To fix https://github.com/github/orchestrator/issues/541
```
$ ln -f /usr/local/orchestrator/orchestrator.requireTLSfix /usr/local/orchestrator/orchestrator; systemctl restart orchestrator.service

$ orchestrator-client -c discover -i 192.168.56.20:3306
192.168.56.20:3306

$ orchestrator-client -c all-instances | wc -l
1

$ orchestrator-client -c all-instances | wc -l
2

$ orchestrator-client -c topology -a db1
192.168.56.20:3306   [0s,ok,5.7.21-21-log,rw,ROW,>>]
+ 192.168.56.21:3306 [0s,ok,5.7.21-21-log,ro,ROW,>>]
```