### PR TITLE
Docker: build packages ; sysv/systemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ main
 *.pcap
 *.log
 .vendor/go19
-./bin
+/bin
+/build

--- a/Dockerfile.packaging
+++ b/Dockerfile.packaging
@@ -14,12 +14,21 @@
 # ORC_USER (default: orc_server_user): username used to login to orchestrator backend MySQL server
 # ORC_PASSWORD (default: orc_server_password): password used to login to orchestrator backend MySQL server
 
-FROM golang:1.12.6-alpine3.9
-
-ENV GOPATH=/tmp/go
+FROM alpine:3.10
 
 RUN apk update
 RUN apk upgrade
+RUN apk add --update ruby
+RUN apk add --update ruby-dev
+RUN apk add --update gcc
+RUN apk add --update libffi-dev
+RUN apk add --update make
+RUN apk add --update libc-dev
+RUN apk add --update rpm
+RUN gem install --no-ri --no-rdoc fpm
+
+ENV GOPATH=/tmp/go
+
 RUN apk add --update libcurl
 RUN apk add --update rsync
 RUN apk add --update gcc
@@ -27,27 +36,13 @@ RUN apk add --update g++
 RUN apk add --update build-base
 RUN apk add --update bash
 RUN apk add --update git
+RUN apk add --update go
+RUN apk add --update ruby-etc
+RUN apk add --update tar
 
 RUN mkdir -p $GOPATH/src/github.com/github/orchestrator
 WORKDIR $GOPATH/src/github.com/github/orchestrator
 COPY . .
 RUN bash build.sh -b -P
-RUN rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator -maxdepth 2)/ /
-RUN rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator-client -maxdepth 2)/ /
-RUN cp conf/orchestrator-sample-sqlite.conf.json /etc/orchestrator.conf.json
-
-FROM alpine:3.8
-
-RUN apk add --no-cache bash
-RUN apk add --no-cache curl
-RUN apk add --no-cache jq
-
-EXPOSE 3000
-
-COPY --from=0 /usr/local/orchestrator /usr/local/orchestrator
-COPY --from=0 /usr/bin/orchestrator-client /usr/bin/orchestrator-client
-COPY --from=0 /etc/orchestrator.conf.json /etc/orchestrator.conf.json
-
-WORKDIR /usr/local/orchestrator
-ADD docker/entrypoint.sh /entrypoint.sh
-CMD /entrypoint.sh
+RUN bash build.sh -R -N -i sysv
+RUN bash build.sh -R -N -i systemd

--- a/build.sh
+++ b/build.sh
@@ -6,13 +6,21 @@
 #
 set -e
 
-mydir=$(dirname $0)
+basedir=$(dirname $0)
 GIT_COMMIT=$(git rev-parse HEAD)
 RELEASE_VERSION=
 RELEASE_SUBVERSION=
-TOPDIR=/tmp/orchestrator-release
-export RELEASE_VERSION TOPDIR
+release_base_path=/tmp/orchestrator-release
+export RELEASE_VERSION release_base_path
 export GO15VENDOREXPERIMENT=1
+
+binary_build_path="build"
+binary_artifact="$binary_build_path/bin/orchestrator"
+skip_build=""
+build_only=""
+build_paths=""
+retain_build_paths=""
+opt_race=
 
 usage() {
   echo
@@ -20,10 +28,13 @@ usage() {
   echo "Options:"
   echo "-h Show this screen"
   echo "-t (linux|darwin) Target OS Default:(linux)"
-  echo "-i (sysv|systemd) Target init system Default:(sysv)"
+  echo "-i (systemd|sysv) Target init system Default:(systemd)"
   echo "-a (amd64|386) Arch Default:(amd64)"
   echo "-d debug output"
   echo "-b build only, do not generate packages"
+  echo "-N do not build; use existing ./buld/bin/orchestrator binary"
+  echo "-P create build/deployment paths"
+  echo "-R retain existing build/deployment paths"
   echo "-p build prefix Default:(/usr/local)"
   echo "-r build with race detector"
   echo "-v release version (optional; default: content of RELEASE_VERSION file)"
@@ -40,18 +51,26 @@ function fail() {
   exit 1
 }
 
+function debug() {
+  local message="${1}"
+
+  export message
+  (>&2 echo "[DEBUG] $message")
+}
+
+
 function precheck() {
   local target="$1"
   local build_only="$2"
   local ok=0 # return err. so shell exit code
 
   if [[ "$target" == "linux" ]]; then
-    if [[ $build_only -eq 0 ]] && [[ ! -x "$( which fpm )" ]]; then
+    if [[ -z "$build_only" ]] && [[ ! -x "$( which fpm )" ]]; then
       echo "Please install fpm and ensure it is in PATH (typically: 'gem install fpm')"
       ok=1
     fi
 
-    if [[ $build_only -eq 0 ]] && [[ ! -x "$( which rpmbuild )" ]]; then
+    if [[ -z "$build_only" ]] && [[ ! -x "$( which rpmbuild )" ]]; then
       echo "rpmbuild not in PATH, rpm will not be built (OS/X: 'brew install rpm')"
     fi
   fi
@@ -74,111 +93,30 @@ function precheck() {
   return $ok
 }
 
-function setuptree() {
-  local b prefix
+setup_build_path() {
+  local prefix build_path
   prefix="$1"
 
-  mkdir -p $TOPDIR
-  rm -rf ${TOPDIR:?}/*
-  b=$( mktemp -d $TOPDIR/orchestratorXXXXXX ) || return 1
-  mkdir -p $b/orchestrator
-  mkdir -p $b/orchestrator${prefix}/orchestrator/
-  mkdir -p $b/orchestrator-cli/usr/bin
-  mkdir -p $b/orchestrator-client/usr/bin
-  [ "$init_system" == "sysv" ] && mkdir -p $b/orchestrator/etc/init.d
-  [ "$init_system" == "systemd" ] && mkdir -p $b/orchestrator/etc/systemd/system
-
-  echo $b
-}
-
-function oinstall() {
-  local builddir prefix
-  builddir="$1"
-  init_system="$2"
-  prefix="$3"
-
-  cd  $mydir
-  gofmt -s -w  go/
-  rsync -qa ./resources $builddir/orchestrator${prefix}/orchestrator/
-  rsync -qa ./conf/orchestrator-sample*.conf.json $builddir/orchestrator${prefix}/orchestrator/
-
-  case $init_system in
-    "sysv")
-      cp etc/init.d/orchestrator.bash $builddir/orchestrator/etc/init.d/orchestrator
-      chmod +x $builddir/orchestrator/etc/init.d/orchestrator
-      ;;
-    "systemd")
-      cp etc/systemd/orchestrator.service $builddir/orchestrator/etc/systemd/system/orchestrator.service
-      ;;
-    *)
-      fail "Unsupported init system '$init_system'."
-      ;;
-  esac
-}
-
-function package() {
-  local target builddir prefix packages
-  target="$1"
-  builddir="$2"
-  prefix="$3"
-
-  cd $TOPDIR
-
-  echo "Release version is ${RELEASE_VERSION} ( ${GIT_COMMIT} )"
-
-  case $target in
-    'linux')
-      echo "Creating Linux Tar package"
-      tar -C $builddir/orchestrator -czf $TOPDIR/orchestrator-"${RELEASE_VERSION}"-$target-$arch.tar.gz ./
-
-      echo "Creating Distro full packages"
-      fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -n orchestrator -m shlomi-noach --description "MySQL replication topology management and HA" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $builddir/orchestrator --prefix=/ --config-files /usr/local/orchestrator/resources/public/css/custom.css --config-files /usr/local/orchestrator/resources/public/js/custom.js --depends 'jq >= 1.5' -t rpm .
-      fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -n orchestrator -m shlomi-noach --description "MySQL replication topology management and HA" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $builddir/orchestrator --prefix=/ --config-files /usr/local/orchestrator/resources/public/css/custom.css --config-files /usr/local/orchestrator/resources/public/js/custom.js --depends 'jq >= 1.5' -t deb .
-
-      cd $TOPDIR
-      # orchestrator-cli packaging -- executable only
-      echo "Creating Distro cli packages"
-      fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -n orchestrator-cli -m shlomi-noach --description "MySQL replication topology management and HA: binary only" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $builddir/orchestrator-cli --prefix=/ --depends 'jq >= 1.5' -t rpm .
-      fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -n orchestrator-cli -m shlomi-noach --description "MySQL replication topology management and HA: binary only" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $builddir/orchestrator-cli --prefix=/ --depends 'jq >= 1.5' -t deb --deb-no-default-config-files .
-
-      cd $TOPDIR
-      # orchestrator-client packaging -- shell script only
-      echo "Creating Distro orchestrator-client packages"
-      fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -n orchestrator-client -m shlomi-noach --description "MySQL replication topology management and HA: client script" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $builddir/orchestrator-client --prefix=/ --depends 'jq >= 1.5' -t rpm .
-      fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -n orchestrator-client -m shlomi-noach --description "MySQL replication topology management and HA: client script" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $builddir/orchestrator-client --prefix=/ --depends 'jq >= 1.5' -t deb --deb-no-default-config-files .
-      ;;
-    'darwin')
-      echo "Creating Darwin full Package"
-      tar -C $builddir/orchestrator -czf $TOPDIR/orchestrator-"${RELEASE_VERSION}"-$target-$arch.tar.gz ./
-      echo "Creating Darwin cli Package"
-      tar -C $builddir/orchestrator-cli -czf $TOPDIR/orchestrator-cli-"${RELEASE_VERSION}"-$target-$arch.tar.gz ./
-      echo "Creating Darwin orchestrator-client Package"
-      tar -C $builddir/orchestrator-client -czf $TOPDIR/orchestrator-client-"${RELEASE_VERSION}"-$target-$arch.tar.gz ./
-      ;;
-  esac
-
-  echo "---"
-  if [[ -f /etc/centos-release ]]; then
-      if cat /etc/centos-release | grep 'CentOS release 6' ; then
-        rm ${TOPDIR:-?}/orchestrator*.deb
-        rm ${TOPDIR:-?}/orchestrator*.tar.gz
-        # n CentOD 6 box: we only want the rpms for CentOS6
-        # Add "-centos6" to the file name.
-        ls ${TOPDIR:-?}/*.rpm | while read f; do centos_file=$(echo $f | sed -r -e "s/^(.*)-${RELEASE_VERSION}(.*)/\1-centos6-${RELEASE_VERSION}\2/g") ; mv $f $centos_file ; done
-      fi
+  mkdir -p $release_base_path
+  if [ -z "$retain_build_paths" ] ; then
+    rm -rf ${release_base_path:?}/*
   fi
-  echo "Done. Find releases in $TOPDIR"
+  build_path=$(mktemp -d $release_base_path/orchestratorXXXXXX) || fail "Unable to 'mktemp -d $release_base_path/orchestratorXXXXXX'"
+
+  echo $build_path
 }
 
-function build() {
-  local target arch builddir gobuild prefix
+build_binary() {
+  local target arch build_path gobuild prefix
   os="$1"
   arch="$2"
-  builddir="$3"
+  build_path="$3"
   prefix="$4"
   ldflags="-X main.AppVersion=${RELEASE_VERSION} -X main.GitCommit=${GIT_COMMIT}"
-  echo "Building via $(go version)"
-  gobuild="go build -i ${opt_race} -ldflags \"$ldflags\" -o $builddir/orchestrator${prefix}/orchestrator/orchestrator go/cmd/orchestrator/main.go"
+  debug "Building via $(go version)"
+  mkdir -p "$binary_build_path/bin"
+  rm -f $binary_artifact
+  gobuild="go build -i ${opt_race} -ldflags \"$ldflags\" -o $binary_artifact go/cmd/orchestrator/main.go"
 
   case $os in
     'linux')
@@ -188,37 +126,179 @@ function build() {
       echo "GOOS=darwin GOARCH=amd64 $gobuild" | bash
     ;;
   esac
-  [[ $(find $builddir/orchestrator${prefix}/orchestrator/ -type f -name orchestrator) ]] &&  echo "orchestrator binary created" || fail "Failed to generate orchestrator binary"
-  cp $builddir/orchestrator${prefix}/orchestrator/orchestrator $builddir/orchestrator-cli/usr/bin && echo "binary copied to orchestrator-cli" || fail "Failed to copy orchestrator binary to orchestrator-cli"
-  cp $builddir/orchestrator${prefix}/orchestrator/resources/bin/orchestrator-client $builddir/orchestrator-client/usr/bin && echo "orchestrator-client copied to orchestrator-client/" || fail "Failed to copy orchestrator-client to orchestrator-client/"
+  find $binary_artifact -type f || fail "Failed to generate orchestrator binary"
 }
 
-function main() {
+copy_binary_artifacts() {
+  build_path="$1"
+  prefix="$2"
+
+  for dest in "orchestrator-cli/usr/bin" "orchestrator$prefix/orchestrator" ; do
+    cp $binary_artifact $build_path/$dest && debug "binary copied to $build_path/$dest" || fail "Failed to copy orchestrator binary to $build_path/$dest"
+  done
+  cp $build_path/orchestrator${prefix}/orchestrator/resources/bin/orchestrator-client $build_path/orchestrator-client/usr/bin && debug "orchestrator-client copied to orchestrator-client/" || fail "Failed to copy orchestrator-client to orchestrator-client/"
+}
+
+setup_artifact_paths() {
+  local prefix build_path
+  build_path="$1"
+  prefix="$2"
+
+  mkdir -p $build_path/orchestrator
+  mkdir -p $build_path/orchestrator${prefix}/orchestrator/
+  mkdir -p $build_path/orchestrator-cli/usr/bin
+  mkdir -p $build_path/orchestrator-client/usr/bin
+  [ "$init_system" == "sysv" ] && mkdir -p $build_path/orchestrator/etc/init.d
+  [ "$init_system" == "systemd" ] && mkdir -p $build_path/orchestrator/etc/systemd/system
+  ln -s $build_path $release_base_path/build
+}
+
+function copy_resource_artifacts() {
+  local build_path prefix
+  build_path="$1"
+  init_system="$2"
+  prefix="$3"
+
+  cd  $basedir
+  gofmt -s -w  go/
+  rsync -qa ./resources $build_path/orchestrator${prefix}/orchestrator/
+  rsync -qa ./conf/orchestrator-sample*.conf.json $build_path/orchestrator${prefix}/orchestrator/
+
+  case $init_system in
+    "sysv")
+      cp etc/init.d/orchestrator.bash $build_path/orchestrator/etc/init.d/orchestrator
+      chmod +x $build_path/orchestrator/etc/init.d/orchestrator
+      ;;
+    "systemd")
+      cp etc/systemd/orchestrator.service $build_path/orchestrator/etc/systemd/system/orchestrator.service
+      ;;
+    *)
+      fail "Unsupported init system '$init_system'."
+      ;;
+  esac
+}
+
+package_linux() {
+  local arch build_path
+  arch="$1"
+  build_path="$2"
+
+  local do_tar=1
+  local do_rpm=1
+  local do_deb=1
+
+  cd $basedir
+
+  tmp_build_path="$release_base_path/build/tmp"
+  mkdir -p $tmp_build_path
+  rm -f "${tmp_build_path:-?}/*.*"
+
+  package_name_extra=""
+
+  if [ "$init_system" == "sysv" ] ; then
+    package_name_extra="${package_name_extra}-sysv"
+  fi
+
+  if [[ -f /etc/centos-release ]]; then
+      if cat /etc/centos-release | grep 'CentOS release 6' ; then
+        do_tar=0
+        do_deb=0
+        # n CentOD 6 box: we only want the rpms for CentOS6
+        # Add "-centos6" to the file name.
+        package_name_extra="${package_name_extra}-centos6"
+      fi
+  fi
+
+  cd $tmp_build_path
+
+  debug "Creating Linux Tar package"
+  [ $do_tar -eq 1 ] && tar -C $build_path/orchestrator -czf $release_base_path/orchestrator-"${RELEASE_VERSION}"-$target-$arch.tar.gz ./
+
+  debug "Creating Distro full packages"
+  [ $do_rpm -eq 1 ] && fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -n orchestrator -m shlomi-noach --description "MySQL replication topology management and HA" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $build_path/orchestrator --prefix=/ --config-files /usr/local/orchestrator/resources/public/css/custom.css --config-files /usr/local/orchestrator/resources/public/js/custom.js --depends 'jq >= 1.5' -t rpm .
+  [ $do_deb -eq 1 ] && fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -n orchestrator -m shlomi-noach --description "MySQL replication topology management and HA" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $build_path/orchestrator --prefix=/ --config-files /usr/local/orchestrator/resources/public/css/custom.css --config-files /usr/local/orchestrator/resources/public/js/custom.js --depends 'jq >= 1.5' -t deb --deb-no-default-config-files .
+
+  debug "Creating Distro cli packages"
+  # orchestrator-cli packaging -- executable only
+  [ $do_rpm -eq 1 ] && fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -n orchestrator-cli -m shlomi-noach --description "MySQL replication topology management and HA: binary only" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $build_path/orchestrator-cli --prefix=/ --depends 'jq >= 1.5' -t rpm .
+  [ $do_deb -eq 1 ] && fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -n orchestrator-cli -m shlomi-noach --description "MySQL replication topology management and HA: binary only" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $build_path/orchestrator-cli --prefix=/ --depends 'jq >= 1.5' -t deb --deb-no-default-config-files .
+
+  debug "Creating Distro orchestrator-client packages"
+  # orchestrator-client packaging -- shell script only
+  [ $do_rpm -eq 1 ] && fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -n orchestrator-client -m shlomi-noach --description "MySQL replication topology management and HA: client script" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $build_path/orchestrator-client --prefix=/ --depends 'jq >= 1.5' -t rpm .
+  [ $do_deb -eq 1 ] && fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -n orchestrator-client -m shlomi-noach --description "MySQL replication topology management and HA: client script" --url "https://github.com/github/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $build_path/orchestrator-client --prefix=/ --depends 'jq >= 1.5' -t deb --deb-no-default-config-files .
+
+  if [ ! -z "$package_name_extra" ] ; then
+    ls *.rpm | while read f; do package_file=$(echo $f | sed -r -e "s/^(.*)-${RELEASE_VERSION}(.*)/\1${package_name_extra}-${RELEASE_VERSION}\2/g") ; mv $f $package_file ; done
+    ls *.deb | while read f; do package_file=$(echo $f | sed -r -e "s/^(.*)_${RELEASE_VERSION}(.*)/\1${package_name_extra}-${RELEASE_VERSION}\2/g") ; mv $f $package_file ; done
+  fi
+
+  debug "packeges:"
+  for f in * ; do debug "- $f" ; done
+
+  mv ./*.* $release_base_path/
+  cd $basedir
+}
+
+package_darwin() {
+  local arch build_path
+  arch="$1"
+  build_path="$2"
+
+  cd $release_base_path
+  debug "Creating Darwin full Package"
+  tar -C $build_path/orchestrator -czf $release_base_path/orchestrator-"${RELEASE_VERSION}"-$target-$arch.tar.gz ./
+  debug "Creating Darwin cli Package"
+  tar -C $build_path/orchestrator-cli -czf $release_base_path/orchestrator-cli-"${RELEASE_VERSION}"-$target-$arch.tar.gz ./
+  debug "Creating Darwin orchestrator-client Package"
+  tar -C $build_path/orchestrator-client -czf $release_base_path/orchestrator-client-"${RELEASE_VERSION}"-$target-$arch.tar.gz ./
+}
+
+package() {
+  local target arch build_path
+  target="$1"
+  arch="$2"
+  build_path="$3"
+
+  debug "Release version is ${RELEASE_VERSION} (${GIT_COMMIT})"
+
+  case $target in
+    'linux') package_linux "$arch" "$build_path" ;;
+    'darwin') package_darwin "$arch" "$build_path" ;;
+  esac
+
+  debug "Done. Find releases in $release_base_path"
+}
+
+main() {
   local target="$1"
   local init_system="$2"
   local arch="$3"
   local prefix="$4"
   local build_only=$5
-  local builddir
+  local build_path
 
   if [ -z "${RELEASE_VERSION}" ] ; then
-    RELEASE_VERSION=$(cat $mydir/RELEASE_VERSION)
+    RELEASE_VERSION=$(cat $basedir/RELEASE_VERSION)
   fi
   RELEASE_VERSION="${RELEASE_VERSION}${RELEASE_SUBVERSION}"
 
   precheck "$target" "$build_only"
-  builddir=$( setuptree "$prefix" )
-  oinstall "$builddir" "$init_system" "$prefix"
-  build "$target" "$arch" "$builddir" "$prefix"
-  [[ $? == 0 ]] || return 1
-  if [[ $build_only -eq 0 ]]; then
-    package "$target" "$builddir" "$prefix"
+  if [ -z "$skip_build" ] ; then
+    build_binary "$target" "$arch" "$build_path" "$prefix" || fail "Failed building binary"
+  fi
+  if [ "$build_paths" == "true" ] ; then
+    build_path=$(setup_build_path "$prefix")
+    setup_artifact_paths "$build_path" "$prefix"
+    copy_resource_artifacts "$build_path" "$init_system" "$prefix"
+    copy_binary_artifacts "$build_path" "$prefix"
+  fi
+  if [[ -z "$build_only" ]]; then
+    package "$target" "$arch" "$build_path"
   fi
 }
 
-build_only=0
-opt_race=
-while getopts a:t:i:p:s:v:dbhr flag; do
+while getopts "a:t:i:p:s:v:dbNPRhr" flag; do
   case $flag in
   a)
     arch="${OPTARG}"
@@ -237,8 +317,21 @@ while getopts a:t:i:p:s:v:dbhr flag; do
     debug=1
     ;;
   b)
-    echo "Build only; no packaging"
-    build_only=1
+    debug "Build only; no packaging"
+    build_only="true"
+    ;;
+  N)
+    debug "skipping build"
+    [ -f "$binary_artifact" ] || fail "cannot find $binary_artifact"
+    skip_build="true"
+    ;;
+  P)
+    debug "Creating build paths"
+    build_paths="true"
+    ;;
+  R)
+    debug "Retaining existing build paths"
+    retain_build_paths="true"
     ;;
   p)
     prefix="${OPTARG}"
@@ -261,6 +354,11 @@ done
 
 shift $(( OPTIND - 1 ));
 
+if [ -z "$build_only" ] ; then
+  # To build packages means we also need to build the paths
+  build_paths="true"
+fi
+
 if [ -z "$target" ]; then
 	uname=$(uname)
 	case $uname in
@@ -270,11 +368,11 @@ if [ -z "$target" ]; then
 	esac
 fi
 
-init_system=${init_system:-"sysv"}
+init_system=${init_system:-"systemd"}
 arch=${arch:-"amd64"} # default for arch is amd64 but should take from environment
 prefix=${prefix:-"/usr/local"}
 
 [[ $debug -eq 1 ]] && set -x
 main "$target" "$init_system" "$arch" "$prefix" "$build_only"
 
-echo "orchestrator build done; exit status is $?"
+debug "orchestrator build done; exit status is $?"


### PR DESCRIPTION
A new docker build: `Dockerfile.packging` is added. Building this image will build `orchestrator` and create the distribution packages: `deb`, `rpm`.

e.b. building via:
```
docker run --rm -it orchestrator-packaging:latest
```

then, e.g.:
```
$ docker run --rm -it orchestrator-packaging:latest
/tmp/go/src/github.com/github/orchestrator # ls -l /tmp/orchestrator-release/
total 98092
lrwxrwxrwx    1 root     root            44 Jul  1 12:06 build -> /tmp/orchestrator-release/orchestratorcHJkJe
-rw-r--r--    1 root     root      11320918 Jul  1 12:07 orchestrator-3.0.14-1.x86_64.rpm
-rw-r--r--    1 root     root      11353373 Jul  1 12:07 orchestrator-3.0.14-linux-amd64.tar.gz
-rw-r--r--    1 root     root      10894910 Jul  1 12:07 orchestrator-cli-3.0.14-1.x86_64.rpm
-rw-r--r--    1 root     root      10894905 Jul  1 12:06 orchestrator-cli-sysv-3.0.14-1.x86_64.rpm
-rw-r--r--    1 root     root      10931266 Jul  1 12:07 orchestrator-cli-sysv-3.0.14_amd64.deb
-rw-r--r--    1 root     root      10931266 Jul  1 12:07 orchestrator-cli_3.0.14_amd64.deb
-rw-r--r--    1 root     root         14989 Jul  1 12:07 orchestrator-client-3.0.14-1.x86_64.rpm
-rw-r--r--    1 root     root         14987 Jul  1 12:07 orchestrator-client-sysv-3.0.14-1.x86_64.rpm
-rw-r--r--    1 root     root         10114 Jul  1 12:07 orchestrator-client-sysv-3.0.14_amd64.deb
-rw-r--r--    1 root     root         10120 Jul  1 12:07 orchestrator-client_3.0.14_amd64.deb
-rw-r--r--    1 root     root      11323431 Jul  1 12:06 orchestrator-sysv-3.0.14-1.x86_64.rpm
-rw-r--r--    1 root     root      11358280 Jul  1 12:06 orchestrator-sysv-3.0.14_amd64.deb
drwx------    5 root     root          4096 Jul  1 12:07 orchestratorOMnNkp
drwx------    5 root     root          4096 Jul  1 12:06 orchestratorPIcdpb
-rw-r--r--    1 root     root      11357076 Jul  1 12:07 orchestrator_3.0.14_amd64.deb
drwx------    1 root     root          4096 Jul  1 12:07 orchestratorcHJkJe
```

The dockerfile has `fpm`, `rpm` and all it needs to generate the distribution packages.

Also, we now ship both `sysv` and `systemd` packages.

`build.sh` has undergone substantial changes to support the above, with more control over artifact generation, and less coupling between the different artifact generations (e.g. binary does not depend on distribution paths; packages do not necessarily build; etc.)