### PR TITLE
take-master operation rejected when target is co-master

### DIFF
--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1587,6 +1587,9 @@ func TakeMaster(instanceKey *InstanceKey) (*Instance, error) {
 	if err != nil || !found {
 		return instance, err
 	}
+	if masterInstance.IsCoMaster {
+		return instance, fmt.Errorf("%+v is co-master. Cannot take it.", masterInstance.Key)
+	}
 	log.Debugf("TakeMaster: will attempt making %+v take its master %+v, now resolved as %+v", *instanceKey, instance.MasterKey, masterInstance.Key)
 
 	if canReplicate, err := masterInstance.CanReplicateFrom(instance); canReplicate == false {

--- a/resources/public/js/cluster.js
+++ b/resources/public/js/cluster.js
@@ -728,7 +728,7 @@ function Cluster() {
       // Obviously can't handle.
       return unaccepted;
     }
-    if (instanceIsChild(node, droppableNode) && !droppableNode.isMaster) {
+    if (instanceIsChild(node, droppableNode) && !droppableNode.isMaster && !droppableNode.isCoMaster) {
       if (node.hasProblem) {
         // Typically, when a node has a problem we do not allow moving it up.
         // But there's a special situation when allowing is desired: when


### PR DESCRIPTION
Closes https://github.com/github/orchestrator/issues/573

`take-master` operation not allowed when target is a co-master. If one wants to shuffle the topology where co-masters are involved, one should first deconstruct the master-master.

The fix is reflected both in the underlying logic as well as in the web interface.