### PR TITLE
Fix to packagecloud-push: duplicate entries

### DIFF
--- a/script/packagecloud-push.rb
+++ b/script/packagecloud-push.rb
@@ -62,12 +62,6 @@ $distro_name_map = {
   "debian/10" => %w(
     debian/buster
   ),
-  "debian/11" => %w(
-    debian/bullseye
-  ),
-  "debian/12" => %w(
-    debian/bookworm
-  ),
 }
 
 # caches distro id lookups

--- a/script/packagecloud-push.rb
+++ b/script/packagecloud-push.rb
@@ -40,7 +40,6 @@ $distro_name_map = {
   ),
   "debian/8" => %w(
     debian/jessie
-    linuxmint/sarah
     linuxmint/rebecca
     linuxmint/rafaela
     linuxmint/rosa


### PR DESCRIPTION
`linuxmint/sarah` was listed twice.