### PR TITLE
on HostnameResolveMethod=none, silently skip flush

### DIFF
--- a/go/inst/resolve.go
+++ b/go/inst/resolve.go
@@ -211,7 +211,7 @@ func loadHostnameResolveCacheFromDatabase() error {
 
 func FlushNontrivialResolveCacheToDatabase() error {
 	if HostnameResolveMethodIsNone() {
-		return log.Errorf("FlushNontrivialResolveCacheToDatabase() called, but HostnameResolveMethod is %+v", config.Config.HostnameResolveMethod)
+		return nil
 	}
 	items, _ := HostnameResolveCache()
 	for hostname := range items {


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/695

When `HostnameResolveMethod=="none"`, we can just silently skip flushing of hostname resolve cache, and the existing error message is superfluous.