### PR TITLE
Master failover: update alias

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -902,6 +902,7 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 		func() error {
 			before := analysisEntry.AnalyzedInstanceKey.StringCode()
 			after := promotedReplica.Key.StringCode()
+			inst.ReplaceClusterName(before, after)
 			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadMaster: updating cluster_alias: %v -> %v", before, after))
 			if alias := analysisEntry.ClusterDetails.ClusterAlias; alias != "" {
 				inst.SetClusterAlias(promotedReplica.Key.StringCode(), alias)


### PR DESCRIPTION
At master failover:

- On successful promotion, immediately update `database_instance` and replace old `cluster_name` with new `cluster_name`. This does not change any logic in the failover, merely speeds up the discovery/resolution of the cluster's instances as part of the new cluster.

- Push post failover hooks till after `MasterFailoverDetachReplicaMasterHost`, `ReplaceClusterName` and `SetGeneralAttribute`, all of which are immediate or near-immediate operations.

A future PR will run more concurrent operations.