### PR TITLE
Adding SingleInstanceTopologyStructureWarning

### DIFF
--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -62,6 +62,7 @@ const (
 	MultipleMajorVersionsLoggingSlaves                                   = "MultipleMajorVersionsLoggingSlaves"
 	DifferentGTIDModesStructureWarning                                   = "DifferentGTIDModesStructureWarning"
 	ErrantGTIDStructureWarning                                           = "ErrantGTIDStructureWarning"
+	SingleInstanceTopologyStructureWarning                               = "SingleInstanceTopologyStructureWarning"
 )
 
 type InstanceAnalysis struct {

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -456,12 +456,14 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			if a.IsMaster && a.CountDistinctMajorVersionsLoggingReplicas > 1 {
 				a.StructureAnalysis = append(a.StructureAnalysis, MultipleMajorVersionsLoggingSlaves)
 			}
-
 			if a.CountReplicas > 0 && (a.GTIDMode != a.MinReplicaGTIDMode || a.GTIDMode != a.MaxReplicaGTIDMode) {
 				a.StructureAnalysis = append(a.StructureAnalysis, DifferentGTIDModesStructureWarning)
 			}
 			if a.MaxReplicaGTIDErrant != "" {
 				a.StructureAnalysis = append(a.StructureAnalysis, ErrantGTIDStructureWarning)
+			}
+			if a.IsMaster && a.CountReplicas == 0 {
+				a.StructureAnalysis = append(a.StructureAnalysis, SingleInstanceTopologyStructureWarning)
 			}
 		}
 		appendAnalysis(&a)


### PR DESCRIPTION
Issue a `SingleInstanceTopologyStructureWarning` when a cluster has a single instance. This is WIP and I'm not sure how desired it is.