### PR TITLE
replace-promoted-replica-with-candidate: relocate replicas 

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -746,6 +746,7 @@ func replacePromotedReplicaWithCandidate(topologyRecovery *TopologyRecovery, dea
 
 			relocatedReplicas, _, err, _ := inst.RelocateReplicas(&promotedReplica.Key, &candidateInstance.Key, "")
 			log.Debugf("replace-promoted-replica-with-candidate: + relocated %+v replicas of %+v below %+v", len(relocatedReplicas), promotedReplica.Key, candidateInstance.Key)
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("relocated %+v replicas of %+v below %+v", len(relocatedReplicas), promotedReplica.Key, candidateInstance.Key))
 			return log.Errore(err)
 		}
 		postponedFunctionsContainer := &topologyRecovery.PostponedFunctionsContainer

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -741,7 +741,6 @@ func replacePromotedReplicaWithCandidate(topologyRecovery *TopologyRecovery, dea
 		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("success promoting %+v over %+v", candidateInstance.Key, promotedReplica.Key))
 
 		// As followup to taking over, let's relocate all the rest of the replicas under the candidate instance
-		postponedFunctionsContainer := &topologyRecovery.PostponedFunctionsContainer
 		relocateReplicasFunc := func() error {
 			log.Debugf("replace-promoted-replica-with-candidate: relocating replicas of %+v below %+v", promotedReplica.Key, candidateInstance.Key)
 
@@ -749,6 +748,7 @@ func replacePromotedReplicaWithCandidate(topologyRecovery *TopologyRecovery, dea
 			log.Debugf("replace-promoted-replica-with-candidate: + relocated %+v replicas of %+v below %+v", len(relocatedReplicas), promotedReplica.Key, candidateInstance.Key)
 			return log.Errore(err)
 		}
+		postponedFunctionsContainer := &topologyRecovery.PostponedFunctionsContainer
 		if postponedFunctionsContainer != nil {
 			postponedFunctionsContainer.AddPostponedFunction(relocateReplicasFunc, fmt.Sprintf("replace-promoted-replica-with-candidate: relocate replicas of %+v", promotedReplica.Key))
 		} else {

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -715,20 +715,36 @@ func replacePromotedReplicaWithCandidate(topologyRecovery *TopologyRecovery, dea
 		return promotedReplica, log.Errore(err)
 	}
 	if !actionRequired {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("promoted instance %+v requires no further action", promotedReplica.Key))
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("replace-promoted-replica-with-candidate: promoted instance %+v requires no further action", promotedReplica.Key))
 		return promotedReplica, nil
 	}
 
 	// Try and promote suggested candidate, if applicable and possible
-	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("promoted instance %+v is not the suggested candidate %+v. Will see what can be done", promotedReplica.Key, candidateInstance.Key))
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("replace-promoted-replica-with-candidate: promoted instance %+v is not the suggested candidate %+v. Will see what can be done", promotedReplica.Key, candidateInstance.Key))
 
 	if candidateInstance.MasterKey.Equals(&promotedReplica.Key) {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("suggested candidate %+v is replica of promoted instance %+v. Will try and take its master", candidateInstance.Key, promotedReplica.Key))
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("replace-promoted-replica-with-candidate: suggested candidate %+v is replica of promoted instance %+v. Will try and take its master", candidateInstance.Key, promotedReplica.Key))
 		candidateInstance, err = inst.TakeMaster(&candidateInstance.Key)
 		if err != nil {
 			return promotedReplica, log.Errore(err)
 		}
 		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("success promoting %+v over %+v", candidateInstance.Key, promotedReplica.Key))
+
+		// As followup to taking over, let's relocate all the rest of the replicas under the candidate instance
+		postponedFunctionsContainer := &topologyRecovery.PostponedFunctionsContainer
+		relocateReplicasFunc := func() error {
+			log.Debugf("replace-promoted-replica-with-candidate: relocating replicas of %+v below %+v", promotedReplica.Key, candidateInstance.Key)
+
+			relocatedReplicas, _, err, _ := inst.RelocateReplicas(&promotedReplica.Key, &candidateInstance.Key, "")
+			log.Debugf("replace-promoted-replica-with-candidate: + relocated %+v replicas of %+v below %+v", len(relocatedReplicas), promotedReplica.Key, candidateInstance.Key)
+			return log.Errore(err)
+		}
+		if postponedFunctionsContainer != nil {
+			postponedFunctionsContainer.AddPostponedFunction(relocateReplicasFunc, fmt.Sprintf("replace-promoted-replica-with-candidate: relocate replicas of %+v", promotedReplica.Key))
+		} else {
+			_ = relocateReplicasFunc()
+			// We do not propagate the error. It is logged, but otherwise should not fail the entire failover operation
+		}
 		return candidateInstance, nil
 	}
 


### PR DESCRIPTION
Upon a 2-step recovery (a candidate replica is promoted on top of the immediate promoted replica), we also relocate-up the remaining replicas. Better illustrated below:

Assume
```
m
+- r1
+- r2
+- r3
+- cand
```

master crashes and the immediate suggestion is to promote `r2`:
```
r2
+- r1
+- r3
+- cand
```

but `cand` is found to be a candiate, that we promote it on top of `r2`:
```
cand
+ r2
   +- r1
   +- r3
```
thus far -- the existing logic in `master` branch.

This PR adds moving `r1, r3` upwards, to replicate from `cand`, as follows:
```
cand
+ r1
+ r2
+ r3
```

The relocation of sub-replicas respects `PostponedFunctionsContainer`, and as such the operation may run asynchronously to the actual promotion of `cand`, and we can speed the availability of the writer while still rewiring the topology.