### PR TITLE
which-cluster-alias

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1112,6 +1112,15 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			clusterName := getClusterName(clusterAlias, instanceKey)
 			fmt.Println(clusterName)
 		}
+	case registerCliCommand("which-cluster-alias", "Information", `Output the alias of the cluster an instance belongs to, or error if unknown to orchestrator`):
+		{
+			clusterName := getClusterName(clusterAlias, instanceKey)
+			clusterInfo, err := inst.ReadClusterInfo(clusterName)
+			if err != nil {
+				log.Fatale(err)
+			}
+			fmt.Println(clusterInfo.ClusterAlias)
+		}
 	case registerCliCommand("which-cluster-domain", "Information", `Output the domain name of the cluster an instance belongs to, or error if unknown to orchestrator`):
 		{
 			clusterName := getClusterName(clusterAlias, instanceKey)

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -471,6 +471,12 @@ function which_cluster {
   print_response | jq -r '.ClusterName'
 }
 
+function which_cluster_alias {
+  assert_nonempty "instance|alias" "${alias:-$instance}"
+  api "cluster-info/${alias:-$instance}"
+  print_response | jq -r '.ClusterAlias'
+}
+
 function which_cluster_master {
   assert_nonempty "instance|alias" "${alias:-$instance}"
   api "master/${alias:-$instance}"
@@ -846,6 +852,7 @@ function run_command {
     "which-broken-replicas") which_broken_replicas ;;           # Output the fully-qualified hostname:port list of broken replicas of a given instance
     "which-cluster-instances") which_cluster_instances ;;       # Output the list of instances participating in same cluster as given instance
     "which-cluster") which_cluster ;;                           # Output the name of the cluster an instance belongs to, or error if unknown to orchestrator
+    "which-cluster-alias") which_cluster_alias ;;               # Output the alias of the cluster an instance belongs to, or error if unknown to orchestrator
     "which-cluster-master") which_cluster_master ;;             # Output the name of a writable master in given cluster
     "all-clusters-masters") all_clusters_masters ;;             # List of writeable masters, one per cluster
     "all-instances") all_instances ;;                           # The complete list of known instances


### PR DESCRIPTION
`orchestrator -c which-cluster-alias` and `orchestrator-client -c which-cluster-alias` return the alias for a cluster given either `-c <cluster>` or `-i <instance>`.

The command returns error is the cluster is not found.

The result may be empty if no alias is set.