### PR TITLE
Reduce container image size by using multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine
 
-EXPOSE 3000
-
 ENV GOPATH=/tmp/go
 
 RUN set -ex \
@@ -20,6 +18,12 @@ RUN set -ex \
     && cd / \
     && apk del .build-deps \
     && rm -rf /tmp/*
+
+FROM alpine
+
+EXPOSE 3000
+
+COPY --from=0 /usr/local/orchestrator /usr/local/orchestrator
 
 WORKDIR /usr/local/orchestrator
 ADD docker/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
fixes: #66 

By using multi stage builds we can reduce the image size by 50%.

Regular build 
```
<none>              <none>              cec3efb55b6d        8 minutes ago       60.6MB
```

After multi stage build
```
<none>              <none>              4ab2bafd0fc9        8 minutes ago       30.1MB
```