### PR TITLE
Fix comment name that doesn't match actual function name

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -1376,7 +1376,7 @@ func FindInstances(regexpPattern string) (result [](*Instance), err error) {
 	return result, nil
 }
 
-// FindFuzzyInstances return instances whose names are like the one given (host & port substrings)
+// findFuzzyInstances return instances whose names are like the one given (host & port substrings)
 // For example, the given `mydb-3:3306` might find `myhosts-mydb301-production.mycompany.com:3306`
 func findFuzzyInstances(fuzzyInstanceKey *InstanceKey) ([](*Instance), error) {
 	condition := `


### PR DESCRIPTION
Tiny weenie patch in the comment to make the function names match. `golint` and `go vet` sometimes get upset about these things.