### PR TITLE
Provide snapshot-topologies support in orchestrator-client (and via api)

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1665,11 +1665,11 @@ func (this *HttpAPI) asciiTopology(params martini.Params, r render.Render, req *
 func (this *HttpAPI) SnapshotTopologies(params martini.Params, r render.Render, req *http.Request) {
 	start := time.Now()
 	if err := inst.SnapshotTopologies(); err != nil {
-		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
+		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err), Details: fmt.Sprintf("Took %v", time.Since(start))})
 		return
 	}
 
-	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Topology Snapshot completed in %v", time.Since(start))})
+	Respond(r, &APIResponse{Code: OK, Message: "Topology Snapshot completed", Details: fmt.Sprintf("Took %v", time.Since(start))})
 }
 
 // AsciiTopology returns an ascii graph of cluster's instances

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -3644,7 +3644,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequest(m, "topology/:host/:port", this.AsciiTopology)
 	this.registerAPIRequest(m, "topology-tabulated/:clusterHint", this.AsciiTopologyTabulated)
 	this.registerAPIRequest(m, "topology-tabulated/:host/:port", this.AsciiTopologyTabulated)
-	this.regsiterAPIRequest(m, "snapshot-topologies", this.SnapshotTopologies)
+	this.registerAPIRequest(m, "snapshot-topologies", this.SnapshotTopologies)
 
 	// Key-value:
 	this.registerAPIRequest(m, "submit-masters-to-kv-stores", this.SubmitMastersToKvStores)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1661,6 +1661,16 @@ func (this *HttpAPI) asciiTopology(params martini.Params, r render.Render, req *
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Topology for cluster %s", clusterName), Details: asciiOutput})
 }
 
+// SnapshotTopologies triggers orchestrator to record a snapshot of host/master for all known hosts.
+func (this *HttpAPI) SnapshotTopologies(params martini.Params, r render.Render, req *http.Request, tabulated bool) {
+	if err := inst.SnapshotTopologies(); err != nil {
+		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
+		return
+	}
+
+	Respond(r, &APIResponse{Code: OK, Message: "Topology Snapshot Completed", Details: ""})
+}
+
 // AsciiTopology returns an ascii graph of cluster's instances
 func (this *HttpAPI) AsciiTopology(params martini.Params, r render.Render, req *http.Request) {
 	this.asciiTopology(params, r, req, false)
@@ -3634,6 +3644,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequest(m, "topology/:host/:port", this.AsciiTopology)
 	this.registerAPIRequest(m, "topology-tabulated/:clusterHint", this.AsciiTopologyTabulated)
 	this.registerAPIRequest(m, "topology-tabulated/:host/:port", this.AsciiTopologyTabulated)
+	this.regsiterAPIRequest(m, "snapshot-topologies", this.SnapshotTopologies)
 
 	// Key-value:
 	this.registerAPIRequest(m, "submit-masters-to-kv-stores", this.SubmitMastersToKvStores)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1662,13 +1662,14 @@ func (this *HttpAPI) asciiTopology(params martini.Params, r render.Render, req *
 }
 
 // SnapshotTopologies triggers orchestrator to record a snapshot of host/master for all known hosts.
-func (this *HttpAPI) SnapshotTopologies(params martini.Params, r render.Render, req *http.Request, tabulated bool) {
+func (this *HttpAPI) SnapshotTopologies(params martini.Params, r render.Render, req *http.Request) {
+	start := time.Now()
 	if err := inst.SnapshotTopologies(); err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return
 	}
 
-	Respond(r, &APIResponse{Code: OK, Message: "Topology Snapshot Completed", Details: ""})
+	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Topology Snapshot completed in %v", time.Since(start))})
 }
 
 // AsciiTopology returns an ascii graph of cluster's instances

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -378,6 +378,11 @@ function ascii_topology_tabulated {
   echo "$api_response" | jq -r '.Details'
 }
 
+function snapshot_topologies {
+  api "snapshot-topologies"
+  echo "$api_response" | jq -r '.Details'
+}
+
 function search {
   assert_nonempty "instance" "$instance"
   api "search?s=$(urlencode "$instance")"
@@ -852,6 +857,7 @@ function run_command {
 
     "topology") ascii_topology ;;                               # Show an ascii-graph of a replication topology, given a member of that topology
     "topology-tabulated") ascii_topology_tabulated ;;           # Show an ascii-graph of a replication topology, given a member of that topology, in tabulated format
+    "snapshot-topologies") snapshot_topologies ;;               # Trigger topology snapshot (recording host/master settings for all hosts)
     "clusters") clusters ;;                                     # List all clusters known to orchestrator
     "clusters-alias") clusters_alias ;;                         # List all clusters known to orchestrator
     "search") search ;;                                         # Search for instances matching given substring
@@ -958,7 +964,6 @@ function run_command {
     "raft-health") raft_health ;;                   # Whether node is part of a healthy raft group
     "raft-leader-hostname") raft_leader_hostname ;; # Get hostname of raft leader, assuming raft setup
     "raft-elect-leader") raft_elect_leader ;;       # Request raft re-elections, provide hint for new leader's identity
-
     *) fail "Unsupported command $command" ;;
   esac
 }


### PR DESCRIPTION
`orchestrator` has a `--snapshot-topologies` option not available via `orchestrator-client`.

This patch provides:
* support in `orchestrator-client` to support `--snapshot-topologies`
* support in the api interface to handle a `/api/snapshot-topologies` call which will do the same thing.

Output of `orchestrator-client` looks like:

```
$ orchestrator-client -c snapshot-topologies
Took 2.125752ms
```

Output of a call to the orchestrator api (e.g. https://orchestrator.example.com/api/snapshot-topologies`) shows:

```
{"Code":"OK","Message":"Topology Snapshot completed","Details":"Took 2.058672ms"}
```

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)     # note: using go 1.12 formatting
- [x] code is built via `./build.sh`
