### PR TITLE
Supporting Consul auto DC KV distribution

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -255,6 +255,7 @@ type Configuration struct {
 	DiscoveryIgnoreReplicaHostnameFilters      []string          // Regexp filters to apply to prevent auto-discovering new replicas. Usage: unreachable servers due to firewalls, applications which trigger binlog dumps
 	ConsulAddress                              string            // Address where Consul HTTP api is found. Example: 127.0.0.1:8500
 	ConsulAclToken                             string            // ACL token used to write to Consul KV
+	ConsulCrossDataCenterDistribution          bool              // should orchestrator automatically auto-deduce all consul DCs and write KVs in all DCs
 	ZkAddress                                  string            // UNSUPPERTED YET. Address where (single or multiple) ZooKeeper servers are found, in `srv1[:port1][,srv2[:port2]...]` format. Default port is 2181. Example: srv-a,srv-b:12181,srv-c
 	KVClusterMasterPrefix                      string            // Prefix to use for clusters' masters entries in KV stores (internal, consul, ZK), default: "mysql/master"
 	WebMessage                                 string            // If provided, will be shown on all web pages below the title bar
@@ -415,6 +416,7 @@ func newConfiguration() *Configuration {
 		DiscoveryIgnoreReplicaHostnameFilters: []string{},
 		ConsulAddress:                         "",
 		ConsulAclToken:                        "",
+		ConsulCrossDataCenterDistribution:     false,
 		ZkAddress:                             "",
 		KVClusterMasterPrefix:                 "mysql/master",
 		WebMessage:                            "",

--- a/go/kv/consul.go
+++ b/go/kv/consul.go
@@ -72,6 +72,7 @@ func (this *consulStore) AddKeyValue(key string, value string) (added bool, err 
 }
 
 func (this *consulStore) DistributePairs(kvPairs [](*KVPair)) (err error) {
+	log.Debugf("kv.consulStore.DistributePairs: %d pairs", len(kvPairs))
 	if true /* && config.Config.ConsulCrossDataCenterDistribution */ {
 		datacenters, err := this.client.Catalog().Datacenters()
 		if err != nil {
@@ -84,7 +85,7 @@ func (this *consulStore) DistributePairs(kvPairs [](*KVPair)) (err error) {
 		for _, datacenter := range datacenters {
 			writeOptions := &consulapi.WriteOptions{Datacenter: datacenter}
 			for _, consulPair := range consulPairs {
-				log.Debugf("kv.consulStore.PutKeyValue: %s on %s", consulPair, datacenter)
+				log.Debugf("kv.consulStore.DistributePairs: %s on %s", consulPair, datacenter)
 				if _, e := this.client.KV().Put(consulPair, writeOptions); e != nil {
 					err = e
 				}

--- a/go/kv/consul.go
+++ b/go/kv/consul.go
@@ -84,7 +84,7 @@ func (this *consulStore) DistributePairs(kvPairs [](*KVPair)) (err error) {
 		for _, datacenter := range datacenters {
 			writeOptions := &consulapi.WriteOptions{Datacenter: datacenter}
 			for _, consulPair := range consulPairs {
-				log.Debugf("consulStore.PutKeyValue: %s on %s", consulPair, datacenter)
+				log.Debugf("kv.consulStore.PutKeyValue: %s on %s", consulPair, datacenter)
 				if _, e := this.client.KV().Put(consulPair, writeOptions); e != nil {
 					err = e
 				}

--- a/go/kv/consul.go
+++ b/go/kv/consul.go
@@ -72,7 +72,6 @@ func (this *consulStore) AddKeyValue(key string, value string) (added bool, err 
 }
 
 func (this *consulStore) DistributePairs(kvPairs [](*KVPair)) (err error) {
-	log.Debugf("kv.consulStore.DistributePairs: %d pairs", len(kvPairs))
 	if true /* && config.Config.ConsulCrossDataCenterDistribution */ {
 		datacenters, err := this.client.Catalog().Datacenters()
 		if err != nil {
@@ -85,7 +84,6 @@ func (this *consulStore) DistributePairs(kvPairs [](*KVPair)) (err error) {
 		for _, datacenter := range datacenters {
 			writeOptions := &consulapi.WriteOptions{Datacenter: datacenter}
 			for _, consulPair := range consulPairs {
-				log.Debugf("kv.consulStore.DistributePairs: %s on %s", consulPair, datacenter)
 				if _, e := this.client.KV().Put(consulPair, writeOptions); e != nil {
 					err = e
 				}

--- a/go/kv/consul.go
+++ b/go/kv/consul.go
@@ -72,7 +72,7 @@ func (this *consulStore) AddKeyValue(key string, value string) (added bool, err 
 }
 
 func (this *consulStore) DistributePairs(kvPairs [](*KVPair)) (err error) {
-	if true /* && config.Config.ConsulCrossDataCenterDistribution */ {
+	if config.Config.ConsulCrossDataCenterDistribution {
 		datacenters, err := this.client.Catalog().Datacenters()
 		if err != nil {
 			return err

--- a/go/kv/internal.go
+++ b/go/kv/internal.go
@@ -30,7 +30,10 @@ func NewInternalKVStore() KVStore {
 	return &internalKVStore{}
 }
 
-func (this *internalKVStore) PutKeyValue(key string, value string) (err error) {
+func (this *internalKVStore) PutKeyValue(key string, value string, hint KVHint) (err error) {
+	if hint == DCDistributeHint {
+		return nil
+	}
 	_, err = db.ExecOrchestrator(`
 		replace
 			into kv_store (
@@ -62,7 +65,10 @@ func (this *internalKVStore) GetKeyValue(key string) (value string, found bool, 
 	return value, found, log.Errore(err)
 }
 
-func (this *internalKVStore) AddKeyValue(key string, value string) (added bool, err error) {
+func (this *internalKVStore) AddKeyValue(key string, value string, hint KVHint) (added bool, err error) {
+	if hint == DCDistributeHint {
+		return false, nil
+	}
 	sqlResult, err := db.ExecOrchestrator(`
 		insert ignore
 			into kv_store (

--- a/go/kv/internal.go
+++ b/go/kv/internal.go
@@ -30,10 +30,7 @@ func NewInternalKVStore() KVStore {
 	return &internalKVStore{}
 }
 
-func (this *internalKVStore) PutKeyValue(key string, value string, hint KVHint) (err error) {
-	if hint == DCDistributeHint {
-		return nil
-	}
+func (this *internalKVStore) PutKeyValue(key string, value string) (err error) {
 	_, err = db.ExecOrchestrator(`
 		replace
 			into kv_store (
@@ -65,10 +62,7 @@ func (this *internalKVStore) GetKeyValue(key string) (value string, found bool, 
 	return value, found, log.Errore(err)
 }
 
-func (this *internalKVStore) AddKeyValue(key string, value string, hint KVHint) (added bool, err error) {
-	if hint == DCDistributeHint {
-		return false, nil
-	}
+func (this *internalKVStore) AddKeyValue(key string, value string) (added bool, err error) {
 	sqlResult, err := db.ExecOrchestrator(`
 		insert ignore
 			into kv_store (
@@ -86,4 +80,8 @@ func (this *internalKVStore) AddKeyValue(key string, value string, hint KVHint) 
 		return false, log.Errore(err)
 	}
 	return (rowsAffected > 0), nil
+}
+
+func (this *internalKVStore) DistributePairs(pairs [](*KVPair)) (err error) {
+	return nil
 }

--- a/go/kv/kv.go
+++ b/go/kv/kv.go
@@ -21,6 +21,13 @@ import (
 	"sync"
 )
 
+type KVHint int
+
+const (
+	NoHint KVHint = iota
+	DCDistributeHint
+)
+
 type KVPair struct {
 	Key   string
 	Value string
@@ -35,10 +42,9 @@ func (this *KVPair) String() string {
 }
 
 type KVStore interface {
-	PutKeyValue(key string, value string) (err error)
+	PutKeyValue(key string, value string, hint KVHint) (err error)
 	GetKeyValue(key string) (value string, found bool, err error)
-
-	AddKeyValue(key string, value string) (added bool, err error)
+	AddKeyValue(key string, value string, hint KVHint) (added bool, err error)
 }
 
 var kvMutex sync.Mutex
@@ -76,25 +82,25 @@ func GetValue(key string) (value string, found bool, err error) {
 	return value, found, err
 }
 
-func PutValue(key string, value string) (err error) {
+func PutValue(key string, value string, hint KVHint) (err error) {
 	for _, store := range getKVStores() {
-		if err := store.PutKeyValue(key, value); err != nil {
+		if err := store.PutKeyValue(key, value, hint); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func PutKVPair(kvPair *KVPair) (err error) {
+func PutKVPair(kvPair *KVPair, hint KVHint) (err error) {
 	if kvPair == nil {
 		return nil
 	}
-	return PutValue(kvPair.Key, kvPair.Value)
+	return PutValue(kvPair.Key, kvPair.Value, hint)
 }
 
-func AddValue(key string, value string) (err error) {
+func AddValue(key string, value string, hint KVHint) (err error) {
 	for _, store := range getKVStores() {
-		added, err := store.AddKeyValue(key, value)
+		added, err := store.AddKeyValue(key, value, hint)
 		if err != nil {
 			return err
 		}
@@ -105,9 +111,9 @@ func AddValue(key string, value string) (err error) {
 	return nil
 }
 
-func AddKVPair(kvPair *KVPair) (err error) {
+func AddKVPair(kvPair *KVPair, hint KVHint) (err error) {
 	if kvPair == nil {
 		return nil
 	}
-	return AddValue(kvPair.Key, kvPair.Value)
+	return AddValue(kvPair.Key, kvPair.Value, hint)
 }

--- a/go/kv/zk.go
+++ b/go/kv/zk.go
@@ -52,8 +52,11 @@ func NewZkStore() KVStore {
 	return store
 }
 
-func (this *zkStore) PutKeyValue(key string, value string) (err error) {
+func (this *zkStore) PutKeyValue(key string, value string, hint KVHint) (err error) {
 	if this.zook == nil {
+		return nil
+	}
+	if hint == DCDistributeHint {
 		return nil
 	}
 
@@ -75,7 +78,10 @@ func (this *zkStore) GetKeyValue(key string) (value string, found bool, err erro
 	return string(result), true, nil
 }
 
-func (this *zkStore) AddKeyValue(key string, value string) (added bool, err error) {
-	err = this.PutKeyValue(key, value)
+func (this *zkStore) AddKeyValue(key string, value string, hint KVHint) (added bool, err error) {
+	if hint == DCDistributeHint {
+		return false, nil
+	}
+	err = this.PutKeyValue(key, value, hint)
 	return (err != nil), err
 }

--- a/go/kv/zk.go
+++ b/go/kv/zk.go
@@ -52,11 +52,8 @@ func NewZkStore() KVStore {
 	return store
 }
 
-func (this *zkStore) PutKeyValue(key string, value string, hint KVHint) (err error) {
+func (this *zkStore) PutKeyValue(key string, value string) (err error) {
 	if this.zook == nil {
-		return nil
-	}
-	if hint == DCDistributeHint {
 		return nil
 	}
 
@@ -78,10 +75,11 @@ func (this *zkStore) GetKeyValue(key string) (value string, found bool, err erro
 	return string(result), true, nil
 }
 
-func (this *zkStore) AddKeyValue(key string, value string, hint KVHint) (added bool, err error) {
-	if hint == DCDistributeHint {
-		return false, nil
-	}
-	err = this.PutKeyValue(key, value, hint)
+func (this *zkStore) AddKeyValue(key string, value string) (added bool, err error) {
+	err = this.PutKeyValue(key, value)
 	return (err != nil), err
+}
+
+func (this *zkStore) DistributePairs(pairs [](*KVPair)) (err error) {
+	return nil
 }

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -262,7 +262,7 @@ func (applier *CommandApplier) putKeyValue(value []byte) interface{} {
 	if err := json.Unmarshal(value, &kvPair); err != nil {
 		return log.Errore(err)
 	}
-	err := kv.PutKVPair(&kvPair, kv.NoHint)
+	err := kv.PutKVPair(&kvPair)
 	return err
 }
 
@@ -271,7 +271,7 @@ func (applier *CommandApplier) addKeyValue(value []byte) interface{} {
 	if err := json.Unmarshal(value, &kvPair); err != nil {
 		return log.Errore(err)
 	}
-	err := kv.AddKVPair(&kvPair, kv.NoHint)
+	err := kv.AddKVPair(&kvPair)
 
 	return err
 }

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -262,7 +262,7 @@ func (applier *CommandApplier) putKeyValue(value []byte) interface{} {
 	if err := json.Unmarshal(value, &kvPair); err != nil {
 		return log.Errore(err)
 	}
-	err := kv.PutKVPair(&kvPair)
+	err := kv.PutKVPair(&kvPair, kv.NoHint)
 	return err
 }
 
@@ -271,7 +271,7 @@ func (applier *CommandApplier) addKeyValue(value []byte) interface{} {
 	if err := json.Unmarshal(value, &kvPair); err != nil {
 		return log.Errore(err)
 	}
-	err := kv.AddKVPair(&kvPair)
+	err := kv.AddKVPair(&kvPair, kv.NoHint)
 
 	return err
 }

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -438,13 +438,14 @@ func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVP
 		if orcraft.IsRaftEnabled() {
 			_, err = orcraft.PublishCommand(command, kvPair)
 		} else {
-			err = applyFunc(kvPair)
+			err = applyFunc(kvPair, kv.NoHint)
 		}
 		if err == nil {
 			submittedCount++
 		} else {
 			selectedError = err
 		}
+		applyFunc(kvPair, kv.DCDistributeHint)
 	}
 	return kvPairs, submittedCount, log.Errore(selectedError)
 }

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -437,7 +437,7 @@ func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVP
 			log.Debugf("kv.SubmitMastersToKvStores: searching pair in cache %+v: not found", kvPair)
 			log.Debugf("kv.SubmitMastersToKvStores: searching pair in kv store %+v", kvPair)
 			v, found, err := kv.GetValue(kvPair.Key)
-			log.Debugf("kv.SubmitMastersToKvStores: searching pair in kv store %+v: v=%+v, found=%+v, err=%+v", kvPair, v, found, err)
+			log.Debugf("kv.SubmitMastersToKvStores: searching pair in kv store %+v: v=%+v, found=%+v, err=%+v, isval: %+v", kvPair, v, found, err, v == kvPair.Value)
 			if err == nil && found && v == kvPair.Value {
 				// Already has the right value.
 				kvFoundCache.Set(kvPair.Key, true, cache.DefaultExpiration)

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -416,12 +416,6 @@ func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVP
 	if err != nil {
 		return kvPairs, submittedCount, log.Errore(err)
 	}
-	command := "add-key-value"
-	applyFunc := kv.AddKVPair
-	if force {
-		command = "put-key-value"
-		applyFunc = kv.PutKVPair
-	}
 	var selectedError error
 	var submitKvPairs [](*kv.KVPair)
 	for _, kvPair := range kvPairs {
@@ -450,9 +444,9 @@ func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVP
 	log.Debugf("kv.SubmitMastersToKvStores: %s, %d submitKvPairs", clusterName, len(submitKvPairs))
 	for _, kvPair := range submitKvPairs {
 		if orcraft.IsRaftEnabled() {
-			_, err = orcraft.PublishCommand(command, kvPair)
+			_, err = orcraft.PublishCommand("put-key-value", kvPair)
 		} else {
-			err = applyFunc(kvPair)
+			err = kv.PutKVPair(kvPair)
 		}
 		if err == nil {
 			submittedCount++

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -410,7 +410,9 @@ func InjectPseudoGTIDOnWriters() error {
 // This should generally only happen once in a lifetime of a cluster. Otherwise KV
 // stores are updated via failovers.
 func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVPair), submittedCount int, err error) {
+	log.Debugf("kv.SubmitMastersToKvStores: %s", clusterName)
 	kvPairs, err = inst.GetMastersKVPairs(clusterName)
+	log.Debugf("kv.SubmitMastersToKvStores: %s, %d", clusterName, len(kvPairs))
 	if err != nil {
 		return kvPairs, submittedCount, log.Errore(err)
 	}

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -410,9 +410,9 @@ func InjectPseudoGTIDOnWriters() error {
 // This should generally only happen once in a lifetime of a cluster. Otherwise KV
 // stores are updated via failovers.
 func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVPair), submittedCount int, err error) {
-	log.Debugf("kv.SubmitMastersToKvStores: %s", clusterName)
+	log.Debugf("kv.SubmitMastersToKvStores: %s, force: %+v", clusterName, force)
 	kvPairs, err = inst.GetMastersKVPairs(clusterName)
-	log.Debugf("kv.SubmitMastersToKvStores: %s, %d", clusterName, len(kvPairs))
+	log.Debugf("kv.SubmitMastersToKvStores: %s, %d pairs", clusterName, len(kvPairs))
 	if err != nil {
 		return kvPairs, submittedCount, log.Errore(err)
 	}
@@ -438,8 +438,10 @@ func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVP
 				continue
 			}
 		}
+		log.Debugf("kv.SubmitMastersToKvStores: adding pair %+v", kvPair)
 		submitKvPairs = append(submitKvPairs, kvPair)
 	}
+	log.Debugf("kv.SubmitMastersToKvStores: %s, %d submitKvPairs", clusterName, len(submitKvPairs))
 	for _, kvPair := range submitKvPairs {
 		if orcraft.IsRaftEnabled() {
 			_, err = orcraft.PublishCommand(command, kvPair)

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -428,11 +428,17 @@ func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVP
 		if !force {
 			// !force: Called periodically to auto-populate KV
 			// We'd like to avoid some overhead.
+			log.Debugf("kv.SubmitMastersToKvStores: searching pair in cache %+v", kvPair)
+
 			if _, found := kvFoundCache.Get(kvPair.Key); found {
 				// Let's not overload database with queries. Let's not overload raft with events.
 				continue
 			}
-			if v, found, err := kv.GetValue(kvPair.Key); err == nil && found && v == kvPair.Value {
+			log.Debugf("kv.SubmitMastersToKvStores: searching pair in cache %+v: not found", kvPair)
+			log.Debugf("kv.SubmitMastersToKvStores: searching pair in kv store %+v", kvPair)
+			v, found, err := kv.GetValue(kvPair.Key)
+			log.Debugf("kv.SubmitMastersToKvStores: searching pair in kv store %+v: v=%+v, found=%+v, err=%+v", kvPair, v, found, err)
+			if err == nil && found && v == kvPair.Value {
 				// Already has the right value.
 				kvFoundCache.Set(kvPair.Key, true, cache.DefaultExpiration)
 				continue

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -434,7 +434,7 @@ func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVP
 		}
 		submitKvPairs = append(submitKvPairs, kvPair)
 	}
-	log.Debugf("kv.SubmitMastersToKvStores: submitKvPairs: %+v", clusterName, len(submitKvPairs))
+	log.Debugf("kv.SubmitMastersToKvStores: submitKvPairs: %+v", len(submitKvPairs))
 	for _, kvPair := range submitKvPairs {
 		if orcraft.IsRaftEnabled() {
 			_, err = orcraft.PublishCommand("put-key-value", kvPair)

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -859,15 +859,13 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 			go orcraft.PublishCommand("async-snapshot", "")
 		} else {
 			for _, kvPair := range kvPairs {
-				err := kv.PutKVPair(kvPair, kv.NoHint)
+				err := kv.PutKVPair(kvPair)
 				log.Errore(err)
 			}
 		}
 		{
-			for _, kvPair := range kvPairs {
-				err := kv.PutKVPair(kvPair, kv.DCDistributeHint)
-				log.Errore(err)
-			}
+			err := kv.DistributePairs(kvPairs)
+			log.Errore(err)
 		}
 		if !skipProcesses {
 			// Execute post master-failover processes

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -859,11 +859,16 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 			go orcraft.PublishCommand("async-snapshot", "")
 		} else {
 			for _, kvPair := range kvPairs {
-				err := kv.PutKVPair(kvPair)
+				err := kv.PutKVPair(kvPair, kv.NoHint)
 				log.Errore(err)
 			}
 		}
-
+		{
+			for _, kvPair := range kvPairs {
+				err := kv.PutKVPair(kvPair, kv.DCDistributeHint)
+				log.Errore(err)
+			}
+		}
 		if !skipProcesses {
 			// Execute post master-failover processes
 			executeProcesses(config.Config.PostMasterFailoverProcesses, "PostMasterFailoverProcesses", topologyRecovery, false)


### PR DESCRIPTION
A new configuration variable `ConsulCrossDataCenterDistribution` (bool, default `false`) is introduced.

When enabled, the `orchestrator` leader (whether `raft`-based on not), as part of `submit-master-kv-stores`, will ask Consul to distribute the KV values to all known datacenters.

This takes advantage of Consul's `/catalog/datacenters` API: https://www.consul.io/docs/guides/datacenters.html

`orchestrator` will do its best to distribute KVs to all known datacenters, and will report up to one error.
