### PR TITLE
reset-master operation: wait for replication to stop

### DIFF
--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -258,6 +258,11 @@ func (this *Instance) ReplicaRunning() bool {
 	return this.IsReplica() && this.Slave_SQL_Running && this.Slave_IO_Running
 }
 
+// NoReplicationThreadRunning returns true when neither SQL nor IO threads are running (including the case where isn't even a replica)
+func (this *Instance) NoReplicationThreadRunning() bool {
+	return !this.Slave_SQL_Running && !this.Slave_IO_Running
+}
+
 // SQLThreadUpToDate returns true when the instance had consumed all relay logs.
 func (this *Instance) SQLThreadUpToDate() bool {
 	return this.ReadBinlogCoordinates.Equals(&this.ExecBinlogCoordinates)

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -242,7 +242,7 @@ func (instance *Instance) checkMaxScale(db *sql.DB, latency *stopwatch.NamedStop
 }
 
 // areReplicationThreadsRunning checks if both IO and SQL threads are running
-func areReplicationThreadsRunning(instanceKey *InstanceKey) (ioThreadRunning, sqlThreadRunning bool, err error) {
+func areReplicationThreadsRunning(instanceKey *InstanceKey) (ioThreadRunning bool, sqlThreadRunning bool, err error) {
 	db, err := db.OpenTopology(instanceKey.Hostname, instanceKey.Port)
 	if err != nil {
 		return ioThreadRunning, sqlThreadRunning, err

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -53,6 +53,11 @@ const (
 	errorIOTimeout         = "i/o timeout"
 )
 
+var replicationThreadStatesMapping = map[bool]string{
+	false: "No",
+	true:  "Yes",
+}
+
 var instanceReadChan = make(chan bool, backendDBConcurrency)
 var instanceWriteChan = make(chan bool, backendDBConcurrency)
 
@@ -241,18 +246,24 @@ func (instance *Instance) checkMaxScale(db *sql.DB, latency *stopwatch.NamedStop
 	return isMaxScale, resolvedHostname, err
 }
 
-// areReplicationThreadsRunning checks if both IO and SQL threads are running
-func areReplicationThreadsRunning(instanceKey *InstanceKey) (ioThreadRunning bool, sqlThreadRunning bool, err error) {
+// expectReplicationThreadsState expects both replication threads to be running, or both to be not running.
+// Specifically, it looks for both to be "Yes" or for both to be "No".
+func expectReplicationThreadsState(instanceKey *InstanceKey, expectRunning bool) (expectationMet bool, err error) {
 	db, err := db.OpenTopology(instanceKey.Hostname, instanceKey.Port)
 	if err != nil {
-		return ioThreadRunning, sqlThreadRunning, err
+		return false, err
 	}
 	err = sqlutils.QueryRowsMap(db, "show slave status", func(m sqlutils.RowMap) error {
-		ioThreadRunning = (m.GetString("Slave_IO_Running") == "Yes")
-		sqlThreadRunning = (m.GetString("Slave_SQL_Running") == "Yes")
+		ioThreadRunning := m.GetString("Slave_IO_Running")
+		sqlThreadRunning := m.GetString("Slave_SQL_Running")
+
+		if ioThreadRunning == replicationThreadStatesMapping[expectRunning] &&
+			sqlThreadRunning == replicationThreadStatesMapping[expectRunning] {
+			expectationMet = true
+		}
 		return nil
 	})
-	return ioThreadRunning, sqlThreadRunning, err
+	return expectationMet, err
 }
 
 // ReadTopologyInstanceBufferable connects to a topology MySQL instance

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -242,18 +242,17 @@ func (instance *Instance) checkMaxScale(db *sql.DB, latency *stopwatch.NamedStop
 }
 
 // areReplicationThreadsRunning checks if both IO and SQL threads are running
-func areReplicationThreadsRunning(instanceKey *InstanceKey) (replicationThreadsRunning bool, err error) {
+func areReplicationThreadsRunning(instanceKey *InstanceKey) (ioThreadRunning, sqlThreadRunning bool, err error) {
 	db, err := db.OpenTopology(instanceKey.Hostname, instanceKey.Port)
 	if err != nil {
-		return replicationThreadsRunning, err
+		return ioThreadRunning, sqlThreadRunning, err
 	}
 	err = sqlutils.QueryRowsMap(db, "show slave status", func(m sqlutils.RowMap) error {
-		ioThreadRunning := (m.GetString("Slave_IO_Running") == "Yes")
-		sqlThreadRunning := (m.GetString("Slave_SQL_Running") == "Yes")
-		replicationThreadsRunning = ioThreadRunning && sqlThreadRunning
+		ioThreadRunning = (m.GetString("Slave_IO_Running") == "Yes")
+		sqlThreadRunning = (m.GetString("Slave_SQL_Running") == "Yes")
 		return nil
 	})
-	return replicationThreadsRunning, err
+	return ioThreadRunning, sqlThreadRunning, err
 }
 
 // ReadTopologyInstanceBufferable connects to a topology MySQL instance

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1289,7 +1289,7 @@ func ErrantGTIDResetMaster(instanceKey *InstanceKey) (instance *Instance, err er
 	executedGtidSet := ""
 	masterStatusFound := false
 	replicationStopped := false
-	waitInterval := time.Millisecond * 250
+	waitInterval := time.Second * 2
 
 	if maintenanceToken, merr := BeginMaintenance(instanceKey, GetMaintenanceOwner(), "reset-master-gtid"); merr != nil {
 		err = fmt.Errorf("Cannot begin maintenance on %+v", *instanceKey)

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1289,7 +1289,7 @@ func ErrantGTIDResetMaster(instanceKey *InstanceKey) (instance *Instance, err er
 	executedGtidSet := ""
 	masterStatusFound := false
 	replicationStopped := false
-	waitInterval := time.Second * 2
+	waitInterval := time.Second * 5
 
 	if maintenanceToken, merr := BeginMaintenance(instanceKey, GetMaintenanceOwner(), "reset-master-gtid"); merr != nil {
 		err = fmt.Errorf("Cannot begin maintenance on %+v", *instanceKey)

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1288,6 +1288,7 @@ func ErrantGTIDResetMaster(instanceKey *InstanceKey) (instance *Instance, err er
 	gtidSubtract := ""
 	executedGtidSet := ""
 	masterStatusFound := false
+	replicationStopped := false
 	waitInterval := time.Millisecond * 250
 
 	if maintenanceToken, merr := BeginMaintenance(instanceKey, GetMaintenanceOwner(), "reset-master-gtid"); merr != nil {
@@ -1300,6 +1301,14 @@ func ErrantGTIDResetMaster(instanceKey *InstanceKey) (instance *Instance, err er
 	if instance.IsReplica() {
 		instance, err = StopSlave(instanceKey)
 		if err != nil {
+			goto Cleanup
+		}
+		replicationStopped, err = waitForReplicationState(instanceKey, false)
+		if err != nil {
+			goto Cleanup
+		}
+		if !replicationStopped {
+			err = fmt.Errorf("gtid-errant-reset-master: timeout while waiting for replication to stop on %+v", instance.Key)
 			goto Cleanup
 		}
 	}

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -554,7 +554,7 @@ func ChangeMasterCredentials(instanceKey *InstanceKey, masterUser string, master
 	}
 
 	if instance.ReplicaRunning() {
-		return instance, fmt.Errorf("ChangeMasterTo: Cannot change master on: %+v because slave is running", *instanceKey)
+		return instance, fmt.Errorf("ChangeMasterTo: Cannot change master on: %+v because replication is running", *instanceKey)
 	}
 	log.Debugf("ChangeMasterTo: will attempt changing master credentials on %+v", *instanceKey)
 
@@ -582,7 +582,7 @@ func EnableMasterSSL(instanceKey *InstanceKey) (*Instance, error) {
 	}
 
 	if instance.ReplicaRunning() {
-		return instance, fmt.Errorf("EnableMasterSSL: Cannot enable SSL replication on %+v because slave is running", *instanceKey)
+		return instance, fmt.Errorf("EnableMasterSSL: Cannot enable SSL replication on %+v because replication is running", *instanceKey)
 	}
 	log.Debugf("EnableMasterSSL: Will attempt enabling SSL replication on %+v", *instanceKey)
 
@@ -609,7 +609,7 @@ func ChangeMasterTo(instanceKey *InstanceKey, masterKey *InstanceKey, masterBinl
 	}
 
 	if instance.ReplicaRunning() {
-		return instance, fmt.Errorf("ChangeMasterTo: Cannot change master on: %+v because slave is running", *instanceKey)
+		return instance, fmt.Errorf("ChangeMasterTo: Cannot change master on: %+v because replication is running", *instanceKey)
 	}
 	log.Debugf("ChangeMasterTo: will attempt changing master on %+v to %+v, %+v", *instanceKey, *masterKey, *masterBinlogCoordinates)
 	changeToMasterKey := masterKey
@@ -710,7 +710,7 @@ func ResetSlave(instanceKey *InstanceKey) (*Instance, error) {
 	}
 
 	if instance.ReplicaRunning() {
-		return instance, fmt.Errorf("Cannot reset slave on: %+v because slave is running", instanceKey)
+		return instance, fmt.Errorf("Cannot reset slave on: %+v because replication is running", instanceKey)
 	}
 
 	if *config.RuntimeCLIFlags.Noop {
@@ -743,7 +743,7 @@ func ResetMaster(instanceKey *InstanceKey) (*Instance, error) {
 	}
 
 	if instance.ReplicaRunning() {
-		return instance, fmt.Errorf("Cannot reset master on: %+v because slave is running", instanceKey)
+		return instance, fmt.Errorf("Cannot reset master on: %+v because replication is running", instanceKey)
 	}
 
 	if *config.RuntimeCLIFlags.Noop {
@@ -871,7 +871,7 @@ func DetachReplica(instanceKey *InstanceKey) (*Instance, error) {
 	}
 
 	if instance.ReplicaRunning() {
-		return instance, fmt.Errorf("Cannot detach slave on: %+v because slave is running", instanceKey)
+		return instance, fmt.Errorf("Cannot detach slave on: %+v because replication is running", instanceKey)
 	}
 
 	isDetached, _ := instance.ExecBinlogCoordinates.ExtractDetachedCoordinates()
@@ -905,7 +905,7 @@ func ReattachReplica(instanceKey *InstanceKey) (*Instance, error) {
 	}
 
 	if instance.ReplicaRunning() {
-		return instance, fmt.Errorf("Cannot (need not) reattach slave on: %+v because slave is running", instanceKey)
+		return instance, fmt.Errorf("Cannot (need not) reattach slave on: %+v because replication is running", instanceKey)
 	}
 
 	isDetached, detachedCoordinates := instance.ExecBinlogCoordinates.ExtractDetachedCoordinates()

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -380,9 +380,9 @@ func StopSlave(instanceKey *InstanceKey) (*Instance, error) {
 	return instance, err
 }
 
-// sleep immediately after START SLAVE for a capped duration, until both replication threads are running.
-// This is to give slack to IO thread to connect and begin streaming, and to SQL thread to start applying.
-// Sleep is incremental with ongoing attempt to see whether replication is already up
+// waitForReplicationState waits for both replication threads to be either running or not running, together.
+// This is useful post- `start slave` operation, ensuring both threads are actually running,
+// or post `stop slave` operation, ensuring both threads are not running.
 func waitForReplicationState(instanceKey *InstanceKey, expectedRunning bool) (expectationMet bool, err error) {
 	waitDuration := time.Second
 	waitInterval := 10 * time.Millisecond

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -383,7 +383,7 @@ func StopSlave(instanceKey *InstanceKey) (*Instance, error) {
 // waitForReplicationState waits for both replication threads to be either running or not running, together.
 // This is useful post- `start slave` operation, ensuring both threads are actually running,
 // or post `stop slave` operation, ensuring both threads are not running.
-func waitForReplicationState(instanceKey *InstanceKey, expectedRunning bool) (expectationMet bool, err error) {
+func waitForReplicationState(instanceKey *InstanceKey, expectRunning bool) (expectationMet bool, err error) {
 	waitDuration := time.Second
 	waitInterval := 10 * time.Millisecond
 	startTime := time.Now()
@@ -391,7 +391,7 @@ func waitForReplicationState(instanceKey *InstanceKey, expectedRunning bool) (ex
 	for {
 		// Since this is an incremental aggressive polling, it's OK if an occasional
 		// error is observed. We don't bail out on a single error.
-		if ioThreadRunning, sqlThreadRunning, _ := areReplicationThreadsRunning(instanceKey); ioThreadRunning == expectedRunning && sqlThreadRunning == expectedRunning {
+		if expectationMet, _ := expectReplicationThreadsState(instanceKey, expectRunning); expectationMet {
 			return true, nil
 		}
 		if time.Since(startTime)+waitInterval > waitDuration {

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -553,7 +553,7 @@ func ChangeMasterCredentials(instanceKey *InstanceKey, masterUser string, master
 		return instance, log.Errorf("Empty user in ChangeMasterCredentials() for %+v", *instanceKey)
 	}
 
-	if instance.ReplicaRunning() {
+	if !instance.NoReplicationThreadRunning() {
 		return instance, fmt.Errorf("ChangeMasterTo: Cannot change master on: %+v because replication is running", *instanceKey)
 	}
 	log.Debugf("ChangeMasterTo: will attempt changing master credentials on %+v", *instanceKey)

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -376,7 +376,7 @@ func StopSlave(instanceKey *InstanceKey) (*Instance, error) {
 	}
 	instance, err = ReadTopologyInstance(instanceKey)
 
-	log.Infof("Stopped slave on %+v, Self:%+v, Exec:%+v", *instanceKey, instance.SelfBinlogCoordinates, instance.ExecBinlogCoordinates)
+	log.Infof("Stopped replication on %+v, Self:%+v, Exec:%+v", *instanceKey, instance.SelfBinlogCoordinates, instance.ExecBinlogCoordinates)
 	return instance, err
 }
 
@@ -432,7 +432,7 @@ func StartSlave(instanceKey *InstanceKey) (*Instance, error) {
 	if err != nil {
 		return instance, log.Errore(err)
 	}
-	log.Infof("Started slave on %+v", instanceKey)
+	log.Infof("Started replication on %+v", instanceKey)
 
 	waitForReplicationState(instanceKey, true)
 


### PR DESCRIPTION
As pointed out by @ggunson , `ErrantGTIDResetMaster()` issues a `reset master` immediately following a `stop slave` operation, but without verifying that replication has indeed stopped. e.g. SQL thread could still be busy.

We've seen crashes in production at running `reset master`. 

In this PR we actively wait (or timeout) for replication to stop, before running `reset master`.