### PR TITLE
Fixed inverted logic on FlushNontrivialResolveCacheToDatabase

### DIFF
--- a/go/inst/resolve.go
+++ b/go/inst/resolve.go
@@ -210,7 +210,7 @@ func loadHostnameResolveCacheFromDatabase() error {
 }
 
 func FlushNontrivialResolveCacheToDatabase() error {
-	if !HostnameResolveMethodIsNone() {
+	if HostnameResolveMethodIsNone() {
 		return log.Errorf("FlushNontrivialResolveCacheToDatabase() called, but HostnameResolveMethod is %+v", config.Config.HostnameResolveMethod)
 	}
 	items, _ := HostnameResolveCache()


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/515

The boolean check for `config.Config.HostnameResolveMethod` was inverted. As result, an annoying `Error` message was printed anytime (every 1 minute) we tried to flush hostname cache to database, and the hostname cache was in fact _not written_ to database. The impact was reasonably small (more hostname resolve on startup), but clearly wrong.