### PR TITLE
Stop graceful master takeover immediately when attempting to promote an ignored host

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1683,10 +1683,11 @@ func GracefulMasterTakeover(clusterName string, designatedKey *inst.InstanceKey)
 		if designatedInstance == nil {
 			return nil, nil, fmt.Errorf("GracefulMasterTakeover: indicated designated instance %+v must be directly replicating from the master %+v", *designatedKey, clusterMaster.Key)
 		}
-		if inst.IsBannedFromBeingCandidateReplica(designatedInstance) {
-			return nil, nil, fmt.Errorf("GracefulMasterTakeover: indicated designated instance %+v cannot be promoted due to promotion rule or it is explicitly ignored in PromotionIgnoreHostnameFilters configuration", *designatedKey)
-		}
 		log.Infof("GracefulMasterTakeover: designated master instructed to be %+v", designatedInstance.Key)
+	}
+
+	if inst.IsBannedFromBeingCandidateReplica(designatedInstance) {
+		return nil, nil, fmt.Errorf("GracefulMasterTakeover: designated instance %+v cannot be promoted due to promotion rule or it is explicitly ignored in PromotionIgnoreHostnameFilters configuration", designatedInstance.Key)
 	}
 
 	masterOfDesignatedInstance, err := inst.GetInstanceMaster(designatedInstance)

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1683,6 +1683,9 @@ func GracefulMasterTakeover(clusterName string, designatedKey *inst.InstanceKey)
 		if designatedInstance == nil {
 			return nil, nil, fmt.Errorf("GracefulMasterTakeover: indicated designated instance %+v must be directly replicating from the master %+v", *designatedKey, clusterMaster.Key)
 		}
+		if inst.IsBannedFromBeingCandidateReplica(designatedInstance) {
+			return nil, nil, fmt.Errorf("GracefulMasterTakeover: indicated designated instance %+v cannot be promoted due to promotion rule or it is explicitly ignored in PromotionIgnoreHostnameFilters configuration", *designatedKey)
+		}
 		log.Infof("GracefulMasterTakeover: designated master instructed to be %+v", designatedInstance.Key)
 	}
 

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1683,9 +1683,6 @@ func GracefulMasterTakeover(clusterName string, designatedKey *inst.InstanceKey)
 		if designatedInstance == nil {
 			return nil, nil, fmt.Errorf("GracefulMasterTakeover: indicated designated instance %+v must be directly replicating from the master %+v", *designatedKey, clusterMaster.Key)
 		}
-		if inst.IsBannedFromBeingCandidateReplica(designatedInstance) {
-			return nil, nil, fmt.Errorf("GracefulMasterTakeover: indicated designated instance %+v cannot be promoted due to promotion rule or it is explicitly ignored in PromotionIgnoreHostnameFilters configuration", *designatedKey)
-		}
 		log.Infof("GracefulMasterTakeover: designated master instructed to be %+v", designatedInstance.Key)
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/github/orchestrator/issues/569

### Description

During a graceful master takeover, this simply checks the `IsBannedFromBeingCandidateReplica` function for the newly designated master before doing anything else. By checking this early and failing early, we avoid making any changes to the topology for a promotion we know will fail at the outset. 

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`



(Thanks @zmoazeni for the idea!)