### PR TITLE
Debian ubuntu versions

### DIFF
--- a/script/packagecloud-push.rb
+++ b/script/packagecloud-push.rb
@@ -48,6 +48,22 @@ $distro_name_map = {
     ubuntu/vivid
     ubuntu/wily
     ubuntu/xenial
+    ubuntu/yakkety
+    ubuntu/zesty
+    ubuntu/artful
+    ubuntu/bionic
+  ),
+  "debian/9" => %w(
+    debian/stretch
+  ),
+  "debian/10" => %w(
+    debian/buster
+  ),
+  "debian/11" => %w(
+    debian/bullseye
+  ),
+  "debian/12" => %w(
+    debian/bookworm
   ),
 }
 

--- a/script/packagecloud-push.rb
+++ b/script/packagecloud-push.rb
@@ -44,6 +44,10 @@ $distro_name_map = {
     linuxmint/rebecca
     linuxmint/rafaela
     linuxmint/rosa
+    linuxmint/sarah
+    linuxmint/serena
+    linuxmint/sonya
+    linuxmint/sylvia
     ubuntu/trusty
     ubuntu/vivid
     ubuntu/wily


### PR DESCRIPTION
Closes https://github.com/github/orchestrator/issues/536

Added list of missing debian/ubuntu/linuxmint versions to `packagecloud` disribution.