### PR TITLE
NoFailoverSupportStructureWarning, NoLoggingReplicasStructureWarning

### DIFF
--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -56,12 +56,14 @@ const (
 )
 
 const (
-	StatementAndMixedLoggingSlavesStructureWarning StructureAnalysisCode = "StatementAndMixedLoggingSlavesStructureWarning"
-	StatementAndRowLoggingSlavesStructureWarning                         = "StatementAndRowLoggingSlavesStructureWarning"
-	MixedAndRowLoggingSlavesStructureWarning                             = "MixedAndRowLoggingSlavesStructureWarning"
-	MultipleMajorVersionsLoggingSlaves                                   = "MultipleMajorVersionsLoggingSlaves"
-	DifferentGTIDModesStructureWarning                                   = "DifferentGTIDModesStructureWarning"
-	ErrantGTIDStructureWarning                                           = "ErrantGTIDStructureWarning"
+	StatementAndMixedLoggingSlavesStructureWarning     StructureAnalysisCode = "StatementAndMixedLoggingSlavesStructureWarning"
+	StatementAndRowLoggingSlavesStructureWarning                             = "StatementAndRowLoggingSlavesStructureWarning"
+	MixedAndRowLoggingSlavesStructureWarning                                 = "MixedAndRowLoggingSlavesStructureWarning"
+	MultipleMajorVersionsLoggingSlavesStructureWarning                       = "MultipleMajorVersionsLoggingSlavesStructureWarning"
+	NoLoggingReplicasStructureWarning                                        = "NoLoggingReplicasStructureWarning"
+	DifferentGTIDModesStructureWarning                                       = "DifferentGTIDModesStructureWarning"
+	ErrantGTIDStructureWarning                                               = "ErrantGTIDStructureWarning"
+	NoFailoverSupportStructureWarning                                        = "NoFailoverSupportStructureWarning"
 )
 
 type InstanceAnalysis struct {
@@ -127,6 +129,7 @@ type ReplicationAnalysis struct {
 	OracleGTIDImmediateTopology               bool
 	MariaDBGTIDImmediateTopology              bool
 	BinlogServerImmediateTopology             bool
+	CountLoggingReplicas                      uint
 	CountStatementBasedLoggingReplicas        uint
 	CountMixedBasedLoggingReplicas            uint
 	CountRowBasedLoggingReplicas              uint

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -451,7 +451,7 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			if a.IsMaster && a.CountLoggingReplicas == 0 && a.CountReplicas > 1 {
 				a.StructureAnalysis = append(a.StructureAnalysis, NoLoggingReplicasStructureWarning)
 			}
-			if a.IsMaster &&
+			if a.IsMaster && a.CountReplicas > 1 &&
 				!a.OracleGTIDImmediateTopology &&
 				!a.MariaDBGTIDImmediateTopology &&
 				!a.BinlogServerImmediateTopology &&

--- a/tests/integration/analysis-major-versions/expect_output
+++ b/tests/integration/analysis-major-versions/expect_output
@@ -1,1 +1,1 @@
-testhost:22293 (cluster testhost:22293): MultipleMajorVersionsLoggingSlaves
+testhost:22293 (cluster testhost:22293): MultipleMajorVersionsLoggingSlavesStructureWarning

--- a/tests/integration/analysis-no-failover-support/create.sql
+++ b/tests/integration/analysis-no-failover-support/create.sql
@@ -1,0 +1,1 @@
+UPDATE database_instance SET oracle_gtid=0, pseudo_gtid=0;

--- a/tests/integration/analysis-no-failover-support/expect_output
+++ b/tests/integration/analysis-no-failover-support/expect_output
@@ -1,0 +1,1 @@
+testhost:22293 (cluster testhost:22293): NoFailoverSupportStructureWarning

--- a/tests/integration/analysis-no-failover-support/extra_args
+++ b/tests/integration/analysis-no-failover-support/extra_args
@@ -1,0 +1,1 @@
+-c replication-analysis

--- a/tests/integration/analysis-no-logging-replicas/create.sql
+++ b/tests/integration/analysis-no-logging-replicas/create.sql
@@ -1,0 +1,1 @@
+UPDATE database_instance SET log_slave_updates=0;

--- a/tests/integration/analysis-no-logging-replicas/expect_output
+++ b/tests/integration/analysis-no-logging-replicas/expect_output
@@ -1,1 +1,1 @@
-testhost:22293 (cluster testhost:22293): NoFailoverSupportStructureWarning
+testhost:22293 (cluster testhost:22293): NoLoggingReplicasStructureWarning

--- a/tests/integration/analysis-no-logging-replicas/expect_output
+++ b/tests/integration/analysis-no-logging-replicas/expect_output
@@ -1,0 +1,1 @@
+testhost:22293 (cluster testhost:22293): NoFailoverSupportStructureWarning

--- a/tests/integration/analysis-no-logging-replicas/extra_args
+++ b/tests/integration/analysis-no-logging-replicas/extra_args
@@ -1,0 +1,1 @@
+-c replication-analysis


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/837

This PR introduces:

- `NoLoggingReplicasStructureWarning`: if the master has `> 1` replicas, and none has binary logs + `log_slave_updates` (which means none can take over its siblings upon failover)
- `NoFailoverSupportStructureWarning`: if there's no Oracle-GTID, MariaDB-GTID, Pseudo-GTID, binlog-server setup, and more than 1 replica: `orchestrator` has no reliable failover plan.
  (related: https://github.com/github/orchestrator/issues/824)

