### PR TITLE
Add support for go 1.11 and 1.12

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,8 +56,8 @@ function precheck() {
     ok=1
   fi
 
-  if ! go version | egrep -q 'go(1\.(8|9|1[0]))' ; then
-    echo "go version must be between 1.8 and 1.10"
+  if ! go version | egrep -q 'go(1\.(8|9|1[012]))' ; then
+    echo "go version must be between 1.8 and 1.12"
     ok=1
   fi
 


### PR DESCRIPTION
Current code does not support building orchestrator with go 1.12. This patch should fix that.

- [x] contributed code is using same conventions as original code
- [x] code is built via `./build.sh`
