### PR TITLE
Fixed GTID Disable button appearance

### DIFF
--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -541,7 +541,7 @@ function openNodeModal(node) {
   $('#node_modal button[data-btn=disable-gtid]').hide();
   if (node.usingGTID) {
     $('#node_modal button[data-btn=disable-gtid]').show();
-  } else {
+  } else if (node.supportsGTID) {
     $('#node_modal button[data-btn=enable-gtid]').show();
   }
 


### PR DESCRIPTION
Fixes #713 
The GTID `Enable` button appeared on `gtid_mode=OFF`. It will now only show up when GTID is configured to run (and off course, not used by replica, i.e. `MASTER_AUTO_POSITION=0`)