### PR TITLE
updating Dockerfile: alpine+go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,13 @@ env:
 - MYSQL_USER=root
 
 before_install:
-  - docker build -t orchestrator-travis-build .
   - mysql -e 'CREATE DATABASE IF NOT EXISTS test;'
 
 install: true
 
-script: script/cibuild
+script:
+  - script/cibuild
+  - docker build -t orchestrator-travis-build .
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.9
+go: 1.10
+
+services:
+  - docker
 
 os:
   - linux
@@ -10,6 +13,7 @@ env:
 - MYSQL_USER=root
 
 before_install:
+  - docker build -t orchestrator-travis-build .
   - mysql -e 'CREATE DATABASE IF NOT EXISTS test;'
 
 install: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # ORC_USER (default: orc_server_user): username used to login to orchestrator backend MySQL server
 # ORC_PASSWORD (default: orc_server_password): password used to login to orchestrator backend MySQL server
 
-FROM alpine:3.6
+FROM alpine:3.8
 
 ENV GOPATH=/tmp/go
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # ORC_USER (default: orc_server_user): username used to login to orchestrator backend MySQL server
 # ORC_PASSWORD (default: orc_server_password): password used to login to orchestrator backend MySQL server
 
-FROM alpine:3.8
+FROM alpine:3.6
 
 ENV GOPATH=/tmp/go
 


### PR DESCRIPTION
Solves https://github.com/github/orchestrator/issues/769

`orchestrator` now requires `go` >= `1.9`. Current Dockerfile build only pulls `go1.8`.

This PR uses `alpine3.8` in Dockerfile, which then uses `go1.10`.