### PR TITLE
force-master-failover does not require master to be writable

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1698,7 +1698,7 @@ func ForceExecuteRecovery(analysisEntry inst.ReplicationAnalysis, candidateInsta
 
 // ForceMasterFailover *trusts* master of given cluster is dead and initiates a failover
 func ForceMasterFailover(clusterName string) (topologyRecovery *TopologyRecovery, err error) {
-	clusterMasters, err := inst.ReadClusterWriteableMaster(clusterName)
+	clusterMasters, err := inst.ReadClusterMaster(clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot deduce cluster master for %+v", clusterName)
 	}


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/906

Previously on a `force-master-failover` orchestrator was expecting the existing master to be writable (`read_only=0`). It would not failover if the master was read-only.

This PR alleviates this constraint. It is OK to `force-master-failover` when the master is `read-only`.
