### PR TITLE
Dockerfile packaging: glibc

### DIFF
--- a/Dockerfile.packaging
+++ b/Dockerfile.packaging
@@ -14,31 +14,21 @@
 # ORC_USER (default: orc_server_user): username used to login to orchestrator backend MySQL server
 # ORC_PASSWORD (default: orc_server_password): password used to login to orchestrator backend MySQL server
 
-FROM alpine:3.10
+FROM golang:1.12.6
 
-RUN apk update
-RUN apk upgrade
-RUN apk add --update ruby
-RUN apk add --update ruby-dev
-RUN apk add --update gcc
-RUN apk add --update libffi-dev
-RUN apk add --update make
-RUN apk add --update libc-dev
-RUN apk add --update rpm
+RUN apt-get update
+RUN apt-get install -y ruby ruby-dev rubygems build-essential
 RUN gem install --no-ri --no-rdoc fpm
-
 ENV GOPATH=/tmp/go
 
-RUN apk add --update libcurl
-RUN apk add --update rsync
-RUN apk add --update gcc
-RUN apk add --update g++
-RUN apk add --update build-base
-RUN apk add --update bash
-RUN apk add --update git
-RUN apk add --update go
-RUN apk add --update ruby-etc
-RUN apk add --update tar
+RUN apt-get install -y curl
+RUN apt-get install -y rsync
+RUN apt-get install -y gcc
+RUN apt-get install -y g++
+RUN apt-get install -y bash
+RUN apt-get install -y git
+RUN apt-get install -y tar
+RUN apt-get install -y rpm
 
 RUN mkdir -p $GOPATH/src/github.com/github/orchestrator
 WORKDIR $GOPATH/src/github.com/github/orchestrator

--- a/go/inst/resolve.go
+++ b/go/inst/resolve.go
@@ -276,6 +276,17 @@ func RegisterHostnameUnresolve(registration *HostnameRegistration) (err error) {
 	return WriteHostnameUnresolve(&registration.Key, registration.Hostname)
 }
 
+func extractIPs(ips []net.IP) (ipv4String string, ipv6String string) {
+	for _, ip := range ips {
+		if ip4 := ip.To4(); ip4 != nil {
+			ipv4String = ip.String()
+		} else {
+			ipv6String = ip.String()
+		}
+	}
+	return ipv4String, ipv6String
+}
+
 func ResolveHostnameIPs(hostname string) error {
 	if _, found := hostnameIPsCache.Get(hostname); found {
 		return nil
@@ -285,5 +296,6 @@ func ResolveHostnameIPs(hostname string) error {
 		return log.Errore(err)
 	}
 	hostnameIPsCache.Set(hostname, true, cache.DefaultExpiration)
-	return writeHostnameIPs(hostname, ips)
+	ipv4String, ipv6String := extractIPs(ips)
+	return writeHostnameIPs(hostname, ipv4String, ipv6String)
 }

--- a/go/inst/resolve_dao.go
+++ b/go/inst/resolve_dao.go
@@ -17,8 +17,6 @@
 package inst
 
 import (
-	"net"
-
 	"github.com/github/orchestrator/go/config"
 	"github.com/github/orchestrator/go/db"
 	"github.com/openark/golib/log"
@@ -327,16 +325,7 @@ func deleteHostnameResolves() error {
 }
 
 // writeHostnameIPs stroes an ipv4 and ipv6 associated witha hostname, if available
-func writeHostnameIPs(hostname string, ips []net.IP) error {
-	ipv4String := ""
-	ipv6String := ""
-	for _, ip := range ips {
-		if ip4 := ip.To4(); ip4 != nil {
-			ipv4String = ip.String()
-		} else {
-			ipv6String = ip.String()
-		}
-	}
+func writeHostnameIPs(hostname string, ipv4String string, ipv6String string) error {
 	writeFunc := func() error {
 		_, err := db.ExecOrchestrator(`
 			insert into


### PR DESCRIPTION
Fixes https://github.com/github/orchestrator/issues/925

An oversight, the `Dockerfile.packging` released in `3.1.0` generates binaries expecting `musl`, where they should be expecting `glibc`. This resulted with the packaged binaries unable to run on `centos` and `debian`...

To be released immediately as `v3.1.1`.