### PR TITLE
New variable: disable AutoPseudoGTID where GTID is on

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -206,6 +206,7 @@ type Configuration struct {
 	SeedAcceptableBytesDiff                    int64             // Difference in bytes between seed source & target data size that is still considered as successful copy
 	SeedWaitSecondsBeforeSend                  int64             // Number of seconds for waiting before start send data command on agent
 	AutoPseudoGTID                             bool              // Should orchestrator automatically inject Pseudo-GTID entries to the masters
+	AutoPseudoGTIDDisabledOnGTID               bool              // Should orchestrator avoid injecting Pseudo GTID where GTID is enabled (default: false)
 	PseudoGTIDPattern                          string            // Pattern to look for in binary logs that makes for a unique entry (pseudo GTID). When empty, Pseudo-GTID based refactoring is disabled.
 	PseudoGTIDPatternIsFixedSubstring          bool              // If true, then PseudoGTIDPattern is not treated as regular expression but as fixed substring, and can boost search time
 	PseudoGTIDMonotonicHint                    string            // subtring in Pseudo-GTID entry which indicates Pseudo-GTID entries are expected to be monotonically increasing
@@ -369,6 +370,7 @@ func newConfiguration() *Configuration {
 		SeedAcceptableBytesDiff:                    8192,
 		SeedWaitSecondsBeforeSend:                  2,
 		AutoPseudoGTID:                             false,
+		AutoPseudoGTIDDisabledOnGTID:               false,
 		PseudoGTIDPattern:                          "",
 		PseudoGTIDPatternIsFixedSubstring:          false,
 		PseudoGTIDMonotonicHint:                    "",

--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -258,6 +258,11 @@ func (this *Instance) SQLThreadUpToDate() bool {
 	return this.ReadBinlogCoordinates.Equals(&this.ExecBinlogCoordinates)
 }
 
+// GTIDModeIsOn
+func (this *Instance) GTIDModeIsOn() bool {
+	return this.GTIDMode == "ON"
+}
+
 // UsingGTID returns true when this replica is currently replicating via GTID (either Oracle or MariaDB)
 func (this *Instance) UsingGTID() bool {
 	return this.UsingOracleGTID || this.UsingMariaDBGTID

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -396,6 +396,9 @@ func InjectPseudoGTIDOnWriters() error {
 	for i := range rand.Perm(len(instances)) {
 		instance := instances[i]
 		go func() {
+			if instance.GTIDModeIsOn() && config.Config.AutoPseudoGTIDDisabledOnGTID {
+				return
+			}
 			if injected, _ := inst.CheckAndInjectPseudoGTIDOnWriter(instance); injected {
 				clusterName := instance.ClusterName
 				if orcraft.IsRaftEnabled() {


### PR DESCRIPTION
A new config variable, `AutoPseudoGTIDDisabledOnGTID`, introduces a new behavior:

When `AutoPseudoGTIDDisabledOnGTID` is `true`, and a master has `gtid_mode = ON`, then `orchestrator` avoids injecting Pseudo GTID entries onto that master.

There is subtlety here: the fact that a master has `gtid_mode=ON` _does not mean_ the replicas are using GTID. They could use `master_auto_position: 0` and just use file:pos. `orchestrator` does not check all of the master's replicas (at this time, maybe this will change) hence the need to a new variable.