### PR TITLE
Added which-broken-replicas to list replicas with errors

### DIFF
--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -233,8 +233,8 @@ function filter_keys {
   cat - | jq '.[] | .Key'
 }
 
-function filter_broken {
-  cat - | jq 'reduce .[] as $instance ([]; if $instance.LastSQLError != "\"\"" then . + [$instance] elif $instance.LastIOError != "\"\"" then . + [$instance] else . + [] end)'
+function filter_broken_replicas {
+  cat - | jq '.[] | select((.Slave_SQL_Running == false or .Slave_IO_Running == false) and (.LastSQLError != "" or .LastIOError != "")) | [.]'
 }
 
 function print_key {
@@ -369,7 +369,7 @@ function which_replicas() {
 function which_broken_replicas() {
   assert_nonempty "instance" "$instance_hostport"
   api "instance-replicas/$instance_hostport"
-  print_response | filter_broken | filter_keys | print_key
+  print_response | filter_broken_replicas | filter_keys | print_key
 }
 
 function which_cluster() {

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -233,6 +233,10 @@ function filter_keys {
   cat - | jq '.[] | .Key'
 }
 
+function filter_broken {
+  cat - | jq 'reduce .[] as $instance ([]; if $instance.LastSQLError != "\"\"" then . + [$instance] elif $instance.LastIOError != "\"\"" then . + [$instance] else . + [] end)'
+}
+
 function print_key {
   cat - | jq -r '. | (.Hostname + ":" + (.Port | tostring))'
 }
@@ -360,6 +364,12 @@ function which_replicas() {
   assert_nonempty "instance" "$instance_hostport"
   api "instance-replicas/$instance_hostport"
   print_response | filter_keys | print_key
+}
+
+function which_broken_replicas() {
+  assert_nonempty "instance" "$instance_hostport"
+  api "instance-replicas/$instance_hostport"
+  print_response | filter_broken | filter_keys | print_key
 }
 
 function which_cluster() {
@@ -682,6 +692,7 @@ function run_command() {
     "instance"|"which-instance") instance ;;                    # Output the fully-qualified hostname:port representation of the given instance, or error if unknown
     "which-master") which_master ;;                             # Output the fully-qualified hostname:port representation of a given instance's master
     "which-replicas") which_replicas ;;                         # Output the fully-qualified hostname:port list of replicas of a given instance
+    "which-broken-replicas") which_broken_replicas ;;           # Output the fully-qualified hostname:port list of broken replicas of a given instance
     "which-cluster-instances") which_cluster_instances ;;       # Output the list of instances participating in same cluster as given instance
     "which-cluster") which_cluster ;;                           # Output the name of the cluster an instance belongs to, or error if unknown to orchestrator
     "which-cluster-master") which_cluster_master ;;             # Output the name of a writable master in given cluster


### PR DESCRIPTION
Adding `which-broken-replicas` to address https://github.com/github/orchestrator/issues/588; Any replicas of instance `xxx` that show with `LastSQLError` or `LastIOError` are reported back to the user.
```
orchestrator-client -c which-broken-replicas -i xxx
```