### PR TITLE
Bugfix in orchestrator-client for authentication handling

### DIFF
--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -129,7 +129,7 @@ function get_curl_auth_params {
   fi
 
   # Test API access
-  curl "${basic_auth}" -s --head "${orchestrator_api}" 2>&1 | fgrep -q "$unauthorized_401" && \
+  curl "${requires_auth}" -s --head "${orchestrator_api}" 2>&1 | fgrep -q "$unauthorized_401" && \
     echo "$unauthorized_401" && \
     return
 


### PR DESCRIPTION
Related issue: https://github.com/github/orchestrator/issues/796

### Description

Reference the correct variable to set the appropriate flags in `curl` so basic authentication will work.
