### PR TITLE
Cluster recovery indicators show up under cluster name

### DIFF
--- a/resources/public/css/orchestrator.css
+++ b/resources/public/css/orchestrator.css
@@ -659,6 +659,10 @@ body {
   font-size: 24px;
 }
 
+#cluster_subtitle {
+  font-size: 12px;
+}
+
 .arrow_box {
     position: relative;
     background: #ffffff;

--- a/resources/public/js/cluster.js
+++ b/resources/public/js/cluster.js
@@ -1413,20 +1413,6 @@ function Cluster() {
       });
     }
     {
-      var content = '';
-      if (clusterInfo.HasAutomatedMasterRecovery === true) {
-        content += '<span class="glyphicon glyphicon-heart text-info" title="Automated master recovery for this cluster ENABLED"></span>';
-      } else {
-        content += '<span class="glyphicon glyphicon-heart text-muted pull-right" title="Automated master recovery for this cluster DISABLED"></span>';
-      }
-      if (clusterInfo.HasAutomatedIntermediateMasterRecovery === true) {
-        content += '<span class="glyphicon glyphicon-heart-empty text-info" title="Automated intermediate master recovery for this cluster ENABLED"></span>';
-      } else {
-        content += '<span class="glyphicon glyphicon-heart-empty text-muted pull-right" title="Automated intermediate master recovery for this cluster DISABLED"></span>';
-      }
-      addSidebarInfoPopoverContent(content, "glyphs", false);
-    }
-    {
       var content = currentClusterName();
       addSidebarInfoPopoverContent(content, "cluster-name", true);
     }
@@ -1733,6 +1719,20 @@ function Cluster() {
 
       if (!isAnonymized()) {
         $("#cluster_name").text(visualAlias);
+        var clusterSubtitle = '';
+        if (clusterInfo.HasAutomatedMasterRecovery === true) {
+          clusterSubtitle += '<span class="glyphicon glyphicon-heart text-info" title="Automated master recovery for this cluster ENABLED"></span>';
+        } else {
+          clusterSubtitle += '<span class="glyphicon glyphicon-heart text-muted pull-right" title="Automated master recovery for this cluster DISABLED"></span>';
+        }
+        if (clusterInfo.HasAutomatedIntermediateMasterRecovery === true) {
+          clusterSubtitle += '<span class="glyphicon glyphicon-heart-empty text-info" title="Automated intermediate master recovery for this cluster ENABLED"></span>';
+        } else {
+          clusterSubtitle += '<span class="glyphicon glyphicon-heart-empty text-muted pull-right" title="Automated intermediate master recovery for this cluster DISABLED"></span>';
+        }
+        $("#cluster_subtitle").append(clusterSubtitle)
+
+
         $("#dropdown-context").append('<li><a data-command="change-cluster-alias" data-alias="' + clusterInfo.ClusterAlias + '">Alias: ' + alias + '</a></li>');
       }
       $("#dropdown-context").append('<li><a href="' + appUrl('/web/cluster-pools/' + currentClusterName()) + '">Pools</a></li>');

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -451,6 +451,15 @@ function openNodeModal(node) {
     });
     return false;
   });
+  $('#node_modal [data-btn=gtid-errant-inject-empty]').click(function() {
+    var message = "<p>Are you sure you wish to inject empty transactions on the master of this cluster?";
+    bootbox.confirm(message, function(confirm) {
+      if (confirm) {
+        apiCommand("/api/gtid-errant-inject-empty/" + node.Key.Hostname + "/" + node.Key.Port);
+      }
+    });
+    return false;
+  });
   $('#node_modal button[data-btn=set-read-only]').click(function() {
     apiCommand("/api/set-read-only/" + node.Key.Hostname + "/" + node.Key.Port);
   });
@@ -976,7 +985,7 @@ function renderGlobalRecoveriesButton(isGlobalRecoveriesEnabled) {
   if (isGlobalRecoveriesEnabled) {
     iconContainer
       .prop("title", "Global Recoveries Enabled")
-      .addClass("glyphicon-heart")
+      .addClass("glyphicon-ok-sign")
       .removeClass("hidden")
       .click(function(event) {
         bootbox.confirm("<h3>Global Recoveries</h3>Are you sure you want to <strong>disable</strong> global recoveries?", function(confirm) {
@@ -988,7 +997,7 @@ function renderGlobalRecoveriesButton(isGlobalRecoveriesEnabled) {
   } else {
     iconContainer
       .prop("title", "Global Recoveries Disabled")
-      .addClass("glyphicon-heart-empty")
+      .addClass("glyphicon-remove-sign")
       .removeClass("hidden")
       .click(function(event) {
         bootbox.confirm("<h3>Global Recoveries</h3>Are you sure you want to enable global recoveries?", function(confirm) {

--- a/resources/templates/cluster.tmpl
+++ b/resources/templates/cluster.tmpl
@@ -37,6 +37,7 @@
 
 <div id="cluster_name_info">
 	<div id="cluster_name" class="text-muted"></div>
+	<div id="cluster_subtitle"></div>
 	<div id="cluster_info"></div>
 </div>
 


### PR DESCRIPTION
In cluster page, there are now visual indicators showing whether the cluster has auto-recovery for master and for intermediate master.

Previously these indicators were in the sidebar.

Now they're right under the cluster name.