### PR TITLE
Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,21 @@
+# Requires Docker 17.09 or later (multi stage builds)
+
 FROM alpine
 
 ENV GOPATH=/tmp/go
 
-RUN set -ex \
-    && apk add --update --no-cache bash \
-    && apk add --update --no-cache --virtual .build-deps \
-        rsync \
-        git \
-        go \
-        build-base \
-    && cd /tmp \
-    && { go get -d github.com/github/orchestrator ; : ; } \
-    && cd $GOPATH/src/github.com/github/orchestrator \
+RUN apk update
+RUN apk add --no-cache libcurl ; apk add libcurl
+RUN apk add --no-cache rsync
+RUN apk add --no-cache go
+RUN apk add --no-cache gcc
+RUN apk add --no-cache g++
+#RUN apk add --no-cache build-base
+
+RUN mkdir -p $GOPATH/src/github.com/github/orchestrator
+WORKDIR $GOPATH/src/github.com/github/orchestrator
+COPY . .
+RUN \
     && bash build.sh -b \
     && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator -maxdepth 2)/ / \
     && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator-cli -maxdepth 2)/ / \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,34 @@
 # Requires Docker 17.09 or later (multi stage builds)
 
-FROM alpine
+FROM alpine:3.6
 
 ENV GOPATH=/tmp/go
 
 RUN apk update
-RUN apk add --no-cache libcurl ; apk add libcurl
-RUN apk add --no-cache rsync
-RUN apk add --no-cache go
-RUN apk add --no-cache gcc
-RUN apk add --no-cache g++
-#RUN apk add --no-cache build-base
+RUN apk upgrade
+RUN apk add --update libcurl
+RUN apk add --update rsync
+RUN apk add --update gcc
+RUN apk add --update g++
+RUN apk add --update go
+RUN apk add --update build-base
+RUN apk add --update bash
+RUN apk add --update git
 
 RUN mkdir -p $GOPATH/src/github.com/github/orchestrator
 WORKDIR $GOPATH/src/github.com/github/orchestrator
 COPY . .
-RUN \
-    && bash build.sh -b \
-    && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator -maxdepth 2)/ / \
-    && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator-cli -maxdepth 2)/ / \
-    && cd / \
-    && apk del .build-deps \
-    && rm -rf /tmp/*
+RUN bash build.sh -b
+RUN rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator -maxdepth 2)/ /
+RUN rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator-cli -maxdepth 2)/ /
+RUN cp /usr/local/orchestrator/orchestrator-sample-sqlite.conf.json /etc/orchestrator.conf.json
 
-FROM alpine
+FROM alpine:3.6
 
 EXPOSE 3000
 
 COPY --from=0 /usr/local/orchestrator /usr/local/orchestrator
+COPY --from=0 /etc/orchestrator.conf.json /etc/orchestrator.conf.json
 
 WORKDIR /usr/local/orchestrator
 ADD docker/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Overhaul to the `Dockerfile`. From now on `Dockerfile` builds `orchestrator` based on local branch/changes, as opposed to cloning `orchestrator/master` from remote `git` repo.

Also, docker image is set to run with `sqlite` backend.