### PR TITLE
read-cluster-master may return read-only master

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1115,7 +1115,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	case registerCliCommand("which-cluster-master", "Information", `Output the name of the master in a given cluster`):
 		{
 			clusterName := getClusterName(clusterAlias, instanceKey)
-			masters, err := inst.ReadClusterWriteableMaster(clusterName)
+			masters, err := inst.ReadClusterMaster(clusterName)
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -216,12 +216,10 @@ func (this *HttpAPI) Discover(params martini.Params, r render.Render, req *http.
 	}
 
 	if orcraft.IsRaftEnabled() {
-		orcraft.PublishCommand("forget", instanceKey)
+		orcraft.PublishCommand("discover", instanceKey)
 	} else {
-		inst.ForgetInstance(&instanceKey)
+		logic.DiscoverInstance(instanceKey)
 	}
-
-	go orcraft.PublishCommand("discover", instanceKey)
 
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Instance discovered: %+v", instance.Key), Details: instance})
 }

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -183,13 +183,17 @@ func (this *HttpAPI) Instance(params martini.Params, r render.Render, req *http.
 // useful for bulk loads of a new set of instances and will not block
 // if the instance is slow to respond or not reachable.
 func (this *HttpAPI) AsyncDiscover(params martini.Params, r render.Render, req *http.Request, user auth.User) {
-	go this.Discover(params, r, req, user)
-
+	if !isAuthorizedForAction(req, user) {
+		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
+		return
+	}
 	instanceKey, err := this.getInstanceKey(params["host"], params["port"])
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
+	go this.Discover(params, r, req, user)
+
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Asynchronous discovery initiated for Instance: %+v", instanceKey)})
 }
 
@@ -200,7 +204,6 @@ func (this *HttpAPI) Discover(params martini.Params, r render.Render, req *http.
 		return
 	}
 	instanceKey, err := this.getInstanceKey(params["host"], params["port"])
-
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
@@ -209,6 +212,12 @@ func (this *HttpAPI) Discover(params martini.Params, r render.Render, req *http.
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
+	}
+
+	if orcraft.IsRaftEnabled() {
+		orcraft.PublishCommand("forget", instanceKey)
+	} else {
+		inst.ForgetInstance(&instanceKey)
 	}
 
 	go orcraft.PublishCommand("discover", instanceKey)
@@ -1704,7 +1713,7 @@ func (this *HttpAPI) ClusterMaster(params martini.Params, r render.Render, req *
 		return
 	}
 
-	masters, err := inst.ReadClusterWriteableMaster(clusterName)
+	masters, err := inst.ReadClusterMaster(clusterName)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -1089,6 +1089,17 @@ func ReadClusterWriteableMaster(clusterName string) ([](*Instance), error) {
 	return readInstancesByCondition(condition, sqlutils.Args(clusterName), "replication_depth asc")
 }
 
+// ReadClusterMaster returns the master of this cluster.
+// - if the cluster has co-masters, the/a writable one is returned
+// - if the cluster has a single master, that master is retuened whether it is read-only or writable.
+func ReadClusterMaster(clusterName string) ([](*Instance), error) {
+	condition := `
+		cluster_name = ?
+		and (replication_depth = 0 or is_co_master)
+	`
+	return readInstancesByCondition(condition, sqlutils.Args(clusterName), "read_only asc, replication_depth asc")
+}
+
 // ReadWriteableClustersMasters returns writeable masters of all clusters, but only one
 // per cluster, in similar logic to ReadClusterWriteableMaster
 func ReadWriteableClustersMasters() (instances [](*Instance), err error) {

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -99,7 +99,7 @@ func (applier *CommandApplier) discover(value []byte) interface{} {
 	if err := json.Unmarshal(value, &instanceKey); err != nil {
 		return log.Errore(err)
 	}
-	discoverInstance(instanceKey)
+	DiscoverInstance(instanceKey)
 	return nil
 }
 

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -174,17 +174,17 @@ func handleDiscoveryRequests() {
 					continue
 				}
 
-				discoverInstance(instanceKey)
+				DiscoverInstance(instanceKey)
 				discoveryQueue.Release(instanceKey)
 			}
 		}()
 	}
 }
 
-// discoverInstance will attempt to discover (poll) an instance (unless
+// DiscoverInstance will attempt to discover (poll) an instance (unless
 // it is already up to date) and will also ensure that its master and
 // replicas (if any) are also checked.
-func discoverInstance(instanceKey inst.InstanceKey) {
+func DiscoverInstance(instanceKey inst.InstanceKey) {
 	if inst.InstanceIsForgotten(&instanceKey) {
 		log.Debugf("discoverInstance: skipping discovery of %+v because it is set to be forgotten", instanceKey)
 		return
@@ -248,7 +248,7 @@ func discoverInstance(instanceKey inst.InstanceKey) {
 			Err:             err,
 		})
 		if util.ClearToLog("discoverInstance", instanceKey.StringCode()) {
-			log.Warningf("discoverInstance(%+v) instance is nil in %.3fs (Backend: %.3fs, Instance: %.3fs), error=%+v",
+			log.Warningf(" DiscoverInstance(%+v) instance is nil in %.3fs (Backend: %.3fs, Instance: %.3fs), error=%+v",
 				instanceKey,
 				totalLatency.Seconds(),
 				backendLatency.Seconds(),

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1635,7 +1635,7 @@ func ForceMasterTakeover(clusterName string, destination *inst.Instance) (topolo
 // for the designated replica to catch up with last position.
 // It will point old master at the newly promoted master at the correct coordinates, but will not start replication.
 func GracefulMasterTakeover(clusterName string, designatedKey *inst.InstanceKey) (topologyRecovery *TopologyRecovery, promotedMasterCoordinates *inst.BinlogCoordinates, err error) {
-	clusterMasters, err := inst.ReadClusterWriteableMaster(clusterName)
+	clusterMasters, err := inst.ReadClusterMaster(clusterName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Cannot deduce cluster master for %+v; error: %+v", clusterName, err)
 	}


### PR DESCRIPTION

`which-cluster-master`, in `/api`, CLI and `orchestrator-client`, can now return a read-only master, if that is the only master for the cluster.
The reasoning, well, is that a master of a cluster is still a master, even if it's `read-only`.

`graceful-master-takeover` now also agrees to run when the master of the cluster is `read-only`. There is nothing wrong with this, per se, albeit a bit strange situation. Such a strange situation though can make perfect sense if the user has made preparations and has turned the master to be `read-only`.