### PR TITLE
Added missing API support to DetachReplicaMasterHost()

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -67,6 +67,7 @@ var apiSynonyms = map[string]string{
 	"regroup-slaves-pgtid":       "regroup-replicas-pgtid",
 	"detach-slave":               "detach-replica",
 	"reattach-slave":             "reattach-replica",
+	"detach-slave-master-host":   "detach-replica-master-host",
 	"reattach-slave-master-host": "reattach-replica-master-host",
 	"cluster-osc-slaves":         "cluster-osc-replicas",
 	"start-slave":                "start-replica",
@@ -628,7 +629,29 @@ func (this *HttpAPI) ReattachReplica(params martini.Params, r render.Render, req
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Replica reattached: %+v", instance.Key), Details: instance})
 }
 
-// ReattachReplicaMasterHost reverts a achReplicaMasterHost command
+// DetachReplicaMasterHost detaches a replica from its master by setting an invalid
+// (yet revertible) host name
+func (this *HttpAPI) DetachReplicaMasterHost(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+	if !isAuthorizedForAction(req, user) {
+		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
+		return
+	}
+	instanceKey, err := this.getInstanceKey(params["host"], params["port"])
+
+	if err != nil {
+		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
+	instance, err := inst.DetachReplicaMasterHost(&instanceKey)
+	if err != nil {
+		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
+
+	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Replica detached: %+v", instance.Key), Details: instance})
+}
+
+// ReattachReplicaMasterHost reverts a detachReplicaMasterHost command
 // by resoting the original master hostname in CHANGE MASTER TO
 func (this *HttpAPI) ReattachReplicaMasterHost(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
@@ -3280,6 +3303,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequest(m, "reset-slave/:host/:port", this.ResetSlave)
 	this.registerAPIRequest(m, "detach-slave/:host/:port", this.DetachReplica)
 	this.registerAPIRequest(m, "reattach-slave/:host/:port", this.ReattachReplica)
+	this.registerAPIRequest(m, "detach-slave-master-host/:host/:port", this.DetachReplicaMasterHost)
 	this.registerAPIRequest(m, "reattach-slave-master-host/:host/:port", this.ReattachReplicaMasterHost)
 	this.registerAPIRequest(m, "flush-binary-logs/:host/:port", this.FlushBinaryLogs)
 	this.registerAPIRequest(m, "restart-slave-statements/:host/:port", this.RestartSlaveStatements)


### PR DESCRIPTION
Closes #571 
Adds missing support for `/api/detach-replica-master-host`. Already supported by `orchestrator-client`.

cc @y-trudeau