### PR TITLE
start-replica: returning error if replication not started after some time

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -239,8 +239,8 @@ func (instance *Instance) checkMaxScale(db *sql.DB, latency *stopwatch.NamedStop
 	return isMaxScale, resolvedHostname, err
 }
 
-// AreReplicationThreadsRunning checks if both IO and SQL threads are running
-func AreReplicationThreadsRunning(instanceKey *InstanceKey) (replicationThreadsRunning bool, err error) {
+// areReplicationThreadsRunning checks if both IO and SQL threads are running
+func areReplicationThreadsRunning(instanceKey *InstanceKey) (replicationThreadsRunning bool, err error) {
 	db, err := db.OpenTopology(instanceKey.Hostname, instanceKey.Port)
 	if err != nil {
 		return replicationThreadsRunning, err

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -38,6 +38,8 @@ const (
 	StopReplicationNicely                       = "StopReplicationNicely"
 )
 
+var ReplicationNotRunningError = fmt.Errorf("Replication not running")
+
 var asciiFillerCharacter = " "
 var tabulatorScharacter = "|"
 


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/589

In this PR a `start slave` operation may result with an error if replica does not, in fact, end up running. E.g. if replication is broken due to some constraint or missing binary logs, `start-replica` operation will report with error.

cc @cezmunsta 