### PR TITLE
manual recovery overrides globally-disabled recoveries

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1478,10 +1478,16 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 		// Unexpected. Shouldn't get this
 		log.Errorf("Unable to determine if recovery is disabled globally: %v", err)
 	} else if recoveryDisabledGlobally {
+		if !forceInstanceRecovery {
+			log.Infof("CheckAndRecover: Analysis: %+v, InstanceKey: %+v, candidateInstanceKey: %+v, "+
+				"skipProcesses: %v: NOT Recovering host (disabled globally)",
+				analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey, candidateInstanceKey, skipProcesses)
+
+			return false, nil, err
+		}
 		log.Infof("CheckAndRecover: Analysis: %+v, InstanceKey: %+v, candidateInstanceKey: %+v, "+
-			"skipProcesses: %v: NOT Recovering host (disabled globally)",
+			"skipProcesses: %v: recoveries disabled globally but forcing this recovery",
 			analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey, candidateInstanceKey, skipProcesses)
-		return false, nil, err
 	}
 
 	// Actually attempt recovery:


### PR DESCRIPTION
globally-disabled recoveries were preventing manual recoveries from taking place. This PR ensures that a human can always choose to run a recovery.

PS 
Maybe I'm just pedantic; but since this is a public repo, and the timing of this PR may be of interest to people, it would be wrong to assume that this PR resolves recent events or that recent events were caused by lack of this PR. Just saying.

cc @github/database-infrastructure 