### PR TITLE
Modify bulk-promotion-rules api call to return the promotion rule expiry timestamp

### DIFF
--- a/go/inst/candidate_database_instance.go
+++ b/go/inst/candidate_database_instance.go
@@ -28,6 +28,7 @@ type CandidateDatabaseInstance struct {
 	Port                int
 	PromotionRule       CandidatePromotionRule
 	LastSuggestedString string
+	PromotionRuleExpiry string // generated when retrieved from database for consistency reasons
 }
 
 func NewCandidateDatabaseInstance(instanceKey *InstanceKey, promotionRule CandidatePromotionRule) *CandidateDatabaseInstance {

--- a/go/inst/candidate_database_instance_dao.go
+++ b/go/inst/candidate_database_instance_dao.go
@@ -87,16 +87,18 @@ func BulkReadCandidateDatabaseInstance() ([]CandidateDatabaseInstance, error) {
 			hostname,
 			port,
 			promotion_rule,
-			last_suggested
+			last_suggested,
+			last_suggested + INTERVAL ? MINUTE AS promotion_rule_expiry
 		FROM
 			candidate_database_instance
 	`
-	err := db.QueryOrchestrator(query, nil, func(m sqlutils.RowMap) error {
+	err := db.QueryOrchestrator(query, sqlutils.Args(config.Config.CandidateInstanceExpireMinutes), func(m sqlutils.RowMap) error {
 		cdi := CandidateDatabaseInstance{
 			Hostname:            m.GetString("hostname"),
 			Port:                m.GetInt("port"),
 			PromotionRule:       CandidatePromotionRule(m.GetString("promotion_rule")),
 			LastSuggestedString: m.GetString("last_suggested"),
+			PromotionRuleExpiry: m.GetString("promotion_rule_expiry"),
 		}
 		// add to end of candidateDatabaseInstances
 		candidateDatabaseInstances = append(candidateDatabaseInstances, cdi)


### PR DESCRIPTION
### Description

See: https://github.com/github/orchestrator/issues/842 bulk promotion rule information does not include expiry information.

This PR [briefly explain what is does]

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
