### PR TITLE
all things equal, prefer promoting instance without errant GTID

### DIFF
--- a/go/inst/instance_topology_test.go
+++ b/go/inst/instance_topology_test.go
@@ -102,6 +102,17 @@ func TestSortInstancesDataCenterHint(t *testing.T) {
 	test.S(t).ExpectEquals(instances[0].Key, i810Key)
 }
 
+func TestSortInstancesGtidErrant(t *testing.T) {
+	instances, instancesMap := generateTestInstances()
+	for _, instance := range instances {
+		instance.ExecBinlogCoordinates = instances[0].ExecBinlogCoordinates
+		instance.GtidErrant = "00020192-1111-1111-1111-111111111111:1"
+	}
+	instancesMap[i810Key.StringCode()].GtidErrant = ""
+	sortInstances(instances)
+	test.S(t).ExpectEquals(instances[0].Key, i810Key)
+}
+
 func TestGetPriorityMajorVersionForCandidate(t *testing.T) {
 	{
 		instances, instancesMap := generateTestInstances()

--- a/go/inst/instance_utils.go
+++ b/go/inst/instance_utils.go
@@ -141,6 +141,10 @@ func (this *InstancesSorterByExec) Less(i, j int) bool {
 		if this.instances[j].DataCenter == this.dataCenter && this.instances[i].DataCenter != this.dataCenter {
 			return true
 		}
+		// Prefer if not having errant GTID
+		if this.instances[j].GtidErrant == "" && this.instances[i].GtidErrant != "" {
+			return true
+		}
 		// Prefer candidates:
 		if this.instances[j].PromotionRule.SmallerThan(this.instances[i].PromotionRule) {
 			return true


### PR DESCRIPTION
When considering instances for promotion, take errant GTID transactions into consideration: prefer promoting servers with no errant GTID transactions over servers with errant GTID.

errant GTID takes lower precedence than binlog coordinates, MySQL version, binlog format, data center.

