### PR TITLE
Create Post Take-Master Processes Hook 

### DIFF
--- a/conf/orchestrator-sample.conf.json
+++ b/conf/orchestrator-sample.conf.json
@@ -135,7 +135,6 @@
   "ApplyMySQLPromotionAfterMasterFailover": true,
   "PreventCrossDataCenterMasterFailover": false,
   "MasterFailoverDetachSlaveMasterHost": false,
-  "PostTakeMasterProcessesEnabled": true,
   "MasterFailoverLostInstancesDowntimeMinutes": 0,
   "PostponeSlaveRecoveryOnLagMinutes": 0,
   "OSCIgnoreHostnameFilters": [],

--- a/conf/orchestrator-sample.conf.json
+++ b/conf/orchestrator-sample.conf.json
@@ -124,6 +124,9 @@
   "PostIntermediateMasterFailoverProcesses": [
     "echo 'Recovered from {failureType} on {failureCluster}. Failed: {failedHost}:{failedPort}; Successor: {successorHost}:{successorPort}' >> /tmp/recovery.log"
   ],
+  "PostTakeMasterProcesses": [
+    "echo 'Running PostTakeMasterProcesses Hook' >> /tmp/recovery.log"
+  ],
   "PostGracefulTakeoverProcesses": [
     "echo 'Planned takeover complete' >> /tmp/recovery.log"
   ],
@@ -132,6 +135,7 @@
   "ApplyMySQLPromotionAfterMasterFailover": true,
   "PreventCrossDataCenterMasterFailover": false,
   "MasterFailoverDetachSlaveMasterHost": false,
+  "PostTakeMasterProcessesEnabled": true,
   "MasterFailoverLostInstancesDowntimeMinutes": 0,
   "PostponeSlaveRecoveryOnLagMinutes": 0,
   "OSCIgnoreHostnameFilters": [],

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -232,7 +232,6 @@ type Configuration struct {
 	PostMasterFailoverProcesses                []string          // Processes to execute after doing a master failover (order of execution undefined). Uses same placeholders as PostFailoverProcesses
 	PostIntermediateMasterFailoverProcesses    []string          // Processes to execute after doing a master failover (order of execution undefined). Uses same placeholders as PostFailoverProcesses
 	PostGracefulTakeoverProcesses              []string          // Processes to execute after runnign a graceful master takeover. Uses same placeholders as PostFailoverProcesses
-	PostTakeMasterProcessesEnabled             bool              // Set to true to enable PostTakeMasterProcesses. Default false
 	PostTakeMasterProcesses                    []string          // Processes to execute after a successful Take-Master event has taken place
 	CoMasterRecoveryMustPromoteOtherCoMaster   bool              // When 'false', anything can get promoted (and candidates are prefered over others). When 'true', orchestrator will promote the other co-master or else fail
 	DetachLostSlavesAfterMasterFailover        bool              // synonym to DetachLostReplicasAfterMasterFailover
@@ -399,7 +398,6 @@ func newConfiguration() *Configuration {
 		PostFailoverProcesses:                      []string{},
 		PostUnsuccessfulFailoverProcesses:          []string{},
 		PostGracefulTakeoverProcesses:              []string{},
-		PostTakeMasterProcessesEnabled:             false,
 		PostTakeMasterProcesses:                    []string{},
 		CoMasterRecoveryMustPromoteOtherCoMaster:   true,
 		DetachLostSlavesAfterMasterFailover:        true,

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -232,6 +232,8 @@ type Configuration struct {
 	PostMasterFailoverProcesses                []string          // Processes to execute after doing a master failover (order of execution undefined). Uses same placeholders as PostFailoverProcesses
 	PostIntermediateMasterFailoverProcesses    []string          // Processes to execute after doing a master failover (order of execution undefined). Uses same placeholders as PostFailoverProcesses
 	PostGracefulTakeoverProcesses              []string          // Processes to execute after runnign a graceful master takeover. Uses same placeholders as PostFailoverProcesses
+	PostTakeMasterProcessesEnabled             bool              // Set to true to enable PostTakeMasterProcesses. Default false
+	PostTakeMasterProcesses                    []string          // Processes to execute after a successful Take-Master event has taken place
 	CoMasterRecoveryMustPromoteOtherCoMaster   bool              // When 'false', anything can get promoted (and candidates are prefered over others). When 'true', orchestrator will promote the other co-master or else fail
 	DetachLostSlavesAfterMasterFailover        bool              // synonym to DetachLostReplicasAfterMasterFailover
 	DetachLostReplicasAfterMasterFailover      bool              // Should replicas that are not to be lost in master recovery (i.e. were more up-to-date than promoted replica) be forcibly detached
@@ -397,6 +399,8 @@ func newConfiguration() *Configuration {
 		PostFailoverProcesses:                      []string{},
 		PostUnsuccessfulFailoverProcesses:          []string{},
 		PostGracefulTakeoverProcesses:              []string{},
+		PostTakeMasterProcessesEnabled:             false,
+		PostTakeMasterProcesses:                    []string{},
 		CoMasterRecoveryMustPromoteOtherCoMaster:   true,
 		DetachLostSlavesAfterMasterFailover:        true,
 		ApplyMySQLPromotionAfterMasterFailover:     true,

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -18,6 +18,7 @@ package inst
 
 import (
 	"fmt"
+	goos "os"
 	"regexp"
 	"sort"
 	"strings"
@@ -1679,20 +1680,15 @@ func TakeSiblings(instanceKey *InstanceKey) (instance *Instance, takenSiblings i
 
 // Created this function to allow a hook to be called after a successful TakeMaster event
 func TakeMasterHook(master *Instance, slave *Instance) {
-
 	masterInstance := master.Key
 	slaveInstance := slave.Key
-
-	env := []string{}
+	env := goos.Environ()
 	env = append(env, fmt.Sprintf("ORC_SUCCESSOR_HOST=%s", masterInstance))
 	env = append(env, fmt.Sprintf("ORC_FAILED_HOST=%s", slaveInstance))
-
-	successor := strings.Replace(fmt.Sprintf("%s", masterInstance), ":3306", "", -1)
-	oldmaster := strings.Replace(fmt.Sprintf("%s", slaveInstance), ":3306", "", -1)
-
+	successor := fmt.Sprintf("%s", masterInstance)
+	oldmaster := fmt.Sprintf("%s", slaveInstance)
 	if config.Config.PostTakeMasterProcesses != nil {
 		processCount := len(config.Config.PostTakeMasterProcesses)
-
 		for i, command := range config.Config.PostTakeMasterProcesses {
 			fullDescription := fmt.Sprintf("PostTakeMasterProcesses hook %d of %d", i+1, processCount)
 			log.Debugf("Take-Master: PostTakeMasterProcesses: Calling %+s", fullDescription)

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -18,6 +18,7 @@ package inst
 
 import (
 	"fmt"
+	goos "os"
 	"regexp"
 	"sort"
 	"strings"
@@ -1676,23 +1677,17 @@ func TakeSiblings(instanceKey *InstanceKey) (instance *Instance, takenSiblings i
 	return instance, len(relocatedReplicas), err
 }
 
-
 // Created this function to allow a hook to be called after a successful TakeMaster event
 func TakeMasterHook(master *Instance, slave *Instance) {
-
 	masterInstance := master.Key
 	slaveInstance := slave.Key
-
-	env := []string{}
+	env := goos.Environ()
 	env = append(env, fmt.Sprintf("ORC_SUCCESSOR_HOST=%s", masterInstance))
 	env = append(env, fmt.Sprintf("ORC_FAILED_HOST=%s", slaveInstance))
-
-	successor := strings.Replace(fmt.Sprintf("%s", masterInstance), ":3306", "", -1)
-	oldmaster := strings.Replace(fmt.Sprintf("%s", slaveInstance), ":3306", "", -1)
-
+	successor := fmt.Sprintf("%s", masterInstance)
+	oldmaster := fmt.Sprintf("%s", slaveInstance)
 	if config.Config.PostTakeMasterProcesses != nil {
 		processCount := len(config.Config.PostTakeMasterProcesses)
-
 		for i, command := range config.Config.PostTakeMasterProcesses {
 			fullDescription := fmt.Sprintf("PostTakeMasterProcesses hook %d of %d", i+1, processCount)
 			log.Debugf("Take-Master: PostTakeMasterProcesses: Calling %+s", fullDescription)
@@ -1774,7 +1769,7 @@ Cleanup:
 	if config.Config.PostTakeMasterProcessesEnabled == true {
 		TakeMasterHook(instance, masterInstance)
 	}
-	
+
 	return instance, err
 }
 

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/github/orchestrator/go/config"
+	"github.com/github/orchestrator/go/os"
 	"github.com/openark/golib/log"
 	"github.com/openark/golib/math"
 	"github.com/openark/golib/util"
@@ -1675,6 +1676,39 @@ func TakeSiblings(instanceKey *InstanceKey) (instance *Instance, takenSiblings i
 	return instance, len(relocatedReplicas), err
 }
 
+
+// Created this function to allow a hook to be called after a successful TakeMaster event
+func TakeMasterHook(master *Instance, slave *Instance) {
+
+	masterInstance := master.Key
+	slaveInstance := slave.Key
+
+	env := []string{}
+	env = append(env, fmt.Sprintf("ORC_SUCCESSOR_HOST=%s", masterInstance))
+	env = append(env, fmt.Sprintf("ORC_FAILED_HOST=%s", slaveInstance))
+
+	successor := strings.Replace(fmt.Sprintf("%s", masterInstance), ":3306", "", -1)
+	oldmaster := strings.Replace(fmt.Sprintf("%s", slaveInstance), ":3306", "", -1)
+
+	if config.Config.PostTakeMasterProcesses != nil {
+		processCount := len(config.Config.PostTakeMasterProcesses)
+
+		for i, command := range config.Config.PostTakeMasterProcesses {
+			fullDescription := fmt.Sprintf("PostTakeMasterProcesses hook %d of %d", i+1, processCount)
+			log.Debugf("Take-Master: PostTakeMasterProcesses: Calling %+s", fullDescription)
+			start := time.Now()
+			if err := os.CommandRun(command, env, successor, oldmaster); err == nil {
+				info := fmt.Sprintf("Completed %s in %v", fullDescription, time.Since(start))
+				log.Infof("Take-Master: %s", info)
+			} else {
+				info := fmt.Sprintf("Execution of PostTakeMasterProcesses failed in %v with error: %v", time.Since(start), err)
+				log.Infof("Take-Master: %s", info)
+				log.Errorf(info)
+			}
+		}
+	}
+}
+
 // TakeMaster will move an instance up the chain and cause its master to become its replica.
 // It's almost a role change, just that other replicas of either 'instance' or its master are currently unaffected
 // (they continue replicate without change)
@@ -1735,6 +1769,12 @@ Cleanup:
 	}
 	AuditOperation("take-master", instanceKey, fmt.Sprintf("took master: %+v", masterInstance.Key))
 
+	// Created this to enable a custom hook to be called after a TakeMaster success.
+	// This only runs if set to true in orchestrator.conf.json
+	if config.Config.PostTakeMasterProcessesEnabled == true {
+		TakeMasterHook(instance, masterInstance)
+	}
+	
 	return instance, err
 }
 


### PR DESCRIPTION
### Description

This PR creates a hook which would only be called upon a successful Take-Master event. This would enable custom scripts to be called at those times when a post failover hook is not called, i.e. When we do a graceful failover of an intermediary master (See #799 for full details)

This PR introduces 1 new config option:

PostTakeMasterProcesses : "some PostTakeMasterHook here"
There is an issue created for this a few months back with details on the reasoning behind this PR: #799

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`
