### PR TITLE
add curl and jq for orchestrator-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ RUN cp /usr/local/orchestrator/orchestrator-sample-sqlite.conf.json /etc/orchest
 FROM alpine:3.8
 
 RUN apk add --no-cache bash
+RUN apk add --no-cache curl
+RUN apk add --no-cache jq
 
 EXPOSE 3000
 


### PR DESCRIPTION
Related issue: https://github.com/github/orchestrator/issues/862

### Description

This pull request adds `curl` and `jq` packages allowing to make runs from inside a docker container like:

```
docker run --rm -ti orchestrator:latest  /usr/local/orchestrator/resources/bin/orchestrator-client
```

which can be very handy.
