### PR TITLE
Forget instance: accept fuzzy/partial hostnames

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1353,15 +1353,15 @@ func Cli(command string, strict bool, instance string, destination string, owner
 		}
 	case registerCliCommand("forget", "Instance management", `Forget about an instance's existence`):
 		{
-			instanceKey, _ = inst.FigureInstanceKey(instanceKey, thisInstanceKey)
 			if rawInstanceKey == nil {
 				log.Fatal("Cannot deduce instance:", instance)
 			}
-			err := inst.ForgetInstance(rawInstanceKey)
+			instanceKey, _ = inst.FigureInstanceKey(rawInstanceKey, nil)
+			err := inst.ForgetInstance(instanceKey)
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Println(rawInstanceKey.DisplayString())
+			fmt.Println(instanceKey.DisplayString())
 		}
 	case registerCliCommand("begin-maintenance", "Instance management", `Request a maintenance lock on an instance`):
 		{

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -283,9 +283,13 @@ func (this *HttpAPI) Forget(params martini.Params, r render.Render, req *http.Re
 	}
 
 	if orcraft.IsRaftEnabled() {
-		orcraft.PublishCommand("forget", instanceKey)
+		_, err = orcraft.PublishCommand("forget", instanceKey)
 	} else {
-		inst.ForgetInstance(&instanceKey)
+		err = inst.ForgetInstance(&instanceKey)
+	}
+	if err != nil {
+		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
 	}
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Instance forgotten: %+v", instanceKey), Details: instanceKey})
 }

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -124,8 +124,14 @@ var API HttpAPI = HttpAPI{}
 var discoveryMetrics = collection.CreateOrReturnCollection("DISCOVERY_METRICS")
 var queryMetrics = collection.CreateOrReturnCollection("BACKEND_WRITES")
 
-func (this *HttpAPI) getInstanceKey(host string, port string) (inst.InstanceKey, error) {
-	instanceKey, err := inst.NewResolveInstanceKeyStrings(host, port)
+func (this *HttpAPI) getInstanceKeyInternal(host string, port string, resolve bool) (inst.InstanceKey, error) {
+	var instanceKey *inst.InstanceKey
+	var err error
+	if resolve {
+		instanceKey, err = inst.NewResolveInstanceKeyStrings(host, port)
+	} else {
+		instanceKey, err = inst.NewRawInstanceKeyStrings(host, port)
+	}
 	if err != nil {
 		return emptyInstanceKey, err
 	}
@@ -133,7 +139,18 @@ func (this *HttpAPI) getInstanceKey(host string, port string) (inst.InstanceKey,
 	if err != nil {
 		return emptyInstanceKey, err
 	}
+	if instanceKey == nil {
+		return emptyInstanceKey, fmt.Errorf("Unexpected nil instanceKey in getInstanceKeyInternal(%+v, %+v, %+v)", host, port, resolve)
+	}
 	return *instanceKey, nil
+}
+
+func (this *HttpAPI) getInstanceKey(host string, port string) (inst.InstanceKey, error) {
+	return this.getInstanceKeyInternal(host, port, true)
+}
+
+func (this *HttpAPI) getNoResolveInstanceKey(host string, port string) (inst.InstanceKey, error) {
+	return this.getInstanceKeyInternal(host, port, false)
 }
 
 func getTag(params martini.Params, req *http.Request) (tag *inst.Tag, err error) {
@@ -259,15 +276,18 @@ func (this *HttpAPI) Forget(params martini.Params, r render.Render, req *http.Re
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}
-	// We ignore errors: we're looking to do a destructive operation anyhow.
-	rawInstanceKey, _ := inst.NewRawInstanceKeyStrings(params["host"], params["port"])
+	instanceKey, err := this.getNoResolveInstanceKey(params["host"], params["port"])
+	if err != nil {
+		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
 
 	if orcraft.IsRaftEnabled() {
-		orcraft.PublishCommand("forget", rawInstanceKey)
+		orcraft.PublishCommand("forget", instanceKey)
 	} else {
-		inst.ForgetInstance(rawInstanceKey)
+		inst.ForgetInstance(&instanceKey)
 	}
-	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Instance forgotten: %+v", *rawInstanceKey)})
+	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Instance forgotten: %+v", instanceKey), Details: instanceKey})
 }
 
 // ForgetCluster forgets all instacnes of a cluster


### PR DESCRIPTION
Previously, `forget` required `fqdn` of the instance to forget. The reasoning was that we wanted to avoid resolving the name, which would lead us to forgetting a different name than the name submitted to be forgotten, e.g. if we wanted to forget an old DNS name.

This PR now allows fuzzy/partial names in `forget`. `orchestrator` will attempt to find a single-matching instance, and without running name resolving.

Thus, `orchestrator-client -c forget -i my-host-123` will succeed if a hostname `my-host-123456.example.com` exists and is the _only_ server to match the partial name.

If both `my-host-123456.example.com` and `my-host-123abc.example.com` exist, that's an ambiguity and the operation aborts.

cc @ggunson 