### PR TITLE
relocate-replicas: sanity check to avoid invalid circular replication

### DIFF
--- a/go/inst/instance_test.go
+++ b/go/inst/instance_test.go
@@ -71,6 +71,45 @@ func TestIsSmallerBinlogFormat(t *testing.T) {
 	test.S(t).ExpectFalse(iRow.IsSmallerBinlogFormat(iMixed))
 }
 
+func TestIsDescendant(t *testing.T) {
+	{
+		i57 := Instance{Key: key1, Version: "5.7"}
+		i56 := Instance{Key: key2, Version: "5.6"}
+		isDescendant := i57.IsDescendantOf(&i56)
+		test.S(t).ExpectEquals(isDescendant, false)
+	}
+	{
+		i57 := Instance{Key: key1, Version: "5.7", AncestryUUID: "00020192-1111-1111-1111-111111111111"}
+		i56 := Instance{Key: key2, Version: "5.6", ServerUUID: ""}
+		isDescendant := i57.IsDescendantOf(&i56)
+		test.S(t).ExpectEquals(isDescendant, false)
+	}
+	{
+		i57 := Instance{Key: key1, Version: "5.7", AncestryUUID: ""}
+		i56 := Instance{Key: key2, Version: "5.6", ServerUUID: "00020192-1111-1111-1111-111111111111"}
+		isDescendant := i57.IsDescendantOf(&i56)
+		test.S(t).ExpectEquals(isDescendant, false)
+	}
+	{
+		i57 := Instance{Key: key1, Version: "5.7", AncestryUUID: "00020193-2222-2222-2222-222222222222"}
+		i56 := Instance{Key: key2, Version: "5.6", ServerUUID: "00020192-1111-1111-1111-111111111111"}
+		isDescendant := i57.IsDescendantOf(&i56)
+		test.S(t).ExpectEquals(isDescendant, false)
+	}
+	{
+		i57 := Instance{Key: key1, Version: "5.7", AncestryUUID: "00020193-2222-2222-2222-222222222222,00020193-3333-3333-3333-222222222222"}
+		i56 := Instance{Key: key2, Version: "5.6", ServerUUID: "00020192-1111-1111-1111-111111111111"}
+		isDescendant := i57.IsDescendantOf(&i56)
+		test.S(t).ExpectEquals(isDescendant, false)
+	}
+	{
+		i57 := Instance{Key: key1, Version: "5.7", AncestryUUID: "00020193-2222-2222-2222-222222222222,00020192-1111-1111-1111-111111111111"}
+		i56 := Instance{Key: key2, Version: "5.6", ServerUUID: "00020192-1111-1111-1111-111111111111"}
+		isDescendant := i57.IsDescendantOf(&i56)
+		test.S(t).ExpectEquals(isDescendant, true)
+	}
+}
+
 func TestCanReplicateFrom(t *testing.T) {
 	i55 := Instance{Key: key1, Version: "5.5"}
 	i56 := Instance{Key: key2, Version: "5.6"}

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -2587,6 +2587,9 @@ func RelocateBelow(instanceKey, otherKey *InstanceKey) (*Instance, error) {
 	if err != nil || !found {
 		return instance, log.Errorf("Error reading %+v", *otherKey)
 	}
+	if other.IsDescendantOf(instance) {
+		return instance, log.Errorf("relocate: %+v is a descendant of %+v", *otherKey, instance.Key)
+	}
 	instance, err = relocateBelowInternal(instance, other)
 	if err == nil {
 		AuditOperation("relocate-below", instanceKey, fmt.Sprintf("relocated %+v below %+v", *instanceKey, *otherKey))

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -2693,6 +2693,11 @@ func RelocateReplicas(instanceKey, otherKey *InstanceKey, pattern string) (repli
 		// Nothing to do
 		return replicas, other, nil, errs
 	}
+	for _, replica := range replicas {
+		if other.IsDescendantOf(replica) {
+			return replicas, other, log.Errorf("relocate-replicas: %+v is a descendant of %+v", *otherKey, replica.Key), errs
+		}
+	}
 	replicas, err, errs = relocateReplicasInternal(replicas, instance, other)
 
 	if err == nil {


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/838

The specific `relocate-replicas` command (e.g. `relocate-replicas -i srv1 -d srv2`) will pre-verify that none of the replicas of instance `srv1` is an ancestor of `srv2`.

The check is based on `ancestry_uuid` which is based on the `server_uuid` variable, which is available `5.6` and onwards. 