### PR TITLE
Reproduce promotion rule premature deletion due to system time setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,5 @@ COPY --from=0 /etc/orchestrator.conf.json /etc/orchestrator.conf.json
 
 WORKDIR /usr/local/orchestrator
 ADD docker/entrypoint.sh /entrypoint.sh
+ADD reproduce_promotion_rule_deletion.sh /reproduce_promotion_rule_deletion.sh
 CMD /entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,13 +4,10 @@ cat <<EOF > /etc/orchestrator.conf.json
 {
   "Debug": true,
   "ListenAddress": ":3000",
+  "BackendDB": "sqlite3",
+  "SQLite3DataFile": "/usr/local/orchestrator/orchestrator.db",
   "MySQLTopologyUser": "${ORC_TOPOLOGY_USER:-orchestrator}",
   "MySQLTopologyPassword": "${ORC_TOPOLOGY_PASSWORD:-orchestrator}",
-  "MySQLOrchestratorHost": "${ORC_DB_HOST:-db}",
-  "MySQLOrchestratorPort": ${ORC_DB_PORT:-3306},
-  "MySQLOrchestratorDatabase": "${ORC_DB_NAME:-orchestrator}",
-  "MySQLOrchestratorUser": "${ORC_USER:-orc_server_user}",
-  "MySQLOrchestratorPassword": "${ORC_PASSWORD:-orc_server_password}"
 }
 EOF
 fi

--- a/reproduce_promotion_rule_deletion.sh
+++ b/reproduce_promotion_rule_deletion.sh
@@ -1,0 +1,25 @@
+apk add -U sqlite
+apk add -U tzdata
+
+cp /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+
+time_start=$(date)
+
+rules_at_start=$(sqlite3 orchestrator.sqlite3 "SELECT hostname, port, promotion_rule, last_suggested FROM candidate_database_instance")
+echo 'Rules at start:'
+echo $rules_at_start
+
+echo 'Tag host'
+promotion_rule='prefer'
+./orchestrator -c register-candidate --promotion-rule $promotion_rule
+
+prom_rules=$(sqlite3 orchestrator.sqlite3 "SELECT hostname, port, promotion_rule, last_suggested FROM candidate_database_instance" | wc -l)
+while [ $prom_rules -ne 0 ]; do
+  prom_rules=$(sqlite3 orchestrator.sqlite3 "SELECT hostname, port, promotion_rule, last_suggested FROM candidate_database_instance" | wc -l)
+  sleep 1
+done
+
+echo 'Started at:'
+echo $time_start
+echo 'Exiting at:'
+date


### PR DESCRIPTION
Recreating issue described in #585.
```
➜  orchestrator git:(master) ✗ docker exec -it 8fa4a00f0156 /bin/sh
/usr/local/orchestrator # sh /reproduce_promotion_rule_deletion.sh
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
(1/5) Installing ncurses-terminfo-base (6.0_p20171125-r0)
(2/5) Installing ncurses-terminfo (6.0_p20171125-r0)
(3/5) Installing ncurses-libs (6.0_p20171125-r0)
(4/5) Installing readline (6.3.008-r5)
(5/5) Installing sqlite (3.20.1-r2)
Executing busybox-1.26.2-r11.trigger
OK: 13 MiB in 18 packages
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
(1/1) Installing tzdata (2017a-r0)
Executing busybox-1.26.2-r11.trigger
OK: 16 MiB in 19 packages
Rules at start:

Tag host
2018-08-20 19:45:36 DEBUG Connected to orchestrator backend: sqlite on /usr/local/orchestrator/orchestrator.sqlite3
2018-08-20 19:45:36 DEBUG Initializing orchestrator
2018-08-20 19:45:36 INFO Connecting to backend :3306: maxConnections: 128, maxIdleConns: 32
2018-08-20 19:45:36 INFO auditType:register-candidate instance:8fa4a00f0156:3306 cluster: message:prefer
8fa4a00f0156:3306
Started at:
Mon Aug 20 19:45:36 PDT 2018
Exiting at:
Mon Aug 20 19:46:02 PDT 2018
/usr/local/orchestrator #
```