### PR TITLE
Handle go version go1.11

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,8 +56,8 @@ function precheck() {
     ok=1
   fi
 
-  if ! go version | egrep -q 'go(1\.(8|9|1[0]))' ; then
-    echo "go version must be between 1.8 and 1.10"
+  if ! go version | egrep -q 'go(1\.(8|9|1[01]))' ; then
+    echo "go version must be between 1.8 and 1.11"
     ok=1
   fi
 


### PR DESCRIPTION
Current code fails with:

```
[user@host ~/src/orchestrator/src/github.com/github/orchestrator]$ ./build.sh -b
Build only; no packaging
go version must be between 1.8 and 1.10
```

With this patch it builds again.

```
[user@host ~/src/orchestrator/src/github.com/github/orchestrator]$ git checkout sjmudd/handle-go-1.11
Switched to branch 'sjmudd/handle-go-1.11'
[user@host ~/src/orchestrator/src/github.com/github/orchestrator]$ ./build.sh -b
Build only; no packaging
Building via go version go1.11 darwin/amd64
...
```