### PR TITLE
GTID: predict replication error and prevent relocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ main
 *.pcap
 *.log
 .vendor/go19
-bin
+./bin

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -575,7 +575,7 @@ func canReplicateAssumingOracleGTID(instance, masterInstance *Instance) (canRepl
 	return subtractGtidSet.IsEmpty(), nil
 }
 
-func instancesGTIDCompatible(instance, otherInstance *Instance) (isOracleGTID bool, isMariaDBGTID, compatible bool) {
+func instancesAreGTIDAndCompatible(instance, otherInstance *Instance) (isOracleGTID bool, isMariaDBGTID, compatible bool) {
 	isOracleGTID = (instance.UsingOracleGTID && otherInstance.SupportsOracleGTID)
 	isMariaDBGTID = (instance.UsingMariaDBGTID && otherInstance.IsMariaDB())
 	compatible = isOracleGTID || isMariaDBGTID
@@ -583,7 +583,7 @@ func instancesGTIDCompatible(instance, otherInstance *Instance) (isOracleGTID bo
 }
 
 func checkMoveViaGTID(instance, otherInstance *Instance) (err error) {
-	isOracleGTID, _, moveCompatible := instancesGTIDCompatible(instance, otherInstance)
+	isOracleGTID, _, moveCompatible := instancesAreGTIDAndCompatible(instance, otherInstance)
 	if !moveCompatible {
 		return fmt.Errorf("Instances %+v, %+v not GTID compatible or not using GTID", instance.Key, otherInstance.Key)
 	}
@@ -2569,7 +2569,7 @@ func relocateBelowInternal(instance, other *Instance) (*Instance, error) {
 		return nil, log.Errorf("Relocating binlog server %+v below %+v turns to be too complex; please do it manually", instance.Key, other.Key)
 	}
 	// Next, try GTID
-	if _, _, gtidCompatible := instancesGTIDCompatible(instance, other); gtidCompatible {
+	if _, _, gtidCompatible := instancesAreGTIDAndCompatible(instance, other); gtidCompatible {
 		return moveInstanceBelowViaGTID(instance, other)
 	}
 

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -554,17 +554,7 @@ Cleanup:
 }
 
 func canReplicateAssumingOracleGTID(instance, masterInstance *Instance) (canReplicate bool, err error) {
-	instanceTotalGtid := fmt.Sprintf("%s,%s", instance.GtidPurged, instance.ExecutedGtidSet)
-	instanceGtidSet, err := NewOracleGtidSet(instanceTotalGtid)
-	if err != nil {
-		return false, err
-	}
-	masterPurgedGtidSet, err := NewOracleGtidSet(masterInstance.GtidPurged)
-	if err != nil {
-		return false, err
-	}
-
-	subtract, err := GTIDSubtract(&instance.Key, masterPurgedGtidSet.String(), instanceGtidSet.String())
+	subtract, err := GTIDSubtract(&instance.Key, masterInstance.GtidPurged, instance.ExecutedGtidSet)
 	if err != nil {
 		return false, err
 	}

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -572,7 +572,7 @@ func instancesAreGTIDAndCompatible(instance, otherInstance *Instance) (isOracleG
 	return isOracleGTID, isMariaDBGTID, compatible
 }
 
-func checkMoveViaGTID(instance, otherInstance *Instance) (err error) {
+func CheckMoveViaGTID(instance, otherInstance *Instance) (err error) {
 	isOracleGTID, _, moveCompatible := instancesAreGTIDAndCompatible(instance, otherInstance)
 	if !moveCompatible {
 		return fmt.Errorf("Instances %+v, %+v not GTID compatible or not using GTID", instance.Key, otherInstance.Key)
@@ -600,7 +600,7 @@ func moveInstanceBelowViaGTID(instance, otherInstance *Instance) (*Instance, err
 	if canReplicate, err := instance.CanReplicateFrom(otherInstance); !canReplicate {
 		return instance, err
 	}
-	if err := checkMoveViaGTID(instance, otherInstance); err != nil {
+	if err := CheckMoveViaGTID(instance, otherInstance); err != nil {
 		return instance, err
 	}
 	log.Infof("Will move %+v below %+v via GTID", instance.Key, otherInstance.Key)

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -660,7 +660,7 @@ func MoveBelowGTID(instanceKey, otherKey *InstanceKey) (*Instance, error) {
 }
 
 // moveReplicasViaGTID moves a list of replicas under another instance via GTID, returning those replicas
-// that could not be moved (do not use GTID)
+// that could not be moved (do not use GTID or had GTID errors)
 func moveReplicasViaGTID(replicas [](*Instance), other *Instance, postponedFunctionsContainer *PostponedFunctionsContainer) (movedReplicas [](*Instance), unmovedReplicas [](*Instance), err error, errs []error) {
 	replicas = RemoveNilInstances(replicas)
 	replicas = RemoveInstance(replicas, &other.Key)
@@ -2679,7 +2679,8 @@ func relocateReplicasInternal(replicas [](*Instance), instance, other *Instance)
 		// Which replicas are using Pseudo GTID?
 		var pseudoGTIDReplicas [](*Instance)
 		for _, replica := range replicas {
-			if replica.UsingPseudoGTID {
+			_, _, hasToBeGTID := instancesAreGTIDAndCompatible(replica, other)
+			if replica.UsingPseudoGTID && !hasToBeGTID {
 				pseudoGTIDReplicas = append(pseudoGTIDReplicas, replica)
 			}
 		}

--- a/go/inst/oracle_gtid_set.go
+++ b/go/inst/oracle_gtid_set.go
@@ -68,6 +68,45 @@ func (this *OracleGtidSet) RemoveUUID(uuid string) (removed bool) {
 	return removed
 }
 
+// RetainUUID retains only entries that belong to given UUID.
+func (this *OracleGtidSet) RetainUUID(uuid string) (anythingRemoved bool) {
+	return this.RetainUUIDs([]string{uuid})
+}
+
+// RetainUUIDs retains only entries that belong to given UUIDs.
+func (this *OracleGtidSet) RetainUUIDs(uuids []string) (anythingRemoved bool) {
+	retainUUIDs := map[string]bool{}
+	for _, uuid := range uuids {
+		retainUUIDs[uuid] = true
+	}
+	filteredEntries := [](*OracleGtidSetEntry){}
+	for _, entry := range this.GtidEntries {
+		if retainUUIDs[entry.UUID] {
+			filteredEntries = append(filteredEntries, entry)
+		} else {
+			anythingRemoved = true
+		}
+	}
+	if anythingRemoved {
+		this.GtidEntries = filteredEntries
+	}
+	return anythingRemoved
+}
+
+// SharedUUIDs returns UUIDs (range-less) that are shared between the two sets
+func (this *OracleGtidSet) SharedUUIDs(other *OracleGtidSet) (shared []string) {
+	thisUUIDs := map[string]bool{}
+	for _, entry := range this.GtidEntries {
+		thisUUIDs[entry.UUID] = true
+	}
+	for _, entry := range other.GtidEntries {
+		if thisUUIDs[entry.UUID] {
+			shared = append(shared, entry.UUID)
+		}
+	}
+	return shared
+}
+
 func (this *OracleGtidSet) String() string {
 	tokens := []string{}
 	for _, entry := range this.GtidEntries {

--- a/go/inst/oracle_gtid_set_test.go
+++ b/go/inst/oracle_gtid_set_test.go
@@ -123,3 +123,93 @@ func TestRemoveUUID(t *testing.T) {
 		test.S(t).ExpectTrue(gtidSet.IsEmpty())
 	}
 }
+
+func TestRetainUUID(t *testing.T) {
+	gtidSetVal := "00020192-1111-1111-1111-111111111111:20-30, 00020194-3333-3333-3333-333333333333:7-8"
+	{
+		gtidSet, err := NewOracleGtidSet(gtidSetVal)
+		test.S(t).ExpectNil(err)
+
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 2)
+		removed := gtidSet.RetainUUID("00020194-3333-3333-3333-333333333333")
+		test.S(t).ExpectTrue(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 1)
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[0].String(), "00020194-3333-3333-3333-333333333333:7-8")
+
+		removed = gtidSet.RetainUUID("00020194-3333-3333-3333-333333333333")
+		test.S(t).ExpectFalse(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 1)
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[0].String(), "00020194-3333-3333-3333-333333333333:7-8")
+
+		removed = gtidSet.RetainUUID("230ea8ea-81e3-11e4-972a-e25ec4bd140a")
+		test.S(t).ExpectTrue(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 0)
+	}
+}
+
+func TestRetainUUIDs(t *testing.T) {
+	gtidSetVal := "00020192-1111-1111-1111-111111111111:20-30, 00020194-3333-3333-3333-333333333333:7-8"
+	{
+		gtidSet, err := NewOracleGtidSet(gtidSetVal)
+		test.S(t).ExpectNil(err)
+
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 2)
+		removed := gtidSet.RetainUUIDs([]string{"00020194-3333-3333-3333-333333333333", "00020194-5555-5555-5555-333333333333"})
+		test.S(t).ExpectTrue(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 1)
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[0].String(), "00020194-3333-3333-3333-333333333333:7-8")
+
+		removed = gtidSet.RetainUUIDs([]string{"00020194-3333-3333-3333-333333333333", "00020194-5555-5555-5555-333333333333"})
+		test.S(t).ExpectFalse(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 1)
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[0].String(), "00020194-3333-3333-3333-333333333333:7-8")
+
+		removed = gtidSet.RetainUUIDs([]string{"230ea8ea-81e3-11e4-972a-e25ec4bd140a"})
+		test.S(t).ExpectTrue(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 0)
+	}
+}
+
+func TestSharedUUIDs(t *testing.T) {
+	gtidSetVal := "00020192-1111-1111-1111-111111111111:20-30, 00020194-3333-3333-3333-333333333333:7-8"
+	gtidSet, err := NewOracleGtidSet(gtidSetVal)
+	test.S(t).ExpectNil(err)
+	{
+		otherSet, err := NewOracleGtidSet("00020194-3333-3333-3333-333333333333:7-8,230ea8ea-81e3-11e4-972a-e25ec4bd140a:1-2")
+		test.S(t).ExpectNil(err)
+		{
+			shared := gtidSet.SharedUUIDs(otherSet)
+			test.S(t).ExpectEquals(len(shared), 1)
+			test.S(t).ExpectEquals(shared[0], "00020194-3333-3333-3333-333333333333")
+		}
+		{
+			shared := otherSet.SharedUUIDs(gtidSet)
+			test.S(t).ExpectEquals(len(shared), 1)
+			test.S(t).ExpectEquals(shared[0], "00020194-3333-3333-3333-333333333333")
+		}
+	}
+	{
+		otherSet, err := NewOracleGtidSet("00020194-4444-4444-4444-333333333333:7-8,230ea8ea-81e3-11e4-972a-e25ec4bd140a:1-2")
+		test.S(t).ExpectNil(err)
+		{
+			shared := gtidSet.SharedUUIDs(otherSet)
+			test.S(t).ExpectEquals(len(shared), 0)
+		}
+		{
+			shared := otherSet.SharedUUIDs(gtidSet)
+			test.S(t).ExpectEquals(len(shared), 0)
+		}
+	}
+	{
+		otherSet, err := NewOracleGtidSet("00020194-3333-3333-3333-333333333333:7-8,00020192-1111-1111-1111-111111111111:1-2")
+		test.S(t).ExpectNil(err)
+		{
+			shared := gtidSet.SharedUUIDs(otherSet)
+			test.S(t).ExpectEquals(len(shared), 2)
+		}
+		{
+			shared := otherSet.SharedUUIDs(gtidSet)
+			test.S(t).ExpectEquals(len(shared), 2)
+		}
+	}
+}

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -339,6 +339,16 @@ function can_replicate_from() {
   fi
 }
 
+function can_replicate_from_gtid() {
+  assert_nonempty "instance" "$instance_hostport"
+  assert_nonempty "destination" "$destination_hostport"
+  api "can-replicate-from-gtid/$instance_hostport/$destination_hostport"
+
+  if print_response | jq -r '.Message' | grep -q "true" ; then
+    print_response | print_details | print_key
+  fi
+}
+
 function is_replicating() {
   assert_nonempty "instance" "$instance_hostport"
   api "instance/$instance_hostport"
@@ -764,8 +774,9 @@ function run_command() {
     "disable-semi-sync-replica") general_instance_command ;;    # Disable semi-sync (replica-side)
     "restart-replica-statements") restart_replica_statements ;; # Given `-q "<query>"` that requires replication restart to apply, wrap query with stop/start slave statements as required to restore instance to same replication state. Print out set of statements
 
-    "can-replicate-from") can_replicate_from ;; # Check if an instance can potentially replicate from another, according to replication rules
-    "is-replicating") is_replicating ;;         # Check if an instance is replicating at this time (both SQL and IO threads running)
+    "can-replicate-from") can_replicate_from ;;      # Check if an instance can potentially replicate from another, according to replication rules
+    "can-replicate-from-gtid") can_replicate_from ;; # Check if an instance can potentially replicate from another, according to replication rules and assuming Oracle GTID
+    "is-replicating") is_replicating ;;              # Check if an instance is replicating at this time (both SQL and IO threads running)
 
     "set-read-only") general_instance_command ;;     # Turn an instance read-only, via SET GLOBAL read_only := 1
     "set-writeable") general_instance_command ;;     # Turn an instance writeable, via SET GLOBAL read_only := 0

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -774,9 +774,9 @@ function run_command() {
     "disable-semi-sync-replica") general_instance_command ;;    # Disable semi-sync (replica-side)
     "restart-replica-statements") restart_replica_statements ;; # Given `-q "<query>"` that requires replication restart to apply, wrap query with stop/start slave statements as required to restore instance to same replication state. Print out set of statements
 
-    "can-replicate-from") can_replicate_from ;;      # Check if an instance can potentially replicate from another, according to replication rules
-    "can-replicate-from-gtid") can_replicate_from ;; # Check if an instance can potentially replicate from another, according to replication rules and assuming Oracle GTID
-    "is-replicating") is_replicating ;;              # Check if an instance is replicating at this time (both SQL and IO threads running)
+    "can-replicate-from") can_replicate_from ;;           # Check if an instance can potentially replicate from another, according to replication rules
+    "can-replicate-from-gtid") can_replicate_from_gtid ;; # Check if an instance can potentially replicate from another, according to replication rules and assuming Oracle GTID
+    "is-replicating") is_replicating ;;                   # Check if an instance is replicating at this time (both SQL and IO threads running)
 
     "set-read-only") general_instance_command ;;     # Turn an instance read-only, via SET GLOBAL read_only := 1
     "set-writeable") general_instance_command ;;     # Turn an instance writeable, via SET GLOBAL read_only := 0


### PR DESCRIPTION
Fixes #642 
Fixes #643

With this PR `orchestrator` can predict whether server A can replicate from server B via `GTID`, in terms of missing/purged GTID transactions. 

`orchestrator` will now prevent relocating A under B if B has purged GTID transactions unknown to A: `orchestrator` predicts that if you try to `change master to`, replication will be broken.

`orchestrator` thereby also protects you against losing data: a `change master to` drops all relay logs. In the particular case of `DELAYED` replicas this is especially important: `change master to` drops relay logs, then replication is found to be broken, but... operation cannot be reverted; relay logs are lost. And so this PR protects against such incident.

It will also serve as the base for even more elaborate failover/promotion decisions.

cc @sjmudd 
Special thanks @MarkLeith and @evanelias for assisting in understanding the logic.