### PR TITLE
Analysis and action for UnreachableMasterWithLaggingReplicas

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -230,7 +230,6 @@ type Configuration struct {
 	PostMasterFailoverProcesses                []string          // Processes to execute after doing a master failover (order of execution undefined). Uses same placeholders as PostFailoverProcesses
 	PostIntermediateMasterFailoverProcesses    []string          // Processes to execute after doing a master failover (order of execution undefined). Uses same placeholders as PostFailoverProcesses
 	PostGracefulTakeoverProcesses              []string          // Processes to execute after runnign a graceful master takeover. Uses same placeholders as PostFailoverProcesses
-	UnreachableMasterWithStaleSlavesProcesses  []string          // Processes to execute when detecting an UnreachableMasterWithStaleSlaves scenario.
 	CoMasterRecoveryMustPromoteOtherCoMaster   bool              // When 'false', anything can get promoted (and candidates are prefered over others). When 'true', orchestrator will promote the other co-master or else fail
 	DetachLostSlavesAfterMasterFailover        bool              // synonym to DetachLostReplicasAfterMasterFailover
 	DetachLostReplicasAfterMasterFailover      bool              // Should replicas that are not to be lost in master recovery (i.e. were more up-to-date than promoted replica) be forcibly detached
@@ -391,7 +390,6 @@ func newConfiguration() *Configuration {
 		PostFailoverProcesses:                      []string{},
 		PostUnsuccessfulFailoverProcesses:          []string{},
 		PostGracefulTakeoverProcesses:              []string{},
-		UnreachableMasterWithStaleSlavesProcesses:  []string{},
 		CoMasterRecoveryMustPromoteOtherCoMaster:   true,
 		DetachLostSlavesAfterMasterFailover:        true,
 		ApplyMySQLPromotionAfterMasterFailover:     true,

--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -32,14 +32,12 @@ const (
 	DeadMaster                                                         = "DeadMaster"
 	DeadMasterAndSlaves                                                = "DeadMasterAndSlaves"
 	DeadMasterAndSomeSlaves                                            = "DeadMasterAndSomeSlaves"
-	UnreachableMasterWithStaleSlaves                                   = "UnreachableMasterWithStaleSlaves"
 	UnreachableMasterWithLaggingReplicas                               = "UnreachableMasterWithLaggingReplicas"
 	UnreachableMaster                                                  = "UnreachableMaster"
 	MasterSingleSlaveNotReplicating                                    = "MasterSingleSlaveNotReplicating"
 	MasterSingleSlaveDead                                              = "MasterSingleSlaveDead"
 	AllMasterSlavesNotReplicating                                      = "AllMasterSlavesNotReplicating"
 	AllMasterSlavesNotReplicatingOrDead                                = "AllMasterSlavesNotReplicatingOrDead"
-	AllMasterSlavesStale                                               = "AllMasterSlavesStale"
 	MasterWithoutSlaves                                                = "MasterWithoutSlaves"
 	DeadCoMaster                                                       = "DeadCoMaster"
 	DeadCoMasterAndSomeSlaves                                          = "DeadCoMasterAndSomeSlaves"
@@ -112,7 +110,6 @@ type ReplicationAnalysis struct {
 	CountValidReplicas                        uint
 	CountValidReplicatingReplicas             uint
 	CountReplicasFailingToConnectToMaster     uint
-	CountStaleReplicas                        uint
 	CountDowntimedReplicas                    uint
 	ReplicationDepth                          uint
 	SlaveHosts                                InstanceKeyMap

--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -33,6 +33,7 @@ const (
 	DeadMasterAndSlaves                                                = "DeadMasterAndSlaves"
 	DeadMasterAndSomeSlaves                                            = "DeadMasterAndSomeSlaves"
 	UnreachableMasterWithStaleSlaves                                   = "UnreachableMasterWithStaleSlaves"
+	UnreachableMasterWithLaggingReplicas                               = "UnreachableMasterWithLaggingReplicas"
 	UnreachableMaster                                                  = "UnreachableMaster"
 	MasterSingleSlaveNotReplicating                                    = "MasterSingleSlaveNotReplicating"
 	MasterSingleSlaveDead                                              = "MasterSingleSlaveDead"

--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -132,6 +132,7 @@ type ReplicationAnalysis struct {
 	CountMixedBasedLoggingReplicas            uint
 	CountRowBasedLoggingReplicas              uint
 	CountDistinctMajorVersionsLoggingReplicas uint
+	CountDelayedReplicas                      uint
 	IsActionableRecovery                      bool
 	ProcessingNodeHostname                    string
 	ProcessingNodeToken                       string

--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -133,6 +133,7 @@ type ReplicationAnalysis struct {
 	CountRowBasedLoggingReplicas              uint
 	CountDistinctMajorVersionsLoggingReplicas uint
 	CountDelayedReplicas                      uint
+	CountLaggingReplicas                      uint
 	IsActionableRecovery                      bool
 	ProcessingNodeHostname                    string
 	ProcessingNodeToken                       string

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -55,7 +55,7 @@ func initializeAnalysisDaoPostConfiguration() {
 func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints) ([]ReplicationAnalysis, error) {
 	result := []ReplicationAnalysis{}
 
-	args := sqlutils.Args(ValidSecondsFromSeenToLastAttemptedCheck(), config.Config.ReasonableMaintenanceReplicationLagSeconds, clusterName)
+	args := sqlutils.Args(ValidSecondsFromSeenToLastAttemptedCheck(), config.Config.ReasonableReplicationLagSeconds, clusterName)
 	analysisQueryReductionClause := ``
 	if config.Config.ReduceReplicationAnalysisCount {
 		analysisQueryReductionClause = `

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -180,6 +180,8 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 								AND replica_instance.log_slave_updates
 								AND replica_instance.binlog_format = 'ROW'),
               0) AS count_row_based_loggin_slaves,
+						IFNULL(SUM(replica_instance.sql_delay > 0),
+              0) AS count_delayed_replicas,
 						IFNULL(MIN(replica_instance.gtid_mode), '')
               AS min_replica_gtid_mode,
 						IFNULL(MAX(replica_instance.gtid_mode), '')
@@ -282,6 +284,8 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		a.CountMixedBasedLoggingReplicas = m.GetUint("count_mixed_based_loggin_slaves")
 		a.CountRowBasedLoggingReplicas = m.GetUint("count_row_based_loggin_slaves")
 		a.CountDistinctMajorVersionsLoggingReplicas = m.GetUint("count_distinct_logging_major_versions")
+
+		a.CountDelayedReplicas = m.GetUint("count_delayed_replicas")
 
 		if a.IsMaster && !a.LastCheckValid && a.CountReplicas == 0 {
 			a.Analysis = DeadMasterWithoutSlaves

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -259,7 +259,6 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		a.CountValidReplicatingReplicas = m.GetUint("count_valid_replicating_slaves")
 		a.CountReplicasFailingToConnectToMaster = m.GetUint("count_slaves_failing_to_connect_to_master")
 		a.CountDowntimedReplicas = m.GetUint("count_downtimed_replicas")
-		a.CountStaleReplicas = 0
 		a.ReplicationDepth = m.GetUint("replication_depth")
 		a.IsFailingToConnectToMaster = m.GetBool("is_failing_to_connect_to_master")
 		a.IsDowntimed = m.GetBool("is_downtimed")
@@ -311,10 +310,6 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			a.Analysis = DeadMasterAndSomeSlaves
 			a.Description = "Master cannot be reached by orchestrator; some of its replicas are unreachable and none of its reachable replicas is replicating"
 			//
-		} else if a.IsMaster && !a.LastCheckValid && a.CountStaleReplicas == a.CountReplicas && a.CountValidReplicatingReplicas > 0 {
-			a.Analysis = UnreachableMasterWithStaleSlaves
-			a.Description = "Master cannot be reached by orchestrator and has running yet stale replicas"
-			//
 		} else if a.IsMaster && !a.LastCheckValid && a.CountLaggingReplicas == a.CountReplicas && a.CountDelayedReplicas < a.CountReplicas && a.CountValidReplicatingReplicas > 0 {
 			a.Analysis = UnreachableMasterWithLaggingReplicas
 			a.Description = "Master cannot be reached by orchestrator and all of its replicas are lagging"
@@ -338,10 +333,6 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		} else if a.IsMaster && a.LastCheckValid && a.CountReplicas > 1 && a.CountValidReplicas < a.CountReplicas && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
 			a.Analysis = AllMasterSlavesNotReplicatingOrDead
 			a.Description = "Master is reachable but none of its replicas is replicating"
-			//
-		} else if a.IsMaster && a.LastCheckValid && a.CountReplicas > 1 && a.CountStaleReplicas == a.CountReplicas && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
-			a.Analysis = AllMasterSlavesStale
-			a.Description = "Master is reachable but all of its replicas are stale, although attempting to replicate"
 			//
 		} else /* co-master */ if a.IsCoMaster && !a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
 			a.Analysis = DeadCoMaster

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -286,9 +286,12 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		a.CountLaggingReplicas = m.GetUint("count_lagging_replicas")
 
 		if !a.LastCheckValid {
-			log.Debugf("analysis: IsMaster: %+v, LastCheckValid: %+v, LastCheckPartialSuccess: %+v, CountReplicas: %+v, CountValidReplicatingReplicas: %+v, CountLaggingReplicas: %+v, CountDelayedReplicas: %+v, ",
+			analysisMessage := fmt.Sprintf("analysis: IsMaster: %+v, LastCheckValid: %+v, LastCheckPartialSuccess: %+v, CountReplicas: %+v, CountValidReplicatingReplicas: %+v, CountLaggingReplicas: %+v, CountDelayedReplicas: %+v, ",
 				a.IsMaster, a.LastCheckValid, a.LastCheckPartialSuccess, a.CountReplicas, a.CountValidReplicatingReplicas, a.CountLaggingReplicas, a.CountDelayedReplicas,
 			)
+			if util.ClearToLog("analysis_dao", analysisMessage) {
+				log.Debugf(analysisMessage)
+			}
 		}
 		if a.IsMaster && !a.LastCheckValid && a.CountReplicas == 0 {
 			a.Analysis = DeadMasterWithoutSlaves

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -290,6 +290,11 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		a.CountDelayedReplicas = m.GetUint("count_delayed_replicas")
 		a.CountLaggingReplicas = m.GetUint("count_lagging_replicas")
 
+		if !a.LastCheckValid {
+			log.Debugf("analysis: IsMaster: %+v, LastCheckValid: %+v, LastCheckPartialSuccess: %+v, CountReplicas: %+v, CountValidReplicatingReplicas: %+v, CountLaggingReplicas: %+v, CountDelayedReplicas: %+v, ",
+				a.IsMaster, a.LastCheckValid, a.LastCheckPartialSuccess, a.CountReplicas, a.CountValidReplicatingReplicas, a.CountLaggingReplicas, a.CountDelayedReplicas,
+			)
+		}
 		if a.IsMaster && !a.LastCheckValid && a.CountReplicas == 0 {
 			a.Analysis = DeadMasterWithoutSlaves
 			a.Description = "Master cannot be reached by orchestrator and has no slave"

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -220,10 +220,6 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		        		AND replica_downtime.downtime_active = 1)
         	LEFT JOIN
 		        cluster_alias ON (cluster_alias.cluster_name = master_instance.cluster_name)
-				  LEFT JOIN
-						database_instance_recent_relaylog_history ON (
-								replica_instance.hostname = database_instance_recent_relaylog_history.hostname
-		        		AND replica_instance.port = database_instance_recent_relaylog_history.port)
 		    WHERE
 		    	database_instance_maintenance.database_instance_maintenance_id IS NULL
 		    	AND ? IN ('', master_instance.cluster_name)

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -310,6 +310,10 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			a.Analysis = UnreachableMasterWithStaleSlaves
 			a.Description = "Master cannot be reached by orchestrator and has running yet stale replicas"
 			//
+		} else if a.IsMaster && !a.LastCheckValid && a.CountLaggingReplicas == a.CountReplicas && a.CountDelayedReplicas < a.CountReplicas && a.CountValidReplicatingReplicas > 0 {
+			a.Analysis = UnreachableMasterWithLaggingReplicas
+			a.Description = "Master cannot be reached by orchestrator and all of its replicas are lagging"
+			//
 		} else if a.IsMaster && !a.LastCheckValid && !a.LastCheckPartialSuccess && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
 			a.Analysis = UnreachableMaster
 			a.Description = "Master cannot be reached by orchestrator but it has replicating replicas; possibly a network/host issue"

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -2693,10 +2693,6 @@ func ResetInstanceRelaylogCoordinatesHistory(instanceKey *InstanceKey) error {
 	return ExecDBWriteFunc(writeFunc)
 }
 
-func ExpireInstanceBinlogFileHistory() error {
-	return ExpireTableData("database_instance_binlog_files_history", "last_seen")
-}
-
 // FigureClusterName will make a best effort to deduce a cluster name using either a given alias
 // or an instanceKey. First attempt is at alias, and if that doesn't work, we try instanceKey.
 func FigureClusterName(clusterHint string, instanceKey *InstanceKey, thisInstanceKey *InstanceKey) (clusterName string, err error) {

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -612,7 +612,7 @@ func moveReplicasViaGTID(replicas [](*Instance), other *Instance) (movedReplicas
 		return movedReplicas, unmovedReplicas, nil, errs
 	}
 
-	log.Infof("Will move %+v replicas below %+v via GTID", len(replicas), other.Key)
+	log.Infof("moveReplicasViaGTID: Will move %+v replicas below %+v via GTID", len(replicas), other.Key)
 
 	barrier := make(chan *InstanceKey)
 	replicaMutex := make(chan bool, 1)
@@ -627,7 +627,7 @@ func moveReplicasViaGTID(replicas [](*Instance), other *Instance) (movedReplicas
 				if _, _, canMove := canMoveViaGTID(replica, other); canMove {
 					replica, replicaErr = moveInstanceBelowViaGTID(replica, other)
 				} else {
-					replicaErr = fmt.Errorf("%+v cannot move below %+v via GTID", replica.Key, other.Key)
+					replicaErr = fmt.Errorf("moveReplicasViaGTID: %+v cannot move below %+v via GTID", replica.Key, other.Key)
 				}
 				func() {
 					// Instantaneous mutex.

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -284,7 +284,7 @@ func StopSlaveNicely(instanceKey *InstanceKey, timeout time.Duration) (*Instance
 	// stop io_thread, start sql_thread but catch any errors
 	for _, cmd := range []string{`stop slave io_thread`, `start slave sql_thread`} {
 		if _, err := ExecInstance(instanceKey, cmd); err != nil {
-			return instance, log.Errorf("%+v: RestartIOThread: '%q' failed: %+v", *instanceKey, cmd, err)
+			return nil, log.Errorf("%+v: StopSlaveNicely: '%q' failed: %+v", *instanceKey, cmd, err)
 		}
 	}
 

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -260,7 +260,7 @@ func SetSemiSyncReplica(instanceKey *InstanceKey, enableReplica bool) (*Instance
 }
 
 func RestartIOThread(instanceKey *InstanceKey) error {
-	for _, cmd := range []string{`stop slave io_thread`, `start slave sql_thread`} {
+	for _, cmd := range []string{`stop slave io_thread`, `start slave io_thread`} {
 		if _, err := ExecInstance(instanceKey, cmd); err != nil {
 			return log.Errorf("%+v: RestartIOThread: '%q' failed: %+v", *instanceKey, cmd, err)
 		}
@@ -282,8 +282,10 @@ func StopSlaveNicely(instanceKey *InstanceKey, timeout time.Duration) (*Instance
 	}
 
 	// stop io_thread, start sql_thread but catch any errors
-	if err := RestartIOThread(instanceKey); err != nil {
-		return instance, err
+	for _, cmd := range []string{`stop slave io_thread`, `start slave sql_thread`} {
+		if _, err := ExecInstance(instanceKey, cmd); err != nil {
+			return instance, log.Errorf("%+v: RestartIOThread: '%q' failed: %+v", *instanceKey, cmd, err)
+		}
 	}
 
 	if instance.SQLDelay == 0 {

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -488,7 +488,6 @@ func ContinuousDiscovery() {
 					go inst.ExpireMasterPositionEquivalence()
 					go inst.ExpirePoolInstances()
 					go inst.FlushNontrivialResolveCacheToDatabase()
-					go inst.ExpireInstanceBinlogFileHistory()
 					go inst.ExpireInjectedPseudoGTID()
 					go process.ExpireNodesHistory()
 					go process.ExpireAccessTokens()

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1323,7 +1323,7 @@ func emergentlyRestartReplicationOnTopologyInstance(instanceKey *inst.InstanceKe
 		return
 	}
 	go inst.ExecuteOnTopology(func() {
-		inst.RestartSlave(instanceKey)
+		inst.RestartIOThread(instanceKey)
 		inst.AuditOperation("emergently-restart-replication-topology-instance", instanceKey, string(analysisCode))
 	})
 }

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -186,7 +186,7 @@ function api() {
   set -o pipefail
 
   api_call_result=0
-  for sleep_time in 0.1 0.2 0.5 1 2 5 10 0 ; do
+  for sleep_time in 0.1 0.2 0.5 1 2 2.5 5 0 ; do
     api_response=$(curl -b "${basic_auth}" -s "$uri" | jq '.')
     api_call_result=$?
     [ $api_call_result -eq 0 ] && break

--- a/resources/public/js/cluster-analysis-shared.js
+++ b/resources/public/js/cluster-analysis-shared.js
@@ -4,6 +4,7 @@ var interestingAnalysis = {
 	"DeadMasterAndSomeSlaves" : true,
 	"DeadMasterWithoutSlaves" : true,
 	"UnreachableMasterWithStaleSlaves": true,
+	"UnreachableMasterWithLaggingReplicas": true,
 	"UnreachableMaster" : true,
 	"AllMasterSlavesNotReplicating" : true,
 	"AllMasterSlavesNotReplicatingOrDead" : true,

--- a/tests/integration/analysis-unreachable-master-not-lagging-replicas/create.sql
+++ b/tests/integration/analysis-unreachable-master-not-lagging-replicas/create.sql
@@ -1,0 +1,2 @@
+UPDATE database_instance SET last_seen=last_checked - interval 1 minute where port=22293;
+UPDATE database_instance SET slave_lag_seconds=60 where port in (22295, 22296, 22297);

--- a/tests/integration/analysis-unreachable-master-not-lagging-replicas/expect_output
+++ b/tests/integration/analysis-unreachable-master-not-lagging-replicas/expect_output
@@ -1,0 +1,1 @@
+testhost:22293 (cluster testhost:22293): UnreachableMaster

--- a/tests/integration/analysis-unreachable-master-not-lagging-replicas/extra_args
+++ b/tests/integration/analysis-unreachable-master-not-lagging-replicas/extra_args
@@ -1,0 +1,1 @@
+-c replication-analysis

--- a/tests/integration/analysis-unreachable-master-with-delayed-replicas/create.sql
+++ b/tests/integration/analysis-unreachable-master-with-delayed-replicas/create.sql
@@ -1,0 +1,2 @@
+UPDATE database_instance SET last_seen=last_checked - interval 1 minute where port=22293;
+UPDATE database_instance SET slave_lag_seconds=600, sql_delay=600 where port in (22294, 22296, 22297);

--- a/tests/integration/analysis-unreachable-master-with-delayed-replicas/expect_output
+++ b/tests/integration/analysis-unreachable-master-with-delayed-replicas/expect_output
@@ -1,0 +1,1 @@
+testhost:22293 (cluster testhost:22293): UnreachableMaster

--- a/tests/integration/analysis-unreachable-master-with-delayed-replicas/extra_args
+++ b/tests/integration/analysis-unreachable-master-with-delayed-replicas/extra_args
@@ -1,0 +1,1 @@
+-c replication-analysis

--- a/tests/integration/analysis-unreachable-master-with-lagging-replicas-and-delayed-replicas/create.sql
+++ b/tests/integration/analysis-unreachable-master-with-lagging-replicas-and-delayed-replicas/create.sql
@@ -1,0 +1,3 @@
+UPDATE database_instance SET last_seen=last_checked - interval 1 minute where port=22293;
+UPDATE database_instance SET slave_lag_seconds=600 where port in (22294, 22296, 22297);
+UPDATE database_instance SET sql_delay=600 where port in (22297);

--- a/tests/integration/analysis-unreachable-master-with-lagging-replicas-and-delayed-replicas/expect_output
+++ b/tests/integration/analysis-unreachable-master-with-lagging-replicas-and-delayed-replicas/expect_output
@@ -1,0 +1,1 @@
+testhost:22293 (cluster testhost:22293): UnreachableMasterWithLaggingReplicas

--- a/tests/integration/analysis-unreachable-master-with-lagging-replicas-and-delayed-replicas/extra_args
+++ b/tests/integration/analysis-unreachable-master-with-lagging-replicas-and-delayed-replicas/extra_args
@@ -1,0 +1,1 @@
+-c replication-analysis

--- a/tests/integration/analysis-unreachable-master-with-lagging-replicas/create.sql
+++ b/tests/integration/analysis-unreachable-master-with-lagging-replicas/create.sql
@@ -1,0 +1,2 @@
+UPDATE database_instance SET last_seen=last_checked - interval 1 minute where port=22293;
+UPDATE database_instance SET slave_lag_seconds=60 where port in (22294, 22296, 22297);

--- a/tests/integration/analysis-unreachable-master-with-lagging-replicas/expect_output
+++ b/tests/integration/analysis-unreachable-master-with-lagging-replicas/expect_output
@@ -1,0 +1,1 @@
+testhost:22293 (cluster testhost:22293): UnreachableMasterWithLaggingReplicas

--- a/tests/integration/analysis-unreachable-master-with-lagging-replicas/extra_args
+++ b/tests/integration/analysis-unreachable-master-with-lagging-replicas/extra_args
@@ -1,0 +1,1 @@
+-c replication-analysis


### PR DESCRIPTION
A new failure analysis: `UnreachableMasterWithLaggingReplicas` identifies the case of a master unreachable to `orchestrator`, where all of its replicas are _seemingly_ OK, but all lagging.

### Failure scenario

This is a known scenario in production. A well-known particular cause for this is the problem of `Too Many Connections` on a master. Say the master is overloaded, connections coming in, finally the master refuses to accept new connections.

`orchestrator` would suddenly be unable to reach the master. But long-time running replicas may enjoy the fact they're using good-old connections. They may actually still be able to replicate.
The master may eventually refuse any/all writes. The replicas would still think everything's fine but they're not getting anything through replication stream.

If using a `pt-heartbeat` or similar, replication lag will be seen to increase even as `Seconds_behind_master` may still indicate `0`.

Some notes:

- We've seen this scenario to happen even if `slave_net_timeout` is configured and replicas are using heartbeats.
- We've seen this scenario in the past while we were still running trigger-based `pt-online-schema-change` (before moving to triggerless `gh-ost`).
- And we've seen a similar scenario for other reasons.

### Analysis

To avoid false positives, the analysis checks:

- The master is unreachable to `orchestrator`
- At least one replica thinks the master is reachable
- All replicas show lag. You should be using `ReplicationLagQuery` configuration, i.e. utilize a heartbeat mechanism such as `pt-heartbeat`, and not trust `Seconds_Behind_Master` to do the right thing (it doesn't).
- Not all replicas are delayed (if all replicas have `SQL_Delay` then they are in fact expected to lag).

### Action

There are two potential courses of action and we picked one over the other. One course of action would be to immediately initiate a failover. However, we chose another course of action. The reason is that this analysis is a bit on the gray zone. There could be a failure of `pt-heartbeat` on the master together with a very brief network isolation of the master from `orchestrator`. It's slim, but because this type of analysis is new, we choose to tread carefully and avoid false positive failovers.

We choose a different action: Issue a `STOP SLAVE; START SLAVE` on all master's direct replicas, credit @tomkrouper.

This would kick the connections on replicas and hopefully the re-authentication and re-connection process would make the replica realize the master is broken, same as `orchestrator` had, or any app connection had.

That would shortly lead to all replicas being broken, which would lead to a `DeadMaster` analysis, and a failover action.

Noteworthy that this analysis is re-generated every second or so, and that the action taken (restart replication on replicas) is not affected by `RecoveryPeriodBlockSeconds`. There is an internal throttling mechanism to avoid flooding the replicas with `stop slave; start slave` operation.

cc @github/database-infrastructure 