### PR TITLE
Initialize CandidateDatabaseInstance LastUpdated field to UTC time

### DIFF
--- a/docs/configuration-recovery.md
+++ b/docs/configuration-recovery.md
@@ -86,7 +86,7 @@ A naive implementation might look like:
 
 #### Hooks arguments and environment
 
-`orchestrator` provides all hooks with failure/recovery related information, such as the identity of the failed instance, identity of promoted instance, affecetd replicas, type of failure, name of cluster, etc.
+`orchestrator` provides all hooks with failure/recovery related information, such as the identity of the failed instance, identity of promoted instance, affected replicas, type of failure, name of cluster, etc.
 
 This information is passed independently in two ways, and you may choose to use one or both:
 
@@ -107,6 +107,7 @@ This information is passed independently in two ways, and you may choose to use 
 - `ORC_IS_SUCCESSFUL`
 - `ORC_LOST_REPLICAS`
 - `ORC_REPLICA_HOSTS`
+- `ORC_COMMAND` (`"force-master-failover"`, `"force-master-takeover"`, `"graceful-master-takeover"` if applicable)
 
 And, in the event a recovery was successful:
 
@@ -131,6 +132,7 @@ And, in the event a recovery was successful:
 - `{lostReplicas}` aka `{lostSlaves}`
 - `{replicaHosts}` aka `{slaveHosts}`
 - `{isSuccessful}`
+- `{command}` (`"force-master-failover"`, `"force-master-takeover"`, `"graceful-master-takeover"` if applicable)
 
 And, in the event a recovery was successful:
 

--- a/docs/configuration-recovery.md
+++ b/docs/configuration-recovery.md
@@ -86,7 +86,7 @@ A naive implementation might look like:
 
 #### Hooks arguments and environment
 
-`orchestrator` provides all hooks with failure/recovery related information, such as the identity of the failed instance, identity of promoted instance, affected replicas, type of failure, name of cluster, etc.
+`orchestrator` provides all hooks with failure/recovery related information, such as the identity of the failed instance, identity of promoted instance, affecetd replicas, type of failure, name of cluster, etc.
 
 This information is passed independently in two ways, and you may choose to use one or both:
 
@@ -107,7 +107,6 @@ This information is passed independently in two ways, and you may choose to use 
 - `ORC_IS_SUCCESSFUL`
 - `ORC_LOST_REPLICAS`
 - `ORC_REPLICA_HOSTS`
-- `ORC_COMMAND` (`"force-master-failover"`, `"force-master-takeover"`, `"graceful-master-takeover"` if applicable)
 
 And, in the event a recovery was successful:
 
@@ -132,7 +131,6 @@ And, in the event a recovery was successful:
 - `{lostReplicas}` aka `{lostSlaves}`
 - `{replicaHosts}` aka `{slaveHosts}`
 - `{isSuccessful}`
-- `{command}` (`"force-master-failover"`, `"force-master-takeover"`, `"graceful-master-takeover"` if applicable)
 
 And, in the event a recovery was successful:
 

--- a/go/inst/candidate_database_instance.go
+++ b/go/inst/candidate_database_instance.go
@@ -34,7 +34,7 @@ func NewCandidateDatabaseInstance(instanceKey *InstanceKey, promotionRule Candid
 		Hostname:      instanceKey.Hostname,
 		Port:          instanceKey.Port,
 		PromotionRule: promotionRule,
-		LastSuggested: time.Now(),
+		LastSuggested: time.Now().UTC(),
 	}
 }
 

--- a/tests/integration/register-candidate-database-instance/extra_args
+++ b/tests/integration/register-candidate-database-instance/extra_args
@@ -1,0 +1,1 @@
+-c register-candidate -i testhost:22293 --promotion-rule prefer

--- a/tests/integration/register-candidate-database-instance/setup.sh
+++ b/tests/integration/register-candidate-database-instance/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Set a timezone that is >= 1 hour behind UTC
+sudo timedatectl set-timezone America/Los_Angeles

--- a/tests/integration/register-candidate-database-instance/tear_down.sh
+++ b/tests/integration/register-candidate-database-instance/tear_down.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Reset timezone
+sudo timedatectl set-timezone UTC

--- a/tests/integration/register-candidate-database-instance/verify.sh
+++ b/tests/integration/register-candidate-database-instance/verify.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+num_results=$(sqlite3 /tmp/orchestrator.db "SELECT hostname, port, promotion_rule, last_suggested FROM candidate_database_instance where last_suggested > datetime('now', ('-60 MINUTE'))" | wc -l)
+if [ $num_results -ne 1 ] ; then
+    echo "ERROR did not find 1 row in candidate_database_instance, found $num_results"
+    return 1
+fi

--- a/tests/integration/test.sh
+++ b/tests/integration/test.sh
@@ -70,6 +70,10 @@ test_single() {
   if [ -f $tests_path/$test_name/extra_args ] ; then
     extra_args=$(cat $tests_path/$test_name/extra_args)
   fi
+
+  if [ -f $tests_path/$test_name/setup.sh ] ; then
+    . $tests_path/$test_name/setup.sh
+  fi
   #
   cmd="$orchestrator_binary \
     --config=${test_config_file}
@@ -124,6 +128,20 @@ test_single() {
       echo "---"
       return 1
     fi
+  fi
+
+  if [ -f $tests_path/$test_name/verify.sh ] ; then
+    . $tests_path/$test_name/verify.sh
+    verify_result=$?
+    if [ $verify_result -ne 0 ] ; then
+      echo
+      echo "ERROR $test_name verify failure."
+      return 1
+    fi
+  fi
+
+  if [ -f $tests_path/$test_name/tear_down.sh ] ; then
+    . $tests_path/$test_name/tear_down.sh
   fi
 
   # all is well


### PR DESCRIPTION
Related issue: https://github.com/github/orchestrator/issues/585

### Description

Initializes CandidateDatabaseInstance LastUpdated field to time.Now().UTC() instead of time.Now(). 

time.Now() outputs the system time with an offset relative to UTC -- on a system set in PDT, sample output is `2018-08-20 20:09:12.395052589-07:00`. SQLite only reads timestamps in the format YYYY-MM-DD HH:MM:SS.SSS", and therefore comparisons against this field are incorrect, namely when determining whether a promotion rule is up for expiration. 

The SQLite datetime('now') function is used for generating a value to compare against the last_updated column of the candidate_database_instance table, and this function implicitly uses UTC. I propose initializing the CandidateDatabaseInstance LastUpdated field to time.Now().UTC() in order for the comparison in the [ExpireCandidateInstances](https://github.com/github/orchestrator/blob/master/go/inst/instance_dao.go#L2572) function to be consistent despite the system time setting.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`
