### PR TITLE
AutoPseudoGTID: log warning when unable to inject

### DIFF
--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -1094,6 +1094,7 @@ func canInjectPseudoGTID(instanceKey *InstanceKey) (canInject bool, err error) {
 
 	canInject = foundAll || foundDropOnAll || foundAllOnSchema || foundDropOnSchema
 	supportedAutoPseudoGTIDWriters.Set(instanceKey.StringCode(), canInject, cache.DefaultExpiration)
+
 	return canInject, nil
 }
 
@@ -1114,6 +1115,10 @@ func CheckAndInjectPseudoGTIDOnWriter(instance *Instance) (injected bool, err er
 		return injected, log.Errore(err)
 	}
 	if !canInject {
+		if util.ClearToLog("CheckAndInjectPseudoGTIDOnWriter", instance.Key.StringCode()) {
+			log.Warningf("AutoPseudoGTID enabled, but orchestrator has no priviliges on %+v to inject pseudo-gtid", instance.Key)
+		}
+
 		return injected, nil
 	}
 	if _, err := injectPseudoGTID(instance); err != nil {


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/704

With this PR, when `AutoPseudoGTID` is enabled, `orchestrator` will issue a warning when it does not have the privileges to inject pseudo-GTID on a master box.

```
2018-11-12 08:38:44 WARNING AutoPseudoGTID enabled, but orchestrator has no priviliges on my-box:20192 to inject pseudo-gtid
```

The warnings are sparse, once per minute per box.

cc @utdrmac