### PR TITLE
ChangeMasterCredentials: fixed when server is not a replica

### DIFF
--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -553,7 +553,7 @@ func ChangeMasterCredentials(instanceKey *InstanceKey, masterUser string, master
 		return instance, log.Errorf("Empty user in ChangeMasterCredentials() for %+v", *instanceKey)
 	}
 
-	if !instance.ReplicationThreadsStopped() {
+	if instance.ReplicationThreadsExist() && !instance.ReplicationThreadsStopped() {
 		return instance, fmt.Errorf("ChangeMasterTo: Cannot change master on: %+v because replication is running", *instanceKey)
 	}
 	log.Debugf("ChangeMasterTo: will attempt changing master credentials on %+v", *instanceKey)


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/788

This fixes the `ChangeMasterCredentials()` behavior on masters. Behavior was broken by https://github.com/github/orchestrator/pull/767

cc @pasha167