### PR TITLE
LeaderURI: self identify, avoid infinite forwarding

### DIFF
--- a/go/http/raft_reverse_proxy.go
+++ b/go/http/raft_reverse_proxy.go
@@ -25,7 +25,14 @@ func raftReverseProxy(w http.ResponseWriter, r *http.Request, c martini.Context)
 	if orcraft.GetLeader() == "" {
 		return
 	}
-
+	if orcraft.LeaderURI.IsThisLeaderURI() {
+		// Although I'm not the leader, the value I see for LeaderURI is my own.
+		// I'm probably not up-to-date with my raft transaction log and don't have the latest information.
+		// But anyway, obviously not going to redirect to myself.
+		// Gonna return: this isn't ideal, because I'm not really the leader. If the user tries to
+		// run an operation they'll fail.
+		return
+	}
 	url, err := url.Parse(orcraft.LeaderURI.Get())
 	if err != nil {
 		log.Errore(err)

--- a/go/raft/raft.go
+++ b/go/raft/raft.go
@@ -62,6 +62,7 @@ type leaderURI struct {
 }
 
 var LeaderURI leaderURI
+var thisLeaderURI string // How this node identifies itself assuming it is the leader
 
 func (luri *leaderURI) Get() string {
 	luri.Lock()
@@ -73,6 +74,12 @@ func (luri *leaderURI) Set(uri string) {
 	luri.Lock()
 	defer luri.Unlock()
 	luri.uri = uri
+}
+
+func (luri *leaderURI) IsThisLeaderURI() bool {
+	luri.Lock()
+	defer luri.Unlock()
+	return luri.uri == thisLeaderURI
 }
 
 func IsRaftEnabled() bool {
@@ -139,18 +146,20 @@ func Setup(applier CommandApplier, snapshotCreatorApplier SnapshotCreatorApplier
 		return log.Errorf("failed to open raft store: %s", err.Error())
 	}
 
-	if leaderURI, err := computeLeaderURI(); err != nil {
+	thisLeaderURI, err = computeLeaderURI()
+	if err != nil {
 		return FatalRaftError(err)
-	} else {
-		leaderCh := store.raft.LeaderCh()
-		go func() {
-			for isTurnedLeader := range leaderCh {
-				if isTurnedLeader {
-					PublishCommand("leader-uri", leaderURI)
-				}
-			}
-		}()
 	}
+
+	leaderCh := store.raft.LeaderCh()
+	go func() {
+		for isTurnedLeader := range leaderCh {
+			if isTurnedLeader {
+				PublishCommand("leader-uri", thisLeaderURI)
+			}
+		}
+	}()
+
 	setupHttpClient()
 
 	atomic.StoreInt64(&raftSetupComplete, 1)


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/696

In https://github.com/github/orchestrator/issues/696, a demoted leader tries to reverse proxy HTTP requests to the leader, but the `LeaderURI` it has is its own, which leads to infinite reverse-proxy to itself.

In this PR:

- A node self-identifies its own URI.
- And can check whether the LeaderURI actually points to itself.
- And avoids an infinite loop in reverse-proxy. 

The change of behavior is:

Instead of an infinite loop, the host will attempt to serve the request. This isn't ideal either: the node is not the leader, but can't figure out who the leader is (yet). A client that attempts to run an operation during this time will get a "read only" error.

Thank you to @mia0x75 @makmanalp for illustrating the problem. Can you please test this PR?