### PR TITLE
Add GracefulMasterTakeoverSkipSiblingTakeover option

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -248,6 +248,7 @@ type Configuration struct {
 	DelayMasterPromotionIfSQLThreadNotUpToDate bool              // when true, and a master failover takes place, if candidate master has not consumed all relay logs, delay promotion until the sql thread has caught up
 	PostponeSlaveRecoveryOnLagMinutes          uint              // Synonym to PostponeReplicaRecoveryOnLagMinutes
 	PostponeReplicaRecoveryOnLagMinutes        uint              // On crash recovery, replicas that are lagging more than given minutes are only resurrected late in the recovery process, after master/IM has been elected and processes executed. Value of 0 disables this feature
+	GracefulMasterTakeoverSkipSiblingTakeover  bool              // When doing a graceful master switchover, do not relocate siblings to the new master
 	OSCIgnoreHostnameFilters                   []string          // OSC replicas recommendation will ignore replica hostnames matching given patterns
 	GraphiteAddr                               string            // Optional; address of graphite port. If supplied, metrics will be written here
 	GraphitePath                               string            // Prefix for graphite path. May include {hostname} magic placeholder
@@ -409,6 +410,7 @@ func newConfiguration() *Configuration {
 		FailMasterPromotionIfSQLThreadNotUpToDate:  false,
 		DelayMasterPromotionIfSQLThreadNotUpToDate: false,
 		PostponeSlaveRecoveryOnLagMinutes:          0,
+		GracefulMasterTakeoverSkipSiblingTakeover:  false,
 		OSCIgnoreHostnameFilters:                   []string{},
 		GraphiteAddr:                               "",
 		GraphitePath:                               "",

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1829,7 +1829,7 @@ func GracefulMasterTakeover(clusterName string, designatedKey *inst.InstanceKey)
 		return nil, nil, fmt.Errorf("Desginated instance %+v seems to be lagging to much for thie operation. Aborting.", designatedInstance.Key)
 	}
 
-	if len(clusterMasterDirectReplicas) > 1 {
+	if len(clusterMasterDirectReplicas) > 1 && !config.Config.GracefulMasterTakeoverSkipSiblingTakeover {
 		log.Infof("GracefulMasterTakeover: Will let %+v take over its siblings", designatedInstance.Key)
 		relocatedReplicas, _, err, _ := inst.RelocateReplicas(&clusterMaster.Key, &designatedInstance.Key, "")
 		if len(relocatedReplicas) != len(clusterMasterDirectReplicas)-1 {


### PR DESCRIPTION
### A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.

Related issue: https://github.com/github/orchestrator/issues/919

> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

This PR adds the GracefulMasterTakeoverSkipSiblingTakeover, which is `false` by default, but when turned to `true` will not move siblings when doing a graceful master switchover. Read the [related issue](https://github.com/github/orchestrator/issues/919) for details on the use case.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [ ] code is tested via `go test ./go/...`
