### PR TITLE
normalizing last_[io|sql]_error when empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ main
 *.pcap
 *.log
 .vendor/go19
-bin
+./bin

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -76,6 +76,8 @@ var readInstanceCounter = metrics.NewCounter()
 var writeInstanceCounter = metrics.NewCounter()
 var backendWrites = collection.CreateOrReturnCollection("BACKEND_WRITES")
 
+var emptyQuotesRegexp = regexp.MustCompile(`^""$`)
+
 func init() {
 	metrics.Register("instance.access_denied", accessDeniedCounter)
 	metrics.Register("instance.read_topology", readTopologyInstanceCounter)
@@ -477,8 +479,8 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 		instance.RelaylogCoordinates.LogFile = m.GetString("Relay_Log_File")
 		instance.RelaylogCoordinates.LogPos = m.GetInt64("Relay_Log_Pos")
 		instance.RelaylogCoordinates.Type = RelayLog
-		instance.LastSQLError = strconv.QuoteToASCII(m.GetString("Last_SQL_Error"))
-		instance.LastIOError = strconv.QuoteToASCII(m.GetString("Last_IO_Error"))
+		instance.LastSQLError = emptyQuotesRegexp.ReplaceAllString(strconv.QuoteToASCII(m.GetString("Last_SQL_Error")), "")
+		instance.LastIOError = emptyQuotesRegexp.ReplaceAllString(strconv.QuoteToASCII(m.GetString("Last_IO_Error")), "")
 		instance.SQLDelay = m.GetUintD("SQL_Delay", 0)
 		instance.UsingOracleGTID = (m.GetIntD("Auto_Position", 0) == 1)
 		instance.UsingMariaDBGTID = (m.GetStringD("Using_Gtid", "No") != "No")


### PR DESCRIPTION
Due to quotation logic we got empty quotes (`""`) in `last_sql_error` and `last_io_error` for replicas which had no error. This is confusing. 
This PR turns empty quotes into empty strings, which make more sense.