### PR TITLE
Add global recoveries button

### DIFF
--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -967,6 +967,35 @@ function getParameterByName(name) {
 }
 
 
+function renderGlobalRecoveriesButton(isGlobalRecoveriesEnabled) {
+  var iconContainer = $("#global-recoveries-icon > span");
+  if (isGlobalRecoveriesEnabled) {
+    iconContainer
+      .prop("title", "Global Recoveries Enabled")
+      .addClass("glyphicon-heart")
+      .removeClass("hidden")
+      .click(function(event) {
+        bootbox.confirm("<h3>Global Recoveries</h3>Are you sure you want to <strong>disable</strong> global recoveries?", function(confirm) {
+          if (confirm) {
+            apiCommand("/api/disable-global-recoveries");
+          }
+        })
+      });
+  } else {
+    iconContainer
+      .prop("title", "Global Recoveries Disabled")
+      .addClass("glyphicon-heart-empty")
+      .removeClass("hidden")
+      .click(function(event) {
+        bootbox.confirm("<h3>Global Recoveries</h3>Are you sure you want to enable global recoveries?", function(confirm) {
+          if (confirm) {
+            apiCommand("/api/enable-global-recoveries");
+          }
+        })
+      });
+  }
+}
+
 $(document).ready(function() {
   visualizeBrand();
 
@@ -995,6 +1024,12 @@ $(document).ready(function() {
       func(clusters);
     });
   }, "json");
+
+  $.get(appUrl("/api/check-global-recoveries"), function(response) {
+    var isEnabled = (response.Details == "enabled")
+    renderGlobalRecoveriesButton(isEnabled);
+  }, "json");
+
   $(".ajaxLoader").click(function() {
     return false;
   });

--- a/resources/templates/layout.tmpl
+++ b/resources/templates/layout.tmpl
@@ -110,6 +110,10 @@
 					</a>
 					<ul class="dropdown-menu" id="dropdown-context">
 					</ul>
+				<li data-nav-page="global-recoveries">
+          <a id="global-recoveries-icon" name="global-recoveries">
+            <span class="glyphicon hidden"></span>
+          </a>
 				</li>
 				<li data-nav-page="read-only" style="display: none;">
 					<a name="read-only" title="read only mode"><span class="glyphicon glyphicon-eye-open"></span></a>


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.
Related issue: https://github.com/github/orchestrator/issues/645

### Description
Add a button on the interface to show and change the global-recovery status:

![Example](https://user-images.githubusercontent.com/1688249/46543401-03098900-c8c1-11e8-9f40-6fe851ea4a02.gif)

- [X] contributed code is using same conventions as original code
- [X] code is formatted via `gofmt` (please avoid `goimports`)
- [X] code is built via `./build.sh`
- [X] code is tested via `go test ./go/...`
