### PR TITLE
Instance write buffer metrics

### DIFF
--- a/go/collection/collection.go
+++ b/go/collection/collection.go
@@ -85,18 +85,28 @@ type Collection struct {
 	expirePeriod time.Duration // time to keep the collection information for
 }
 
+// This is a collection name
+type Name string
+
+const (
+	// Some fixed collections we use, to avoid using strings everywhere
+	BackendWrites       Name = "BACKEND_WRITES"
+	DiscoveryMetrics    Name = "DISCOVERY_METRICS"
+	FlushInstanceWrites Name = "FLUSH_INSTANCE_WRITES"
+)
+
 // hard-coded at every second
 const defaultExpireTickerPeriod = time.Second
 
 // backendMetricCollection contains the last N backend "channelled"
 // metrics which can then be accessed via an API call for monitoring.
 var (
-	namedCollection     map[string](*Collection)
+	namedCollection     map[Name](*Collection)
 	namedCollectionLock sync.Mutex
 )
 
 func init() {
-	namedCollection = make(map[string](*Collection))
+	namedCollection = make(map[Name](*Collection))
 }
 
 // StopMonitoring stops monitoring all the collections
@@ -109,7 +119,7 @@ func StopMonitoring() {
 // CreateOrReturnCollection allows for creation of a new collection or
 // returning a pointer to an existing one given the name. This allows access
 // to the data structure from the api interface (http/api.go) and also when writing (inst).
-func CreateOrReturnCollection(name string) *Collection {
+func CreateOrReturnCollection(name Name) *Collection {
 	namedCollectionLock.Lock()
 	defer namedCollectionLock.Unlock()
 	if q, found := namedCollection[name]; found {

--- a/go/collection/collection_test.go
+++ b/go/collection/collection_test.go
@@ -21,9 +21,9 @@ import (
 	"time"
 )
 
-var randomString = []string{
-	"RANDOM_STRING",
-	"SOME_OTHER_STRING",
+var randomString = []Name{
+	BackendWrites,
+	DiscoveryMetrics,
 }
 
 // some random base timestamp

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -124,6 +124,7 @@ type HttpAPI struct {
 var API HttpAPI = HttpAPI{}
 var discoveryMetrics = collection.CreateOrReturnCollection("DISCOVERY_METRICS")
 var queryMetrics = collection.CreateOrReturnCollection("BACKEND_WRITES")
+var instanceBufferedWriteMetrics = collection.CreateOrReturnCollection("FLUSH_INSTANCE_WRITES")
 
 func (this *HttpAPI) getInstanceKey(host string, port string) (inst.InstanceKey, error) {
 	instanceKey, err := inst.NewResolveInstanceKeyStrings(host, port)
@@ -2216,6 +2217,42 @@ func (this *HttpAPI) BackendQueryMetricsAggregated(params martini.Params, r rend
 	r.JSON(http.StatusOK, aggregated)
 }
 
+func (this *HttpAPI) InstanceBufferedWriteMetricsRaw(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+	seconds, err := strconv.Atoi(params["seconds"])
+	log.Debugf("InstanceBufferedWriteMetricsRaw: seconds: %d", seconds)
+	if err != nil {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unable to generate raw instance buffere write metrics"})
+		return
+	}
+
+	refTime := time.Now().Add(-time.Duration(seconds) * time.Second)
+	m, err := instanceBufferedWriteMetrics.Since(refTime)
+	if err != nil {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unable to return backend query metrics"})
+		return
+	}
+
+	log.Debugf("InstanceBufferedWritesMetricsRaw data: %+v", m)
+
+	r.JSON(200, m)
+}
+
+// InstanceBufferedWriteMetricsAggregated provides aggregate metrics of the instance buffered writes
+func (this *HttpAPI) InstanceBufferedWriteMetricsAggregated(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+	seconds, err := strconv.Atoi(params["seconds"])
+	log.Debugf("InstanceBufferedWriteMetricsAggregated: seconds: %d", seconds)
+	if err != nil {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unable to generate aggregated instance buffered write metrics"})
+		return
+	}
+
+	refTime := time.Now().Add(-time.Duration(seconds) * time.Second)
+	aggregated := inst.WriteBufferAggregatedSince(instanceBufferedWriteMetrics, refTime)
+	log.Debugf("InstanceBufferedWriteMetricsAggregated data: %+v", aggregated)
+
+	r.JSON(200, aggregated)
+}
+
 // Agents provides complete list of registered agents (See https://github.com/github/orchestrator-agent)
 func (this *HttpAPI) Agents(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
@@ -3551,6 +3588,8 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequest(m, "discovery-queue-metrics-aggregated/:seconds", this.DiscoveryQueueMetricsAggregated)
 	this.registerAPIRequest(m, "backend-query-metrics-raw/:seconds", this.BackendQueryMetricsRaw)
 	this.registerAPIRequest(m, "backend-query-metrics-aggregated/:seconds", this.BackendQueryMetricsAggregated)
+	this.registerAPIRequest(m, "instance-buffered-write-metrics-raw/:seconds", this.InstanceBufferedWriteMetricsRaw)
+	this.registerAPIRequest(m, "instance-buffered-write-metrics-aggregated/:seconds", this.InstanceBufferedWriteMetricsAggregated)
 
 	// Agents
 	this.registerAPIRequest(m, "agents", this.Agents)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -122,9 +122,9 @@ type HttpAPI struct {
 }
 
 var API HttpAPI = HttpAPI{}
-var discoveryMetrics = collection.CreateOrReturnCollection("DISCOVERY_METRICS")
-var queryMetrics = collection.CreateOrReturnCollection("BACKEND_WRITES")
-var instanceBufferedWriteMetrics = collection.CreateOrReturnCollection("FLUSH_INSTANCE_WRITES")
+var discoveryMetrics = collection.CreateOrReturnCollection(collection.DiscoveryMetrics)
+var queryMetrics = collection.CreateOrReturnCollection(collection.BackendWrites)
+var instanceBufferedWriteMetrics = collection.CreateOrReturnCollection(collection.FlushInstanceWrites)
 
 func (this *HttpAPI) getInstanceKey(host string, port string) (inst.InstanceKey, error) {
 	instanceKey, err := inst.NewResolveInstanceKeyStrings(host, port)

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -74,7 +74,8 @@ var accessDeniedCounter = metrics.NewCounter()
 var readTopologyInstanceCounter = metrics.NewCounter()
 var readInstanceCounter = metrics.NewCounter()
 var writeInstanceCounter = metrics.NewCounter()
-var backendWrites = collection.CreateOrReturnCollection("BACKEND_WRITES")
+var backendWrites = collection.CreateOrReturnCollection(collection.BackendWrites)
+var instanceBufferedWriteMetrics = collection.CreateOrReturnCollection(collection.FlushInstanceWrites)
 
 var emptyQuotesRegexp = regexp.MustCompile(`^""$`)
 
@@ -2364,6 +2365,7 @@ func writeManyInstances(instances []*Instance, instanceWasActuallyFound bool, up
 	if _, err := db.ExecOrchestrator(sql, args...); err != nil {
 		return err
 	}
+	writeInstanceCounter.Inc(int64(len(instances)))
 	return nil
 }
 
@@ -2401,6 +2403,8 @@ func flushInstanceWriteBuffer() {
 		return
 	}
 
+	wbm := NewWriteBufferMetric() // prepare metric
+
 	for i := 0; i < len(instanceWriteBuffer); i++ {
 		upd := <-instanceWriteBuffer
 		if upd.instanceWasActuallyFound && upd.lastError == nil {
@@ -2419,18 +2423,23 @@ func flushInstanceWriteBuffer() {
 		if err != nil {
 			return log.Errorf("flushInstanceWriteBuffer writemany: %v", err)
 		}
+		writeInstanceCounter.Inc(int64(len(instances)))
+
 		err = writeManyInstances(lastseen, true, true)
 		if err != nil {
 			return log.Errorf("flushInstanceWriteBuffer last_seen: %v", err)
 		}
 
-		writeInstanceCounter.Inc(int64(len(instances) + len(lastseen)))
+		writeInstanceCounter.Inc(int64(len(lastseen)))
 		return nil
 	}
 	err := ExecDBWriteFunc(writeFunc)
 	if err != nil {
 		log.Errorf("flushInstanceWriteBuffer: %v", err)
 	}
+
+	wbm.Update(len(instances)+len(lastseen), err)
+	instanceBufferedWriteMetrics.Append(wbm)
 }
 
 // WriteInstance stores an instance in the orchestrator backend

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -85,6 +85,8 @@ func init() {
 	metrics.Register("instance.read", readInstanceCounter)
 	metrics.Register("instance.write", writeInstanceCounter)
 
+	InitWriteBufferMetrics()
+
 	go initializeInstanceDao()
 }
 

--- a/go/inst/write_buffer.go
+++ b/go/inst/write_buffer.go
@@ -34,11 +34,11 @@ type WriteBufferMetric struct {
 }
 
 var (
-	writeCount = metrics.NewCounter()
-	errorCount = metrics.NewCounter()
-	instancesErrors = metrics.NewCounter()
-	instancesWritten = metrics.NewHistogram(metrics.NewUniformSample(16384))
-	writeLatency = metrics.NewTimer()
+	writeCount            = metrics.NewCounter()
+	errorCount            = metrics.NewCounter()
+	instancesErrors       = metrics.NewCounter()
+	instancesWritten      = metrics.NewHistogram(metrics.NewUniformSample(16384))
+	writeLatency          = metrics.NewTimer()
 	instanceFlushInterval = metrics.NewFunctionalGauge(func() int64 {
 		return int64(config.Config.InstanceFlushIntervalMilliseconds)
 	})
@@ -80,19 +80,19 @@ func (wbm WriteBufferMetric) When() time.Time {
 
 // WriteBufferAggregate holds the results of a number of buffered write attempts to the backend
 type WriteBufferAggregate struct {
-	InstanceFlushIntervalMilliseconds int64     // config setting
-	InstanceWriteBufferSize           int64     // config setting
-	WriteCount                        int64     // number of writes done
-	ErrorCount                        int64     // number of writes with errors
-	SumInstancesWritten               int64     // total number of rows written
-	SumInstancesErrors                int64     // total number of rows with errors
-	MaxInstancesWritten               int64     // metrics for instances written in each call
+	InstanceFlushIntervalMilliseconds int64 // config setting
+	InstanceWriteBufferSize           int64 // config setting
+	WriteCount                        int64 // number of writes done
+	ErrorCount                        int64 // number of writes with errors
+	SumInstancesWritten               int64 // total number of rows written
+	SumInstancesErrors                int64 // total number of rows with errors
+	MaxInstancesWritten               int64 // metrics for instances written in each call
 	MeanInstancesWritten              float64
 	MedianInstancesWritten            float64
 	P75InstancesWritten               float64
 	P95InstancesWritten               float64
 	P99InstancesWritten               float64
-	MaxWriteLatencySeconds            int64     // metrics for time to write each set of instances
+	MaxWriteLatencySeconds            int64 // metrics for time to write each set of instances
 	MeanWriteLatencySeconds           float64
 	MedianWriteLatencySeconds         float64
 	P75WriteLatencySeconds            float64

--- a/go/inst/write_buffer.go
+++ b/go/inst/write_buffer.go
@@ -1,0 +1,150 @@
+/*
+   Copyright 2017 Simon J Mudd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package inst
+
+import (
+	"time"
+
+	"github.com/montanaflynn/stats"
+
+	"github.com/github/orchestrator/go/collection"
+	"github.com/github/orchestrator/go/config"
+)
+
+// WriteBufferMetric holds the result of a single buffered write attempt to the backend
+type WriteBufferMetric struct {
+	Timestamp    time.Time
+	WriteLatency time.Duration // time that we had to wait before starting query execution
+	Items        int           // number of rows written
+	Err          error         // any error resulting from the query execution
+}
+
+// NewWriteBufferMetric returns a new metric with timestamp starting from now
+func NewWriteBufferMetric() *WriteBufferMetric {
+	wbm := &WriteBufferMetric{
+		Timestamp: time.Now(),
+	}
+
+	return wbm
+}
+
+// Update the metrics based on the given values
+func (wbm *WriteBufferMetric) Update(items int, err error) {
+	wbm.WriteLatency = time.Since(wbm.Timestamp)
+	wbm.Items = items
+	wbm.Err = err
+}
+
+// When records the timestamp of the start of the recording
+func (wbm WriteBufferMetric) When() time.Time {
+	return wbm.Timestamp
+}
+
+// WriteBufferAggregate holds the results of a number of buffered write attempts to the backend
+type WriteBufferAggregate struct {
+	InstanceFlushIntervalMilliseconds int     // config setting
+	InstanceWriteBufferSize           int     // config setting
+	WriteCount                        int     // number of writes done
+	ErrorCount                        int     // number of writes with errors
+	SumInstancesWritten               int     // total number of rows written
+	SumInstancesErrors                int     // total number of rows with errors
+	MaxInstancesWritten               float64 // metrics for instances written in each call
+	MeanInstancesWritten              float64
+	MedianInstancesWritten            float64
+	P75InstancesWritten               float64
+	P95InstancesWritten               float64
+	P99InstancesWritten               float64
+	MaxWriteLatencySeconds            float64 // metrics for time to write each set of instances
+	MeanWriteLatencySeconds           float64
+	MedianWriteLatencySeconds         float64
+	P75WriteLatencySeconds            float64
+	P95WriteLatencySeconds            float64
+	P99WriteLatencySeconds            float64
+}
+
+// WriteBufferAggregatedSince returns the aggregated for metrics in the collection since the specified time.
+func WriteBufferAggregatedSince(c *collection.Collection, t time.Time) WriteBufferAggregate {
+	var (
+		writeTimings []float64
+		writeItems   []float64
+	)
+
+	// Retrieve values since the time specified
+	values, err := c.Since(t)
+	wba := WriteBufferAggregate{
+		InstanceFlushIntervalMilliseconds: config.Config.InstanceFlushIntervalMilliseconds,
+		InstanceWriteBufferSize:           config.Config.InstanceWriteBufferSize,
+	}
+
+	if err != nil {
+		return wba // empty data
+	}
+
+	// generate the metrics
+	for _, v := range values {
+		writeTimings = append(writeTimings, v.(*WriteBufferMetric).WriteLatency.Seconds())
+		writeItems = append(writeItems, float64(v.(*WriteBufferMetric).Items))
+		wba.SumInstancesWritten += v.(*WriteBufferMetric).Items
+		if v.(*WriteBufferMetric).Err != nil {
+			wba.ErrorCount++
+			wba.SumInstancesErrors += v.(*WriteBufferMetric).Items
+		}
+	}
+
+	wba.WriteCount = len(writeTimings)
+
+	// generate aggregate timing metrics
+	if s, err := stats.Max(stats.Float64Data(writeTimings)); err == nil {
+		wba.MaxWriteLatencySeconds = s
+	}
+	if s, err := stats.Mean(stats.Float64Data(writeTimings)); err == nil {
+		wba.MeanWriteLatencySeconds = s
+	}
+	if s, err := stats.Median(stats.Float64Data(writeTimings)); err == nil {
+		wba.MedianWriteLatencySeconds = s
+	}
+	if s, err := stats.Percentile(stats.Float64Data(writeTimings), 75); err == nil {
+		wba.P75WriteLatencySeconds = s
+	}
+	if s, err := stats.Percentile(stats.Float64Data(writeTimings), 95); err == nil {
+		wba.P95WriteLatencySeconds = s
+	}
+	if s, err := stats.Percentile(stats.Float64Data(writeTimings), 99); err == nil {
+		wba.P99WriteLatencySeconds = s
+	}
+	// generate aggregate item size metrics
+	if s, err := stats.Max(stats.Float64Data(writeItems)); err == nil {
+		wba.MaxInstancesWritten = s
+	}
+	if s, err := stats.Mean(stats.Float64Data(writeItems)); err == nil {
+		wba.MeanInstancesWritten = s
+	}
+	if s, err := stats.Median(stats.Float64Data(writeItems)); err == nil {
+		wba.MedianInstancesWritten = s
+	}
+	if s, err := stats.Percentile(stats.Float64Data(writeItems), 75); err == nil {
+		wba.P75InstancesWritten = s
+	}
+	if s, err := stats.Percentile(stats.Float64Data(writeItems), 95); err == nil {
+		wba.P95InstancesWritten = s
+	}
+	if s, err := stats.Percentile(stats.Float64Data(writeItems), 99); err == nil {
+		wba.P99InstancesWritten = s
+	}
+
+	return wba
+}

--- a/vendor/github.com/rcrowley/go-metrics/.travis.yml
+++ b/vendor/github.com/rcrowley/go-metrics/.travis.yml
@@ -1,10 +1,13 @@
 language: go
 
 go:
-    - 1.2
     - 1.3
     - 1.4
     - 1.5
+    - 1.6
+    - 1.7
+    - 1.8
+    - 1.9
 
 script:
     - ./validate.sh

--- a/vendor/github.com/rcrowley/go-metrics/README.md
+++ b/vendor/github.com/rcrowley/go-metrics/README.md
@@ -21,6 +21,9 @@ g := metrics.NewGauge()
 metrics.Register("bar", g)
 g.Update(47)
 
+r := NewRegistry()
+g := metrics.NewRegisteredFunctionalGauge("cache-evictions", r, func() int64 { return cache.getEvictionsCount() })
+
 s := metrics.NewExpDecaySample(1028, 0.015) // or metrics.NewUniformSample(1028)
 h := metrics.NewHistogram(s)
 metrics.Register("baz", h)
@@ -34,6 +37,25 @@ t := metrics.NewTimer()
 metrics.Register("bang", t)
 t.Time(func() {})
 t.Update(47)
+```
+
+Register() is not threadsafe. For threadsafe metric registration use
+GetOrRegister:
+
+```go
+t := metrics.GetOrRegisterTimer("account.create.latency", nil)
+t.Time(func() {})
+t.Update(47)
+```
+
+**NOTE:** Be sure to unregister short-lived meters and timers otherwise they will
+leak memory:
+
+```go
+// Will call Stop() on the Meter to allow for garbage collection
+metrics.Unregister("quux")
+// Or similarly for a Timer that embeds a Meter
+metrics.Unregister("bang")
 ```
 
 Periodically log every metric in human-readable form to standard error:
@@ -67,14 +89,15 @@ issues [#121](https://github.com/rcrowley/go-metrics/issues/121) and
 [#124](https://github.com/rcrowley/go-metrics/issues/124) for progress and details.
 
 ```go
-import "github.com/rcrowley/go-metrics/influxdb"
+import "github.com/vrischmann/go-metrics-influxdb"
 
-go influxdb.Influxdb(metrics.DefaultRegistry, 10e9, &influxdb.Config{
-    Host:     "127.0.0.1:8086",
-    Database: "metrics",
-    Username: "test",
-    Password: "test",
-})
+go influxdb.InfluxDB(metrics.DefaultRegistry,
+  10e9, 
+  "127.0.0.1:8086", 
+  "database-name", 
+  "username", 
+  "password"
+)
 ```
 
 Periodically upload every metric to Librato using the [Librato client](https://github.com/mihasya/go-metrics-librato):
@@ -134,7 +157,12 @@ Publishing Metrics
 
 Clients are available for the following destinations:
 
-* Librato - [https://github.com/mihasya/go-metrics-librato](https://github.com/mihasya/go-metrics-librato)
-* Graphite - [https://github.com/cyberdelia/go-metrics-graphite](https://github.com/cyberdelia/go-metrics-graphite)
-* InfluxDB - [https://github.com/vrischmann/go-metrics-influxdb](https://github.com/vrischmann/go-metrics-influxdb)
-* Ganglia - [https://github.com/appscode/metlia](https://github.com/appscode/metlia)
+* Librato - https://github.com/mihasya/go-metrics-librato
+* Graphite - https://github.com/cyberdelia/go-metrics-graphite
+* InfluxDB - https://github.com/vrischmann/go-metrics-influxdb
+* Ganglia - https://github.com/appscode/metlia
+* Prometheus - https://github.com/deathowl/go-metrics-prometheus
+* DataDog - https://github.com/syntaqx/go-metrics-datadog
+* SignalFX - https://github.com/pascallouisperez/go-metrics-signalfx
+* Honeycomb - https://github.com/getspine/go-metrics-honeycomb
+* Wavefront - https://github.com/wavefrontHQ/go-metrics-wavefront

--- a/vendor/github.com/rcrowley/go-metrics/ewma_test.go
+++ b/vendor/github.com/rcrowley/go-metrics/ewma_test.go
@@ -1,6 +1,11 @@
 package metrics
 
-import "testing"
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
 
 func BenchmarkEWMA(b *testing.B) {
 	a := NewEWMA1()
@@ -9,6 +14,34 @@ func BenchmarkEWMA(b *testing.B) {
 		a.Update(1)
 		a.Tick()
 	}
+}
+
+func BenchmarkEWMAParallel(b *testing.B) {
+	a := NewEWMA1()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			a.Update(1)
+			a.Tick()
+		}
+	})
+}
+
+// exercise race detector
+func TestEWMAConcurrency(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+	a := NewEWMA1()
+	wg := &sync.WaitGroup{}
+	reps := 100
+	for i := 0; i < reps; i++ {
+		wg.Add(1)
+		go func(ewma EWMA, wg *sync.WaitGroup) {
+			a.Update(rand.Int63())
+			wg.Done()
+		}(a, wg)
+	}
+	wg.Wait()
 }
 
 func TestEWMA1(t *testing.T) {

--- a/vendor/github.com/rcrowley/go-metrics/gauge_float64.go
+++ b/vendor/github.com/rcrowley/go-metrics/gauge_float64.go
@@ -1,6 +1,9 @@
 package metrics
 
-import "sync"
+import (
+	"math"
+	"sync/atomic"
+)
 
 // GaugeFloat64s hold a float64 value that can be set arbitrarily.
 type GaugeFloat64 interface {
@@ -38,6 +41,24 @@ func NewRegisteredGaugeFloat64(name string, r Registry) GaugeFloat64 {
 	return c
 }
 
+// NewFunctionalGauge constructs a new FunctionalGauge.
+func NewFunctionalGaugeFloat64(f func() float64) GaugeFloat64 {
+	if UseNilMetrics {
+		return NilGaugeFloat64{}
+	}
+	return &FunctionalGaugeFloat64{value: f}
+}
+
+// NewRegisteredFunctionalGauge constructs and registers a new StandardGauge.
+func NewRegisteredFunctionalGaugeFloat64(name string, r Registry, f func() float64) GaugeFloat64 {
+	c := NewFunctionalGaugeFloat64(f)
+	if nil == r {
+		r = DefaultRegistry
+	}
+	r.Register(name, c)
+	return c
+}
+
 // GaugeFloat64Snapshot is a read-only copy of another GaugeFloat64.
 type GaugeFloat64Snapshot float64
 
@@ -67,8 +88,7 @@ func (NilGaugeFloat64) Value() float64 { return 0.0 }
 // StandardGaugeFloat64 is the standard implementation of a GaugeFloat64 and uses
 // sync.Mutex to manage a single float64 value.
 type StandardGaugeFloat64 struct {
-	mutex sync.Mutex
-	value float64
+	value uint64
 }
 
 // Snapshot returns a read-only copy of the gauge.
@@ -78,14 +98,28 @@ func (g *StandardGaugeFloat64) Snapshot() GaugeFloat64 {
 
 // Update updates the gauge's value.
 func (g *StandardGaugeFloat64) Update(v float64) {
-	g.mutex.Lock()
-	defer g.mutex.Unlock()
-	g.value = v
+	atomic.StoreUint64(&g.value, math.Float64bits(v))
 }
 
 // Value returns the gauge's current value.
 func (g *StandardGaugeFloat64) Value() float64 {
-	g.mutex.Lock()
-	defer g.mutex.Unlock()
-	return g.value
+	return math.Float64frombits(atomic.LoadUint64(&g.value))
+}
+
+// FunctionalGaugeFloat64 returns value from given function
+type FunctionalGaugeFloat64 struct {
+	value func() float64
+}
+
+// Value returns the gauge's current value.
+func (g FunctionalGaugeFloat64) Value() float64 {
+	return g.value()
+}
+
+// Snapshot returns the snapshot.
+func (g FunctionalGaugeFloat64) Snapshot() GaugeFloat64 { return GaugeFloat64Snapshot(g.Value()) }
+
+// Update panics.
+func (FunctionalGaugeFloat64) Update(float64) {
+	panic("Update called on a FunctionalGaugeFloat64")
 }

--- a/vendor/github.com/rcrowley/go-metrics/gauge_float64_test.go
+++ b/vendor/github.com/rcrowley/go-metrics/gauge_float64_test.go
@@ -10,6 +10,16 @@ func BenchmarkGuageFloat64(b *testing.B) {
 	}
 }
 
+func BenchmarkGuageFloat64Parallel(b *testing.B) {
+	g := NewGaugeFloat64()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			g.Update(float64(1))
+		}
+	})
+}
+
 func TestGaugeFloat64(t *testing.T) {
 	g := NewGaugeFloat64()
 	g.Update(float64(47.0))
@@ -33,6 +43,27 @@ func TestGetOrRegisterGaugeFloat64(t *testing.T) {
 	NewRegisteredGaugeFloat64("foo", r).Update(float64(47.0))
 	t.Logf("registry: %v", r)
 	if g := GetOrRegisterGaugeFloat64("foo", r); float64(47.0) != g.Value() {
+		t.Fatal(g)
+	}
+}
+
+func TestFunctionalGaugeFloat64(t *testing.T) {
+	var counter float64
+	fg := NewFunctionalGaugeFloat64(func() float64 {
+		counter++
+		return counter
+	})
+	fg.Value()
+	fg.Value()
+	if counter != 2 {
+		t.Error("counter != 2")
+	}
+}
+
+func TestGetOrRegisterFunctionalGaugeFloat64(t *testing.T) {
+	r := NewRegistry()
+	NewRegisteredFunctionalGaugeFloat64("foo", r, func() float64 { return 47 })
+	if g := GetOrRegisterGaugeFloat64("foo", r); 47 != g.Value() {
 		t.Fatal(g)
 	}
 }

--- a/vendor/github.com/rcrowley/go-metrics/gauge_test.go
+++ b/vendor/github.com/rcrowley/go-metrics/gauge_test.go
@@ -1,6 +1,12 @@
 package metrics
 
-import "testing"
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
 
 func BenchmarkGuage(b *testing.B) {
 	g := NewGauge()
@@ -8,6 +14,22 @@ func BenchmarkGuage(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		g.Update(int64(i))
 	}
+}
+
+// exercise race detector
+func TestGaugeConcurrency(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+	g := NewGauge()
+	wg := &sync.WaitGroup{}
+	reps := 100
+	for i := 0; i < reps; i++ {
+		wg.Add(1)
+		go func(g Gauge, wg *sync.WaitGroup) {
+			g.Update(rand.Int63())
+			wg.Done()
+		}(g, wg)
+	}
+	wg.Wait()
 }
 
 func TestGauge(t *testing.T) {
@@ -34,4 +56,32 @@ func TestGetOrRegisterGauge(t *testing.T) {
 	if g := GetOrRegisterGauge("foo", r); 47 != g.Value() {
 		t.Fatal(g)
 	}
+}
+
+func TestFunctionalGauge(t *testing.T) {
+	var counter int64
+	fg := NewFunctionalGauge(func() int64 {
+		counter++
+		return counter
+	})
+	fg.Value()
+	fg.Value()
+	if counter != 2 {
+		t.Error("counter != 2")
+	}
+}
+
+func TestGetOrRegisterFunctionalGauge(t *testing.T) {
+	r := NewRegistry()
+	NewRegisteredFunctionalGauge("foo", r, func() int64 { return 47 })
+	if g := GetOrRegisterGauge("foo", r); 47 != g.Value() {
+		t.Fatal(g)
+	}
+}
+
+func ExampleGetOrRegisterGauge() {
+	m := "server.bytes_sent"
+	g := GetOrRegisterGauge(m, nil)
+	g.Update(47)
+	fmt.Println(g.Value()) // Output: 47
 }

--- a/vendor/github.com/rcrowley/go-metrics/json.go
+++ b/vendor/github.com/rcrowley/go-metrics/json.go
@@ -9,63 +9,7 @@ import (
 // MarshalJSON returns a byte slice containing a JSON representation of all
 // the metrics in the Registry.
 func (r *StandardRegistry) MarshalJSON() ([]byte, error) {
-	data := make(map[string]map[string]interface{})
-	r.Each(func(name string, i interface{}) {
-		values := make(map[string]interface{})
-		switch metric := i.(type) {
-		case Counter:
-			values["count"] = metric.Count()
-		case Gauge:
-			values["value"] = metric.Value()
-		case GaugeFloat64:
-			values["value"] = metric.Value()
-		case Healthcheck:
-			values["error"] = nil
-			metric.Check()
-			if err := metric.Error(); nil != err {
-				values["error"] = metric.Error().Error()
-			}
-		case Histogram:
-			h := metric.Snapshot()
-			ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
-			values["count"] = h.Count()
-			values["min"] = h.Min()
-			values["max"] = h.Max()
-			values["mean"] = h.Mean()
-			values["stddev"] = h.StdDev()
-			values["median"] = ps[0]
-			values["75%"] = ps[1]
-			values["95%"] = ps[2]
-			values["99%"] = ps[3]
-			values["99.9%"] = ps[4]
-		case Meter:
-			m := metric.Snapshot()
-			values["count"] = m.Count()
-			values["1m.rate"] = m.Rate1()
-			values["5m.rate"] = m.Rate5()
-			values["15m.rate"] = m.Rate15()
-			values["mean.rate"] = m.RateMean()
-		case Timer:
-			t := metric.Snapshot()
-			ps := t.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
-			values["count"] = t.Count()
-			values["min"] = t.Min()
-			values["max"] = t.Max()
-			values["mean"] = t.Mean()
-			values["stddev"] = t.StdDev()
-			values["median"] = ps[0]
-			values["75%"] = ps[1]
-			values["95%"] = ps[2]
-			values["99%"] = ps[3]
-			values["99.9%"] = ps[4]
-			values["1m.rate"] = t.Rate1()
-			values["5m.rate"] = t.Rate5()
-			values["15m.rate"] = t.Rate15()
-			values["mean.rate"] = t.RateMean()
-		}
-		data[name] = values
-	})
-	return json.Marshal(data)
+	return json.Marshal(r.GetAll())
 }
 
 // WriteJSON writes metrics from the given registry  periodically to the
@@ -80,4 +24,8 @@ func WriteJSON(r Registry, d time.Duration, w io.Writer) {
 // io.Writer as JSON.
 func WriteJSONOnce(r Registry, w io.Writer) {
 	json.NewEncoder(w).Encode(r)
+}
+
+func (p *PrefixedRegistry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.GetAll())
 }

--- a/vendor/github.com/rcrowley/go-metrics/log.go
+++ b/vendor/github.com/rcrowley/go-metrics/log.go
@@ -1,17 +1,20 @@
 package metrics
 
 import (
-	"log"
 	"time"
 )
 
-func Log(r Registry, freq time.Duration, l *log.Logger) {
+type Logger interface {
+	Printf(format string, v ...interface{})
+}
+
+func Log(r Registry, freq time.Duration, l Logger) {
 	LogScaled(r, freq, time.Nanosecond, l)
 }
 
 // Output each metric in the given registry periodically using the given
 // logger. Print timings in `scale` units (eg time.Millisecond) rather than nanos.
-func LogScaled(r Registry, freq time.Duration, scale time.Duration, l *log.Logger) {
+func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
 	du := float64(scale)
 	duSuffix := scale.String()[1:]
 

--- a/vendor/github.com/rcrowley/go-metrics/meter.go
+++ b/vendor/github.com/rcrowley/go-metrics/meter.go
@@ -1,7 +1,9 @@
 package metrics
 
 import (
+	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -15,10 +17,13 @@ type Meter interface {
 	Rate15() float64
 	RateMean() float64
 	Snapshot() Meter
+	Stop()
 }
 
 // GetOrRegisterMeter returns an existing Meter or constructs and registers a
 // new StandardMeter.
+// Be sure to unregister the meter from the registry once it is of no use to
+// allow for garbage collection.
 func GetOrRegisterMeter(name string, r Registry) Meter {
 	if nil == r {
 		r = DefaultRegistry
@@ -27,6 +32,7 @@ func GetOrRegisterMeter(name string, r Registry) Meter {
 }
 
 // NewMeter constructs a new StandardMeter and launches a goroutine.
+// Be sure to call Stop() once the meter is of no use to allow for garbage collection.
 func NewMeter() Meter {
 	if UseNilMetrics {
 		return NilMeter{}
@@ -34,7 +40,7 @@ func NewMeter() Meter {
 	m := newStandardMeter()
 	arbiter.Lock()
 	defer arbiter.Unlock()
-	arbiter.meters = append(arbiter.meters, m)
+	arbiter.meters[m] = struct{}{}
 	if !arbiter.started {
 		arbiter.started = true
 		go arbiter.tick()
@@ -44,6 +50,8 @@ func NewMeter() Meter {
 
 // NewMeter constructs and registers a new StandardMeter and launches a
 // goroutine.
+// Be sure to unregister the meter from the registry once it is of no use to
+// allow for garbage collection.
 func NewRegisteredMeter(name string, r Registry) Meter {
 	c := NewMeter()
 	if nil == r {
@@ -56,7 +64,7 @@ func NewRegisteredMeter(name string, r Registry) Meter {
 // MeterSnapshot is a read-only copy of another Meter.
 type MeterSnapshot struct {
 	count                          int64
-	rate1, rate5, rate15, rateMean float64
+	rate1, rate5, rate15, rateMean uint64
 }
 
 // Count returns the count of events at the time the snapshot was taken.
@@ -69,22 +77,25 @@ func (*MeterSnapshot) Mark(n int64) {
 
 // Rate1 returns the one-minute moving average rate of events per second at the
 // time the snapshot was taken.
-func (m *MeterSnapshot) Rate1() float64 { return m.rate1 }
+func (m *MeterSnapshot) Rate1() float64 { return math.Float64frombits(m.rate1) }
 
 // Rate5 returns the five-minute moving average rate of events per second at
 // the time the snapshot was taken.
-func (m *MeterSnapshot) Rate5() float64 { return m.rate5 }
+func (m *MeterSnapshot) Rate5() float64 { return math.Float64frombits(m.rate5) }
 
 // Rate15 returns the fifteen-minute moving average rate of events per second
 // at the time the snapshot was taken.
-func (m *MeterSnapshot) Rate15() float64 { return m.rate15 }
+func (m *MeterSnapshot) Rate15() float64 { return math.Float64frombits(m.rate15) }
 
 // RateMean returns the meter's mean rate of events per second at the time the
 // snapshot was taken.
-func (m *MeterSnapshot) RateMean() float64 { return m.rateMean }
+func (m *MeterSnapshot) RateMean() float64 { return math.Float64frombits(m.rateMean) }
 
 // Snapshot returns the snapshot.
 func (m *MeterSnapshot) Snapshot() Meter { return m }
+
+// Stop is a no-op.
+func (m *MeterSnapshot) Stop() {}
 
 // NilMeter is a no-op Meter.
 type NilMeter struct{}
@@ -110,12 +121,15 @@ func (NilMeter) RateMean() float64 { return 0.0 }
 // Snapshot is a no-op.
 func (NilMeter) Snapshot() Meter { return NilMeter{} }
 
+// Stop is a no-op.
+func (NilMeter) Stop() {}
+
 // StandardMeter is the standard implementation of a Meter.
 type StandardMeter struct {
-	lock        sync.RWMutex
 	snapshot    *MeterSnapshot
 	a1, a5, a15 EWMA
 	startTime   time.Time
+	stopped     uint32
 }
 
 func newStandardMeter() *StandardMeter {
@@ -128,19 +142,28 @@ func newStandardMeter() *StandardMeter {
 	}
 }
 
+// Stop stops the meter, Mark() will be a no-op if you use it after being stopped.
+func (m *StandardMeter) Stop() {
+	if atomic.CompareAndSwapUint32(&m.stopped, 0, 1) {
+		arbiter.Lock()
+		delete(arbiter.meters, m)
+		arbiter.Unlock()
+	}
+}
+
 // Count returns the number of events recorded.
 func (m *StandardMeter) Count() int64 {
-	m.lock.RLock()
-	count := m.snapshot.count
-	m.lock.RUnlock()
-	return count
+	return atomic.LoadInt64(&m.snapshot.count)
 }
 
 // Mark records the occurance of n events.
 func (m *StandardMeter) Mark(n int64) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	m.snapshot.count += n
+	if atomic.LoadUint32(&m.stopped) == 1 {
+		return
+	}
+
+	atomic.AddInt64(&m.snapshot.count, n)
+
 	m.a1.Update(n)
 	m.a5.Update(n)
 	m.a15.Update(n)
@@ -149,70 +172,65 @@ func (m *StandardMeter) Mark(n int64) {
 
 // Rate1 returns the one-minute moving average rate of events per second.
 func (m *StandardMeter) Rate1() float64 {
-	m.lock.RLock()
-	rate1 := m.snapshot.rate1
-	m.lock.RUnlock()
-	return rate1
+	return math.Float64frombits(atomic.LoadUint64(&m.snapshot.rate1))
 }
 
 // Rate5 returns the five-minute moving average rate of events per second.
 func (m *StandardMeter) Rate5() float64 {
-	m.lock.RLock()
-	rate5 := m.snapshot.rate5
-	m.lock.RUnlock()
-	return rate5
+	return math.Float64frombits(atomic.LoadUint64(&m.snapshot.rate5))
 }
 
 // Rate15 returns the fifteen-minute moving average rate of events per second.
 func (m *StandardMeter) Rate15() float64 {
-	m.lock.RLock()
-	rate15 := m.snapshot.rate15
-	m.lock.RUnlock()
-	return rate15
+	return math.Float64frombits(atomic.LoadUint64(&m.snapshot.rate15))
 }
 
 // RateMean returns the meter's mean rate of events per second.
 func (m *StandardMeter) RateMean() float64 {
-	m.lock.RLock()
-	rateMean := m.snapshot.rateMean
-	m.lock.RUnlock()
-	return rateMean
+	return math.Float64frombits(atomic.LoadUint64(&m.snapshot.rateMean))
 }
 
 // Snapshot returns a read-only copy of the meter.
 func (m *StandardMeter) Snapshot() Meter {
-	m.lock.RLock()
-	snapshot := *m.snapshot
-	m.lock.RUnlock()
-	return &snapshot
+	copiedSnapshot := MeterSnapshot{
+		count:    atomic.LoadInt64(&m.snapshot.count),
+		rate1:    atomic.LoadUint64(&m.snapshot.rate1),
+		rate5:    atomic.LoadUint64(&m.snapshot.rate5),
+		rate15:   atomic.LoadUint64(&m.snapshot.rate15),
+		rateMean: atomic.LoadUint64(&m.snapshot.rateMean),
+	}
+	return &copiedSnapshot
 }
 
 func (m *StandardMeter) updateSnapshot() {
-	// should run with write lock held on m.lock
-	snapshot := m.snapshot
-	snapshot.rate1 = m.a1.Rate()
-	snapshot.rate5 = m.a5.Rate()
-	snapshot.rate15 = m.a15.Rate()
-	snapshot.rateMean = float64(snapshot.count) / time.Since(m.startTime).Seconds()
+	rate1 := math.Float64bits(m.a1.Rate())
+	rate5 := math.Float64bits(m.a5.Rate())
+	rate15 := math.Float64bits(m.a15.Rate())
+	rateMean := math.Float64bits(float64(m.Count()) / time.Since(m.startTime).Seconds())
+
+	atomic.StoreUint64(&m.snapshot.rate1, rate1)
+	atomic.StoreUint64(&m.snapshot.rate5, rate5)
+	atomic.StoreUint64(&m.snapshot.rate15, rate15)
+	atomic.StoreUint64(&m.snapshot.rateMean, rateMean)
 }
 
 func (m *StandardMeter) tick() {
-	m.lock.Lock()
-	defer m.lock.Unlock()
 	m.a1.Tick()
 	m.a5.Tick()
 	m.a15.Tick()
 	m.updateSnapshot()
 }
 
+// meterArbiter ticks meters every 5s from a single goroutine.
+// meters are references in a set for future stopping.
 type meterArbiter struct {
 	sync.RWMutex
 	started bool
-	meters  []*StandardMeter
+	meters  map[*StandardMeter]struct{}
 	ticker  *time.Ticker
 }
 
-var arbiter = meterArbiter{ticker: time.NewTicker(5e9)}
+var arbiter = meterArbiter{ticker: time.NewTicker(5e9), meters: make(map[*StandardMeter]struct{})}
 
 // Ticks meters on the scheduled interval
 func (ma *meterArbiter) tick() {
@@ -227,7 +245,7 @@ func (ma *meterArbiter) tick() {
 func (ma *meterArbiter) tickMeters() {
 	ma.RLock()
 	defer ma.RUnlock()
-	for _, meter := range ma.meters {
+	for meter := range ma.meters {
 		meter.tick()
 	}
 }

--- a/vendor/github.com/rcrowley/go-metrics/meter_test.go
+++ b/vendor/github.com/rcrowley/go-metrics/meter_test.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"math/rand"
+	"sync"
 	"testing"
 	"time"
 )
@@ -11,6 +13,43 @@ func BenchmarkMeter(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		m.Mark(1)
 	}
+}
+
+func BenchmarkMeterParallel(b *testing.B) {
+	m := NewMeter()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			m.Mark(1)
+		}
+	})
+}
+
+// exercise race detector
+func TestMeterConcurrency(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+	ma := meterArbiter{
+		ticker: time.NewTicker(time.Millisecond),
+		meters: make(map[*StandardMeter]struct{}),
+	}
+	m := newStandardMeter()
+	ma.meters[m] = struct{}{}
+	go ma.tick()
+	wg := &sync.WaitGroup{}
+	reps := 100
+	for i := 0; i < reps; i++ {
+		wg.Add(1)
+		go func(m Meter, wg *sync.WaitGroup) {
+			m.Mark(1)
+			wg.Done()
+		}(m, wg)
+		wg.Add(1)
+		go func(m Meter, wg *sync.WaitGroup) {
+			m.Stop()
+			wg.Done()
+		}(m, wg)
+	}
+	wg.Wait()
 }
 
 func TestGetOrRegisterMeter(t *testing.T) {
@@ -24,9 +63,10 @@ func TestGetOrRegisterMeter(t *testing.T) {
 func TestMeterDecay(t *testing.T) {
 	ma := meterArbiter{
 		ticker: time.NewTicker(time.Millisecond),
+		meters: make(map[*StandardMeter]struct{}),
 	}
 	m := newStandardMeter()
-	ma.meters = append(ma.meters, m)
+	ma.meters[m] = struct{}{}
 	go ma.tick()
 	m.Mark(1)
 	rateMean := m.RateMean()
@@ -41,6 +81,18 @@ func TestMeterNonzero(t *testing.T) {
 	m.Mark(3)
 	if count := m.Count(); 3 != count {
 		t.Errorf("m.Count(): 3 != %v\n", count)
+	}
+}
+
+func TestMeterStop(t *testing.T) {
+	l := len(arbiter.meters)
+	m := NewMeter()
+	if len(arbiter.meters) != l+1 {
+		t.Errorf("arbiter.meters: %d != %d\n", l+1, len(arbiter.meters))
+	}
+	m.Stop()
+	if len(arbiter.meters) != l {
+		t.Errorf("arbiter.meters: %d != %d\n", l, len(arbiter.meters))
 	}
 }
 

--- a/vendor/github.com/rcrowley/go-metrics/metrics_test.go
+++ b/vendor/github.com/rcrowley/go-metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"sync"
@@ -104,4 +105,20 @@ func BenchmarkMetrics(b *testing.B) {
 	wgD.Wait()
 	wgR.Wait()
 	wgW.Wait()
+}
+
+func Example() {
+	c := NewCounter()
+	Register("money", c)
+	c.Inc(17)
+
+	// Threadsafe registration
+	t := GetOrRegisterTimer("db.get.latency", nil)
+	t.Time(func() {})
+	t.Update(1)
+
+	fmt.Println(c.Count())
+	fmt.Println(t.Min())
+	// Output: 17
+	// 1
 }

--- a/vendor/github.com/rcrowley/go-metrics/registry.go
+++ b/vendor/github.com/rcrowley/go-metrics/registry.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 )
 
@@ -28,6 +29,9 @@ type Registry interface {
 	// Get the metric by the given name or nil if none is registered.
 	Get(string) interface{}
 
+	// GetAll metrics in the Registry.
+	GetAll() map[string]map[string]interface{}
+
 	// Gets an existing metric or registers the given one.
 	// The interface can be the metric to register if not found in registry,
 	// or a function returning the metric for lazy instantiation.
@@ -50,7 +54,7 @@ type Registry interface {
 // of names to metrics.
 type StandardRegistry struct {
 	metrics map[string]interface{}
-	mutex   sync.Mutex
+	mutex   sync.RWMutex
 }
 
 // Create a new registry.
@@ -67,8 +71,8 @@ func (r *StandardRegistry) Each(f func(string, interface{})) {
 
 // Get the metric by the given name or nil if none is registered.
 func (r *StandardRegistry) Get(name string) interface{} {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 	return r.metrics[name]
 }
 
@@ -77,6 +81,15 @@ func (r *StandardRegistry) Get(name string) interface{} {
 // The interface can be the metric to register if not found in registry,
 // or a function returning the metric for lazy instantiation.
 func (r *StandardRegistry) GetOrRegister(name string, i interface{}) interface{} {
+	// access the read lock first which should be re-entrant
+	r.mutex.RLock()
+	metric, ok := r.metrics[name]
+	r.mutex.RUnlock()
+	if ok {
+		return metric
+	}
+
+	// only take the write lock if we'll be modifying the metrics map
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	if metric, ok := r.metrics[name]; ok {
@@ -99,8 +112,8 @@ func (r *StandardRegistry) Register(name string, i interface{}) error {
 
 // Run all registered healthchecks.
 func (r *StandardRegistry) RunHealthchecks() {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 	for _, i := range r.metrics {
 		if h, ok := i.(Healthcheck); ok {
 			h.Check()
@@ -108,10 +121,72 @@ func (r *StandardRegistry) RunHealthchecks() {
 	}
 }
 
+// GetAll metrics in the Registry
+func (r *StandardRegistry) GetAll() map[string]map[string]interface{} {
+	data := make(map[string]map[string]interface{})
+	r.Each(func(name string, i interface{}) {
+		values := make(map[string]interface{})
+		switch metric := i.(type) {
+		case Counter:
+			values["count"] = metric.Count()
+		case Gauge:
+			values["value"] = metric.Value()
+		case GaugeFloat64:
+			values["value"] = metric.Value()
+		case Healthcheck:
+			values["error"] = nil
+			metric.Check()
+			if err := metric.Error(); nil != err {
+				values["error"] = metric.Error().Error()
+			}
+		case Histogram:
+			h := metric.Snapshot()
+			ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+			values["count"] = h.Count()
+			values["min"] = h.Min()
+			values["max"] = h.Max()
+			values["mean"] = h.Mean()
+			values["stddev"] = h.StdDev()
+			values["median"] = ps[0]
+			values["75%"] = ps[1]
+			values["95%"] = ps[2]
+			values["99%"] = ps[3]
+			values["99.9%"] = ps[4]
+		case Meter:
+			m := metric.Snapshot()
+			values["count"] = m.Count()
+			values["1m.rate"] = m.Rate1()
+			values["5m.rate"] = m.Rate5()
+			values["15m.rate"] = m.Rate15()
+			values["mean.rate"] = m.RateMean()
+		case Timer:
+			t := metric.Snapshot()
+			ps := t.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+			values["count"] = t.Count()
+			values["min"] = t.Min()
+			values["max"] = t.Max()
+			values["mean"] = t.Mean()
+			values["stddev"] = t.StdDev()
+			values["median"] = ps[0]
+			values["75%"] = ps[1]
+			values["95%"] = ps[2]
+			values["99%"] = ps[3]
+			values["99.9%"] = ps[4]
+			values["1m.rate"] = t.Rate1()
+			values["5m.rate"] = t.Rate5()
+			values["15m.rate"] = t.Rate15()
+			values["mean.rate"] = t.RateMean()
+		}
+		data[name] = values
+	})
+	return data
+}
+
 // Unregister the metric with the given name.
 func (r *StandardRegistry) Unregister(name string) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
+	r.stop(name)
 	delete(r.metrics, name)
 }
 
@@ -120,6 +195,7 @@ func (r *StandardRegistry) UnregisterAll() {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	for name, _ := range r.metrics {
+		r.stop(name)
 		delete(r.metrics, name)
 	}
 }
@@ -145,6 +221,19 @@ func (r *StandardRegistry) registered() map[string]interface{} {
 	return metrics
 }
 
+func (r *StandardRegistry) stop(name string) {
+	if i, ok := r.metrics[name]; ok {
+		if s, ok := i.(Stoppable); ok {
+			s.Stop()
+		}
+	}
+}
+
+// Stoppable defines the metrics which has to be stopped.
+type Stoppable interface {
+	Stop()
+}
+
 type PrefixedRegistry struct {
 	underlying Registry
 	prefix     string
@@ -166,7 +255,28 @@ func NewPrefixedChildRegistry(parent Registry, prefix string) Registry {
 
 // Call the given function for each registered metric.
 func (r *PrefixedRegistry) Each(fn func(string, interface{})) {
-	r.underlying.Each(fn)
+	wrappedFn := func(prefix string) func(string, interface{}) {
+		return func(name string, iface interface{}) {
+			if strings.HasPrefix(name, prefix) {
+				fn(name, iface)
+			} else {
+				return
+			}
+		}
+	}
+
+	baseRegistry, prefix := findPrefix(r, "")
+	baseRegistry.Each(wrappedFn(prefix))
+}
+
+func findPrefix(registry Registry, prefix string) (Registry, string) {
+	switch r := registry.(type) {
+	case *PrefixedRegistry:
+		return findPrefix(r.underlying, r.prefix+prefix)
+	case *StandardRegistry:
+		return r, prefix
+	}
+	return nil, ""
 }
 
 // Get the metric by the given name or nil if none is registered.
@@ -192,6 +302,11 @@ func (r *PrefixedRegistry) Register(name string, metric interface{}) error {
 // Run all registered healthchecks.
 func (r *PrefixedRegistry) RunHealthchecks() {
 	r.underlying.RunHealthchecks()
+}
+
+// GetAll metrics in the Registry
+func (r *PrefixedRegistry) GetAll() map[string]map[string]interface{} {
+	return r.underlying.GetAll()
 }
 
 // Unregister the metric with the given name. The name will be prefixed.

--- a/vendor/github.com/rcrowley/go-metrics/registry_test.go
+++ b/vendor/github.com/rcrowley/go-metrics/registry_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -11,6 +12,16 @@ func BenchmarkRegistry(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		r.Each(func(string, interface{}) {})
 	}
+}
+
+func BenchmarkRegistryParallel(b *testing.B) {
+	r := NewRegistry()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r.GetOrRegister("foo", NewCounter())
+		}
+	})
 }
 
 func TestRegistry(t *testing.T) {
@@ -119,6 +130,23 @@ func TestRegistryGetOrRegisterWithLazyInstantiation(t *testing.T) {
 	}
 }
 
+func TestRegistryUnregister(t *testing.T) {
+	l := len(arbiter.meters)
+	r := NewRegistry()
+	r.Register("foo", NewCounter())
+	r.Register("bar", NewMeter())
+	r.Register("baz", NewTimer())
+	if len(arbiter.meters) != l+2 {
+		t.Errorf("arbiter.meters: %d != %d\n", l+2, len(arbiter.meters))
+	}
+	r.Unregister("foo")
+	r.Unregister("bar")
+	r.Unregister("baz")
+	if len(arbiter.meters) != l {
+		t.Errorf("arbiter.meters: %d != %d\n", l+2, len(arbiter.meters))
+	}
+}
+
 func TestPrefixedChildRegistryGetOrRegister(t *testing.T) {
 	r := NewRegistry()
 	pr := NewPrefixedChildRegistry(r, "prefix.")
@@ -156,8 +184,9 @@ func TestPrefixedRegistryGetOrRegister(t *testing.T) {
 
 func TestPrefixedRegistryRegister(t *testing.T) {
 	r := NewPrefixedRegistry("prefix.")
-
 	err := r.Register("foo", NewCounter())
+	c := NewCounter()
+	Register("bar", c)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -221,5 +250,114 @@ func TestPrefixedChildRegistryGet(t *testing.T) {
 	fooCounter := pr.Get(name)
 	if fooCounter == nil {
 		t.Fatal(name)
+	}
+}
+
+func TestChildPrefixedRegistryRegister(t *testing.T) {
+	r := NewPrefixedChildRegistry(DefaultRegistry, "prefix.")
+	err := r.Register("foo", NewCounter())
+	c := NewCounter()
+	Register("bar", c)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	i := 0
+	r.Each(func(name string, m interface{}) {
+		i++
+		if name != "prefix.foo" {
+			t.Fatal(name)
+		}
+	})
+	if i != 1 {
+		t.Fatal(i)
+	}
+}
+
+func TestChildPrefixedRegistryOfChildRegister(t *testing.T) {
+	r := NewPrefixedChildRegistry(NewRegistry(), "prefix.")
+	r2 := NewPrefixedChildRegistry(r, "prefix2.")
+	err := r.Register("foo2", NewCounter())
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = r2.Register("baz", NewCounter())
+	c := NewCounter()
+	Register("bars", c)
+
+	i := 0
+	r2.Each(func(name string, m interface{}) {
+		i++
+		if name != "prefix.prefix2.baz" {
+			//t.Fatal(name)
+		}
+	})
+	if i != 1 {
+		t.Fatal(i)
+	}
+}
+
+func TestWalkRegistries(t *testing.T) {
+	r := NewPrefixedChildRegistry(NewRegistry(), "prefix.")
+	r2 := NewPrefixedChildRegistry(r, "prefix2.")
+	err := r.Register("foo2", NewCounter())
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = r2.Register("baz", NewCounter())
+	c := NewCounter()
+	Register("bars", c)
+
+	_, prefix := findPrefix(r2, "")
+	if "prefix.prefix2." != prefix {
+		t.Fatal(prefix)
+	}
+}
+
+func TestConcurrentRegistryAccess(t *testing.T) {
+	r := NewRegistry()
+
+	counter := NewCounter()
+
+	signalChan := make(chan struct{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(dowork chan struct{}) {
+			defer wg.Done()
+			iface := r.GetOrRegister("foo", counter)
+			retCounter, ok := iface.(Counter)
+			if !ok {
+				t.Fatal("Expected a Counter type")
+			}
+			if retCounter != counter {
+				t.Fatal("Counter references don't match")
+			}
+		}(signalChan)
+	}
+
+	close(signalChan) // Closing will cause all go routines to execute at the same time
+	wg.Wait()         // Wait for all go routines to do their work
+
+	// At the end of the test we should still only have a single "foo" Counter
+	i := 0
+	r.Each(func(name string, iface interface{}) {
+		i++
+		if "foo" != name {
+			t.Fatal(name)
+		}
+		if _, ok := iface.(Counter); !ok {
+			t.Fatal(iface)
+		}
+	})
+	if 1 != i {
+		t.Fatal(i)
+	}
+	r.Unregister("foo")
+	i = 0
+	r.Each(func(string, interface{}) { i++ })
+	if 0 != i {
+		t.Fatal(i)
 	}
 }

--- a/vendor/github.com/rcrowley/go-metrics/sample.go
+++ b/vendor/github.com/rcrowley/go-metrics/sample.go
@@ -33,7 +33,7 @@ type Sample interface {
 // priority reservoir.  See Cormode et al's "Forward Decay: A Practical Time
 // Decay Model for Streaming Systems".
 //
-// <http://www.research.att.com/people/Cormode_Graham/library/publications/CormodeShkapenyukSrivastavaXu09.pdf>
+// <http://dimacs.rutgers.edu/~graham/pubs/papers/fwddecay.pdf>
 type ExpDecaySample struct {
 	alpha         float64
 	count         int64
@@ -300,6 +300,13 @@ func SamplePercentiles(values int64Slice, ps []float64) []float64 {
 type SampleSnapshot struct {
 	count  int64
 	values []int64
+}
+
+func NewSampleSnapshot(count int64, values []int64) *SampleSnapshot {
+	return &SampleSnapshot{
+		count:  count,
+		values: values,
+	}
 }
 
 // Clear panics.

--- a/vendor/github.com/rcrowley/go-metrics/timer.go
+++ b/vendor/github.com/rcrowley/go-metrics/timer.go
@@ -19,6 +19,7 @@ type Timer interface {
 	RateMean() float64
 	Snapshot() Timer
 	StdDev() float64
+	Stop()
 	Sum() int64
 	Time(func())
 	Update(time.Duration)
@@ -28,6 +29,8 @@ type Timer interface {
 
 // GetOrRegisterTimer returns an existing Timer or constructs and registers a
 // new StandardTimer.
+// Be sure to unregister the meter from the registry once it is of no use to
+// allow for garbage collection.
 func GetOrRegisterTimer(name string, r Registry) Timer {
 	if nil == r {
 		r = DefaultRegistry
@@ -36,6 +39,7 @@ func GetOrRegisterTimer(name string, r Registry) Timer {
 }
 
 // NewCustomTimer constructs a new StandardTimer from a Histogram and a Meter.
+// Be sure to call Stop() once the timer is of no use to allow for garbage collection.
 func NewCustomTimer(h Histogram, m Meter) Timer {
 	if UseNilMetrics {
 		return NilTimer{}
@@ -47,6 +51,8 @@ func NewCustomTimer(h Histogram, m Meter) Timer {
 }
 
 // NewRegisteredTimer constructs and registers a new StandardTimer.
+// Be sure to unregister the meter from the registry once it is of no use to
+// allow for garbage collection.
 func NewRegisteredTimer(name string, r Registry) Timer {
 	c := NewTimer()
 	if nil == r {
@@ -58,6 +64,7 @@ func NewRegisteredTimer(name string, r Registry) Timer {
 
 // NewTimer constructs a new StandardTimer using an exponentially-decaying
 // sample with the same reservoir size and alpha as UNIX load averages.
+// Be sure to call Stop() once the timer is of no use to allow for garbage collection.
 func NewTimer() Timer {
 	if UseNilMetrics {
 		return NilTimer{}
@@ -111,6 +118,9 @@ func (NilTimer) Snapshot() Timer { return NilTimer{} }
 
 // StdDev is a no-op.
 func (NilTimer) StdDev() float64 { return 0.0 }
+
+// Stop is a no-op.
+func (NilTimer) Stop() {}
 
 // Sum is a no-op.
 func (NilTimer) Sum() int64 { return 0 }
@@ -201,6 +211,11 @@ func (t *StandardTimer) StdDev() float64 {
 	return t.histogram.StdDev()
 }
 
+// Stop stops the meter.
+func (t *StandardTimer) Stop() {
+	t.meter.Stop()
+}
+
 // Sum returns the sum in the sample.
 func (t *StandardTimer) Sum() int64 {
 	return t.histogram.Sum()
@@ -287,6 +302,9 @@ func (t *TimerSnapshot) Snapshot() Timer { return t }
 // StdDev returns the standard deviation of the values at the time the snapshot
 // was taken.
 func (t *TimerSnapshot) StdDev() float64 { return t.histogram.StdDev() }
+
+// Stop is a no-op.
+func (t *TimerSnapshot) Stop() {}
 
 // Sum returns the sum at the time the snapshot was taken.
 func (t *TimerSnapshot) Sum() int64 { return t.histogram.Sum() }

--- a/vendor/github.com/rcrowley/go-metrics/timer_test.go
+++ b/vendor/github.com/rcrowley/go-metrics/timer_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -28,6 +29,18 @@ func TestTimerExtremes(t *testing.T) {
 	tm.Update(0)
 	if stdDev := tm.StdDev(); 4.611686018427388e+18 != stdDev {
 		t.Errorf("tm.StdDev(): 4.611686018427388e+18 != %v\n", stdDev)
+	}
+}
+
+func TestTimerStop(t *testing.T) {
+	l := len(arbiter.meters)
+	tm := NewTimer()
+	if len(arbiter.meters) != l+1 {
+		t.Errorf("arbiter.meters: %d != %d\n", l+1, len(arbiter.meters))
+	}
+	tm.Stop()
+	if len(arbiter.meters) != l {
+		t.Errorf("arbiter.meters: %d != %d\n", l, len(arbiter.meters))
 	}
 }
 
@@ -78,4 +91,11 @@ func TestTimerZero(t *testing.T) {
 	if rateMean := tm.RateMean(); 0.0 != rateMean {
 		t.Errorf("tm.RateMean(): 0.0 != %v\n", rateMean)
 	}
+}
+
+func ExampleGetOrRegisterTimer() {
+	m := "account.create.latency"
+	t := GetOrRegisterTimer(m, nil)
+	t.Update(47)
+	fmt.Println(t.Max()) // Output: 47
 }

--- a/vendor/github.com/rcrowley/go-metrics/validate.sh
+++ b/vendor/github.com/rcrowley/go-metrics/validate.sh
@@ -7,4 +7,4 @@ GOFMT_LINES=`gofmt -l . | wc -l | xargs`
 test $GOFMT_LINES -eq 0 || echo "gofmt needs to be run, ${GOFMT_LINES} files have issues"
 
 # run the tests for the root package
-go test .
+go test -race .


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Related issue: https://github.com/github/orchestrator/issues/113

### Description
This is the rebased version of #146, it:
- Adds fixed collection names to avoid errors when creating new ones
- Adds a write-buffer collection to store individual write-buffer counters to be either aggregated or exposed in raw format
- Adds endpoints to `metrics/instance-write-buffer/{raw,aggregated}/:seconds`
- Updates go-metrics to the latest commit (3113b8401b8a98917cde58f8bbd42a1b1c03b1fd)

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`
