### PR TITLE
enabling/disabling global recoveries only for authorized users

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -3200,6 +3200,11 @@ func (this *HttpAPI) BlockedRecoveries(params martini.Params, r render.Render, r
 
 // DisableGlobalRecoveries globally disables recoveries
 func (this *HttpAPI) DisableGlobalRecoveries(params martini.Params, r render.Render, req *http.Request) {
+	if !isAuthorizedForAction(req, user) {
+		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
+		return
+	}
+
 	var err error
 	if orcraft.IsRaftEnabled() {
 		_, err = orcraft.PublishCommand("disable-global-recoveries", 0)
@@ -3217,6 +3222,11 @@ func (this *HttpAPI) DisableGlobalRecoveries(params martini.Params, r render.Ren
 
 // EnableGlobalRecoveries globally enables recoveries
 func (this *HttpAPI) EnableGlobalRecoveries(params martini.Params, r render.Render, req *http.Request) {
+	if !isAuthorizedForAction(req, user) {
+		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
+		return
+	}
+
 	var err error
 	if orcraft.IsRaftEnabled() {
 		_, err = orcraft.PublishCommand("enable-global-recoveries", 0)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -3199,7 +3199,7 @@ func (this *HttpAPI) BlockedRecoveries(params martini.Params, r render.Render, r
 }
 
 // DisableGlobalRecoveries globally disables recoveries
-func (this *HttpAPI) DisableGlobalRecoveries(params martini.Params, r render.Render, req *http.Request) {
+func (this *HttpAPI) DisableGlobalRecoveries(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
@@ -3221,7 +3221,7 @@ func (this *HttpAPI) DisableGlobalRecoveries(params martini.Params, r render.Ren
 }
 
 // EnableGlobalRecoveries globally enables recoveries
-func (this *HttpAPI) EnableGlobalRecoveries(params martini.Params, r render.Render, req *http.Request) {
+func (this *HttpAPI) EnableGlobalRecoveries(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -1077,5 +1077,13 @@ $(document).ready(function() {
       expires: 1
     });
   }
-  $("#searchInput").focus();
+  $("#searchInput").focusin(function() {
+    $("[data-nav-page=search] button").show();
+    $("#searchInput").css("width", "");
+  });
+  $("#searchInput").focusout(function() {
+    $("[data-nav-page=search] button").hide();
+    $("#searchInput").css("width", $("#searchInput").width()/2);
+  });
+  $("#searchInput").focusout();
 });

--- a/resources/templates/layout.tmpl
+++ b/resources/templates/layout.tmpl
@@ -111,7 +111,7 @@
 					<ul class="dropdown-menu" id="dropdown-context">
 					</ul>
 				<li data-nav-page="global-recoveries">
-          <a id="global-recoveries-icon" name="global-recoveries">
+          <a id="global-recoveries-icon" name="global-recoveries" href="#">
             <span class="glyphicon hidden"></span>
           </a>
 				</li>


### PR DESCRIPTION
followup to #646 , API for `enable-global-recoveries`, `disable-global-recoveries` is limited to authorized users.