### PR TITLE
graceful master takeover: reduced some overhead; revert to writable on error

### DIFF
--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -504,6 +504,29 @@ func StartSlaves(replicas [](*Instance)) {
 	}
 }
 
+func WaitForExecBinlogCoordinatesToReach(instanceKey *InstanceKey, coordinates *BinlogCoordinates, maxWait time.Duration) (instance *Instance, exactMatch bool, err error) {
+	startTime := time.Now()
+	for {
+		if maxWait != 0 && time.Since(startTime) > maxWait {
+			return nil, exactMatch, fmt.Errorf("WaitForExecBinlogCoordinatesToReach: reached maxWait %+v on %+v", maxWait, *instanceKey)
+		}
+		instance, err = ReadTopologyInstance(instanceKey)
+		if err != nil {
+			return instance, exactMatch, log.Errore(err)
+		}
+
+		switch {
+		case instance.ExecBinlogCoordinates.SmallerThan(coordinates):
+			time.Sleep(retryInterval)
+		case instance.ExecBinlogCoordinates.Equals(coordinates):
+			return instance, true, nil
+		case coordinates.SmallerThan(&instance.ExecBinlogCoordinates):
+			return instance, false, nil
+		}
+	}
+	return instance, exactMatch, err
+}
+
 // StartSlaveUntilMasterCoordinates issuesa START SLAVE UNTIL... statement on given instance
 func StartSlaveUntilMasterCoordinates(instanceKey *InstanceKey, masterCoordinates *BinlogCoordinates) (*Instance, error) {
 	instance, err := ReadTopologyInstance(instanceKey)
@@ -538,20 +561,12 @@ func StartSlaveUntilMasterCoordinates(instanceKey *InstanceKey, masterCoordinate
 		return instance, log.Errore(err)
 	}
 
-	for upToDate := false; !upToDate; {
-		instance, err = ReadTopologyInstance(instanceKey)
-		if err != nil {
-			return instance, log.Errore(err)
-		}
-
-		switch {
-		case instance.ExecBinlogCoordinates.SmallerThan(masterCoordinates):
-			time.Sleep(retryInterval)
-		case instance.ExecBinlogCoordinates.Equals(masterCoordinates):
-			upToDate = true
-		case masterCoordinates.SmallerThan(&instance.ExecBinlogCoordinates):
-			return instance, fmt.Errorf("Start SLAVE UNTIL is past coordinates: %+v", instanceKey)
-		}
+	instance, exactMatch, err := WaitForExecBinlogCoordinatesToReach(instanceKey, masterCoordinates, 0)
+	if err != nil {
+		return instance, log.Errore(err)
+	}
+	if !exactMatch {
+		return instance, fmt.Errorf("Start SLAVE UNTIL is past coordinates: %+v", instanceKey)
 	}
 
 	instance, err = StopSlave(instanceKey)


### PR DESCRIPTION
Upon `graceful-master-takeover`:

- Reduced some toil for identifying replication coordinates on designated master; instead of `stop slave; start slave until ...` commands (which take time to execute) we just check the coordinates on the server. 

- If promotion is aborted (e.g. failed datacenter constraints) then the original master is restored as writable.
