### PR TITLE
take-siblings now uses 'smart' relocation

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -240,6 +240,18 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				}
 			}
 		}
+	case registerCliCommand("take-siblings", "Smart relocation", `Turn all siblings of a replica into its sub-replicas.`):
+		{
+			instanceKey, _ = inst.FigureInstanceKey(instanceKey, thisInstanceKey)
+			if instanceKey == nil {
+				log.Fatal("Cannot deduce instance:", instance)
+			}
+			_, _, err := inst.TakeSiblings(instanceKey)
+			if err != nil {
+				log.Fatale(err)
+			}
+			fmt.Println(instanceKey.DisplayString())
+		}
 	case registerCliCommand("regroup-replicas", "Smart relocation", `Given an instance, pick one of its replicas and make it local master of its siblings`):
 		{
 			instanceKey, _ = inst.FigureInstanceKey(instanceKey, thisInstanceKey)
@@ -339,18 +351,6 @@ func Cli(command string, strict bool, instance string, destination string, owner
 					fmt.Println(fmt.Sprintf("%s<%s", replica.Key.DisplayString(), instanceKey.DisplayString()))
 				}
 			}
-		}
-	case registerCliCommand("take-siblings", "Classic file:pos relocation", `Turn all siblings of a replica into its sub-replicas.`):
-		{
-			instanceKey, _ = inst.FigureInstanceKey(instanceKey, thisInstanceKey)
-			if instanceKey == nil {
-				log.Fatal("Cannot deduce instance:", instance)
-			}
-			_, _, err := inst.TakeSiblings(instanceKey)
-			if err != nil {
-				log.Fatale(err)
-			}
-			fmt.Println(instanceKey.DisplayString())
 		}
 	case registerCliCommand("take-master", "Classic file:pos relocation", `Turn an instance into a master of its own master; essentially switch the two.`):
 		{

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -738,13 +738,13 @@ function run_command() {
     "move-up-replicas") general_singular_relocate_replicas_command ;;  # Moves replicas of the given instance one level up the topology
     "make-co-master") general_singular_relocate_command ;;             # Create a master-master replication. Given instance is a replica which replicates directly from a master.
     "take-master") general_singular_relocate_command ;;                # Turn an instance into a master of its own master; essentially switch the two.
-    "take-siblings") general_singular_relocate_command ;;              # Turn all siblings of a replica into its sub-replicas.
 
     "move-gtid") general_relocate_command ;;                           # Move a replica beneath another instance via GTID
     "move-replicas-gtid") general_relocate_replicas_command ;;         # Moves all replicas of a given instance under another (destination) instance using GTID
 
     "repoint") general_relocate_command ;;                             # Make the given instance replicate from another instance without changing the binglog coordinates. Use with care
     "repoint-replicas") general_singular_relocate_replicas_command ;;  # Repoint all replicas of given instance to replicate back from the instance. Use with care
+    "take-siblings") general_singular_relocate_command ;;              # Turn all siblings of a replica into its sub-replicas.
 
     "submit-pool-instances") submit_pool_instances ;;                  # Submit a pool name with a list of instances in that pool
     "which-heuristic-cluster-pool-instances") which_heuristic_cluster_pool_instances ;; # List instances of a given cluster which are in either any pool or in a specific pool

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -565,14 +565,18 @@ function openNodeModal(node) {
     $('#node_modal button[data-btn=take-siblings]').show();
   }
   $('#node_modal button[data-btn=take-siblings]').click(function() {
-    var message = "<p>Are you sure you want <code><strong>" + node.Key.Hostname + ":" + node.Key.Port +
-      "</strong></code> to take its siblings?" +
-      "<p>This will stop replication on this replica and on its siblings throughout the operation";
-    bootbox.confirm(message, function(confirm) {
-      if (confirm) {
-        apiCommand("/api/take-siblings/" + node.Key.Hostname + "/" + node.Key.Port);
-      }
-    });
+    var apiUrl = "/api/take-siblings/" + node.Key.Hostname + "/" + node.Key.Port;
+    if (isSilentUI()) {
+      apiCommand(apiUrl);
+    } else {
+      var message = "<p>Are you sure you want <code><strong>" + node.Key.Hostname + ":" + node.Key.Port +
+        "</strong></code> to take its siblings?";
+      bootbox.confirm(message, function(confirm) {
+        if (confirm) {
+          apiCommand(apiUrl);
+        }
+      });
+    }
   });
   $('#node_modal button[data-btn=end-downtime]').click(function() {
     apiCommand("/api/end-downtime/" + node.Key.Hostname + "/" + node.Key.Port);


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/667

`take-siblings` was originally designed to only operate via standard `file:pos` (documented).

However, I feel this is mostly confusing and not really required. With this PR, `take-siblings` uses the "smart" relocation method, which can utilize GTID, Pseudo-GTID, standard replication, binlog servers...

It is now essentially a syntactic sugar to `relocate-replicas`:

`orchestrator -c take-siblings -i the.server` == `orchestrator -c relocate-replicas -i master.of.the.server -d the.server` 