### PR TITLE
Improve MySQL backend developer docs

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -71,8 +71,8 @@ No special setup is required. Make sure to configure database file path.
 Once your backend MySQL setup is complete, issue:
 
     CREATE DATABASE IF NOT EXISTS orchestrator;
-    CREATE USER 'orchestrator'@'%' IDENTIFIED BY 'orch_backend_password';
-    GRANT ALL PRIVILEGES ON `orchestrator`.* TO 'orchestrator'@'%';
+    CREATE USER 'orc_server_user'@'%' IDENTIFIED BY 'orc_server_password';
+    GRANT ALL PRIVILEGES ON `orchestrator`.* TO 'orc_server_user'@'%';
 
 `orchestrator` uses a configuration file whose search path is either `/etc/orchestrator.conf.json`,  `conf/orchestrator.conf.json` or `orchestrator.conf.json`.
 The repository includes a file called `conf/orchestrator-sample.conf.json` with some basic settings. Issue:
@@ -81,14 +81,14 @@ The repository includes a file called `conf/orchestrator-sample.conf.json` with 
 
 The `conf/orchestrator.conf.json` file is not part of the repository and there is in fact a `.gitignore` entry for this file.
 
-Edit `orchestrator.conf.json` to match the above as follows:
+Verify `orchestrator.conf.json` matches the above as follows:
 
     ...
     "MySQLOrchestratorHost": "127.0.0.1",
     "MySQLOrchestratorPort": 3306,
     "MySQLOrchestratorDatabase": "orchestrator",
-    "MySQLOrchestratorUser": "orchestrator",
-    "MySQLOrchestratorPassword": "orch_backend_password",
+    "MySQLOrchestratorUser": "orc_server_user",
+    "MySQLOrchestratorPassword": "orc_server_password",
     ...
 
 Edit the above as as fit for your MySQL backend install.

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -71,8 +71,8 @@ No special setup is required. Make sure to configure database file path.
 Once your backend MySQL setup is complete, issue:
 
     CREATE DATABASE IF NOT EXISTS orchestrator;
-    CREATE USER 'orchestrator'@'127.0.0.1' IDENTIFIED BY 'orch_backend_password';
-    GRANT ALL PRIVILEGES ON `orchestrator`.* TO 'orchestrator'@'127.0.0.1';
+    CREATE USER 'orchestrator'@'%' IDENTIFIED BY 'orch_backend_password';
+    GRANT ALL PRIVILEGES ON `orchestrator`.* TO 'orchestrator'@'%';
 
 `orchestrator` uses a configuration file whose search path is either `/etc/orchestrator.conf.json`,  `conf/orchestrator.conf.json` or `orchestrator.conf.json`.
 The repository includes a file called `conf/orchestrator-sample.conf.json` with some basic settings. Issue:


### PR DESCRIPTION
While following the instructions provided by this document, I encountered the following errors:
```
➜  orchestrator git:(master) ✗ go run go/cmd/orchestrator/main.go http
2018-08-29 13:35:07 ERROR Error 1045: Access denied for user 'orchestrator'@'172.23.0.1' (using password: YES)
2018-08-29 13:35:07 DEBUG Connected to orchestrator backend: orchestrator:?@tcp(127.0.0.1:43306)/orchestrator?timeout=1s
2018-08-29 13:35:07 DEBUG Orchestrator pool SetMaxOpenConns: 128
2018-08-29 13:35:07 DEBUG Initializing orchestrator
2018-08-29 13:35:07 DEBUG Migrating database schema
2018-08-29 13:35:07 FATAL Error 1045: Access denied for user 'orchestrator'@'172.23.0.1' (using password: YES)
```

This is likely because I was using a MySQL backend hosted in docker.

I propose we change the grants to be more permissive to ease onboarding developers.

Additionally, I propose the SQL provided by the documentation creates the same user/pass combination provided in the sample configuration.

## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.

Related issue: https://github.com/github/orchestrator/issues/0123456789

> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

This PR [briefly explain what is does]

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] code is formatted via `gofmt` (please avoid `goimports`)
- [ ] code is built via `./build.sh`
- [ ] code is tested via `go test ./go/...`
