### PR TITLE
Add MySQLConnectTimeoutSeconds option in sample conf files.

### DIFF
--- a/conf/orchestrator-sample-sqlite.conf.json
+++ b/conf/orchestrator-sample-sqlite.conf.json
@@ -12,6 +12,7 @@
   "MySQLTopologyUseMutualTLS": false,
   "BackendDB": "sqlite",
   "SQLite3DataFile": "/usr/local/orchestrator/orchestrator.sqlite3",
+  "MySQLConnectTimeoutSeconds": 1,
   "DefaultInstancePort": 3306,
   "DiscoverByShowSlaveHosts": true,
   "InstancePollSeconds": 5,

--- a/conf/orchestrator-simple.conf.json
+++ b/conf/orchestrator-simple.conf.json
@@ -14,6 +14,7 @@
   "#": "-----",
   "#": "The above is all you need for initial setup. Below is more advanced stuff",
   "#": "-----",
+  "MySQLConnectTimeoutSeconds": 1,
   "DiscoverByShowSlaveHosts": true,
   "InstancePollSeconds": 5,
   "DiscoveryIgnoreReplicaHostnameFilters": [


### PR DESCRIPTION
From issue 823, MySQLConnectTimeoutSeconds was in:
- ./docs/configuration-sample.md
- ./conf/orchestrator-sample.conf.json
but not in:
- conf/orchestrator-sample-sqlite.conf.json
- conf/orchestrator-simple.conf.json


## A Pull Request should be associated with an Issue.

Related issue: https://github.com/github/orchestrator/issues/823


### Description

This PR add MySQLConnectTimeoutSeconds option in sample conf files.
