### PR TITLE
Global web message

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -256,6 +256,7 @@ type Configuration struct {
 	ConsulAclToken                             string            // ACL token used to write to Consul KV
 	ZkAddress                                  string            // UNSUPPERTED YET. Address where (single or multiple) ZooKeeper servers are found, in `srv1[:port1][,srv2[:port2]...]` format. Default port is 2181. Example: srv-a,srv-b:12181,srv-c
 	KVClusterMasterPrefix                      string            // Prefix to use for clusters' masters entries in KV stores (internal, consul, ZK), default: "mysql/master"
+	WebMessage                                 string            // If provided, will be shown on all web pages below the title bar
 }
 
 // ToJSONString will marshal this configuration as JSON
@@ -414,6 +415,7 @@ func newConfiguration() *Configuration {
 		ConsulAclToken:                        "",
 		ZkAddress:                             "",
 		KVClusterMasterPrefix:                 "mysql/master",
+		WebMessage:                            "",
 	}
 }
 

--- a/go/http/web.go
+++ b/go/http/web.go
@@ -77,6 +77,7 @@ func (this *HttpWeb) Clusters(params martini.Params, r render.Render, req *http.
 		"userId":                        getUserId(req, user),
 		"removeTextFromHostnameDisplay": config.Config.RemoveTextFromHostnameDisplay,
 		"prefix":                        this.URLPrefix,
+		"webMessage":                    config.Config.WebMessage,
 	})
 }
 
@@ -89,6 +90,7 @@ func (this *HttpWeb) ClustersAnalysis(params martini.Params, r render.Render, re
 		"userId":                        getUserId(req, user),
 		"removeTextFromHostnameDisplay": config.Config.RemoveTextFromHostnameDisplay,
 		"prefix":                        this.URLPrefix,
+		"webMessage":                    config.Config.WebMessage,
 	})
 }
 
@@ -107,6 +109,7 @@ func (this *HttpWeb) Cluster(params martini.Params, r render.Render, req *http.R
 		"removeTextFromHostnameDisplay": config.Config.RemoveTextFromHostnameDisplay,
 		"compactDisplay":                template.JSEscapeString(req.URL.Query().Get("compact")),
 		"prefix":                        this.URLPrefix,
+		"webMessage":                    config.Config.WebMessage,
 	})
 }
 
@@ -158,6 +161,7 @@ func (this *HttpWeb) ClusterPools(params martini.Params, r render.Render, req *h
 		"removeTextFromHostnameDisplay": config.Config.RemoveTextFromHostnameDisplay,
 		"compactDisplay":                template.JSEscapeString(req.URL.Query().Get("compact")),
 		"prefix":                        this.URLPrefix,
+		"webMessage":                    config.Config.WebMessage,
 	})
 }
 
@@ -175,6 +179,7 @@ func (this *HttpWeb) Search(params martini.Params, r render.Render, req *http.Re
 		"userId":              getUserId(req, user),
 		"autoshow_problems":   false,
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -187,6 +192,7 @@ func (this *HttpWeb) Discover(params martini.Params, r render.Render, req *http.
 		"userId":              getUserId(req, user),
 		"autoshow_problems":   false,
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -206,6 +212,7 @@ func (this *HttpWeb) Audit(params martini.Params, r render.Render, req *http.Req
 		"auditHostname":       params["host"],
 		"auditPort":           params["port"],
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -234,6 +241,7 @@ func (this *HttpWeb) AuditRecovery(params martini.Params, r render.Render, req *
 		"recoveryId":          recoveryId,
 		"recoveryUid":         recoveryUid,
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -258,6 +266,7 @@ func (this *HttpWeb) AuditFailureDetection(params martini.Params, r render.Rende
 		"detectionId":         detectionId,
 		"clusterAlias":        clusterAlias,
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -269,6 +278,7 @@ func (this *HttpWeb) Agents(params martini.Params, r render.Render, req *http.Re
 		"userId":              getUserId(req, user),
 		"autoshow_problems":   false,
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -281,6 +291,7 @@ func (this *HttpWeb) Agent(params martini.Params, r render.Render, req *http.Req
 		"autoshow_problems":   false,
 		"agentHost":           params["host"],
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -293,6 +304,7 @@ func (this *HttpWeb) AgentSeedDetails(params martini.Params, r render.Render, re
 		"autoshow_problems":   false,
 		"seedId":              params["seedId"],
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -304,6 +316,7 @@ func (this *HttpWeb) Seeds(params martini.Params, r render.Render, req *http.Req
 		"userId":              getUserId(req, user),
 		"autoshow_problems":   false,
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -316,6 +329,7 @@ func (this *HttpWeb) Home(params martini.Params, r render.Render, req *http.Requ
 		"userId":              getUserId(req, user),
 		"autoshow_problems":   false,
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -328,6 +342,7 @@ func (this *HttpWeb) About(params martini.Params, r render.Render, req *http.Req
 		"userId":              getUserId(req, user),
 		"autoshow_problems":   false,
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -340,6 +355,7 @@ func (this *HttpWeb) KeepCalm(params martini.Params, r render.Render, req *http.
 		"userId":              getUserId(req, user),
 		"autoshow_problems":   false,
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -352,6 +368,7 @@ func (this *HttpWeb) FAQ(params martini.Params, r render.Render, req *http.Reque
 		"userId":              getUserId(req, user),
 		"autoshow_problems":   false,
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 
@@ -364,6 +381,7 @@ func (this *HttpWeb) Status(params martini.Params, r render.Render, req *http.Re
 		"userId":              getUserId(req, user),
 		"autoshow_problems":   false,
 		"prefix":              this.URLPrefix,
+		"webMessage":          config.Config.WebMessage,
 	})
 }
 

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -1002,7 +1002,9 @@ function renderGlobalRecoveriesButton(isGlobalRecoveriesEnabled) {
 
 $(document).ready(function() {
   visualizeBrand();
-
+  if (webMessage()) {
+    addAlert(webMessage(), "warning")
+  }
   $.get(appUrl("/api/clusters-info"), function(clusters) {
     clusters = clusters || [];
 

--- a/resources/templates/layout.tmpl
+++ b/resources/templates/layout.tmpl
@@ -267,6 +267,10 @@
 		function getUserId() {
 			return "{{.userId}}";
 		}
+
+		function webMessage() {
+			return "{{.webMessage}}";
+		}
 	</script>
 	<script src="{{.prefix}}/js/instance-problems.js"></script>
 </body>


### PR DESCRIPTION
A `WebMessage` [configuration variable](https://github.com/github/orchestrator/pull/733/files#diff-275bf73f26d818144b1ddd4a37797935R259) is added. If non-empty, a web message is displayed on all web pages, just under the title bar, with given text. Example:

```json
  "WebMessage": "LOCAL TESTING",
```
![screen shot 2018-11-22 at 07 24 41](https://user-images.githubusercontent.com/2607934/48883303-d9cc9a00-ee27-11e8-9f42-359262c280b1.png)
