### PR TITLE
Add support for go1.11

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,8 +56,8 @@ function precheck() {
     ok=1
   fi
 
-  if ! go version | egrep -q 'go(1\.(8|9|1[0]))' ; then
-    echo "go version must be between 1.8 and 1.10"
+  if ! go version | egrep -q 'go(1\.(8|9|1[01]))' ; then
+    echo "go version must be between 1.8 and 1.11"
     ok=1
   fi
 


### PR DESCRIPTION
Current code does not support the latest go1.11. This patch allows orchestrator to run with go 1.11.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`

`build.sh` now runs to completion happily on go 1.11.