### PR TITLE
Fixing raft leaderAPI URL when URLPrefix nonempty

### DIFF
--- a/go/raft/http_client.go
+++ b/go/raft/http_client.go
@@ -54,7 +54,8 @@ func HttpGetLeader(path string) (response []byte, err error) {
 	}
 	leaderAPI := leaderURI
 	if config.Config.URLPrefix != "" {
-		leaderAPI = fmt.Sprintf("%s/%s", leaderAPI, config.Config.URLPrefix)
+		// We know URLPrefix begind with "/"
+		leaderAPI = fmt.Sprintf("%s%s", leaderAPI, config.Config.URLPrefix)
 	}
 	leaderAPI = fmt.Sprintf("%s/api", leaderAPI)
 


### PR DESCRIPTION
Context: https://github.com/github/orchestrator/issues/950#issuecomment-518147062

When `URLPrefix` is non-empty, the `raft` `leaderAPI` URL is malformed, as in `http://127.0.0.1:3000//myprefix/api` (note the double slash in `//myprefix`).

This PR fixes that so that the URL is `http://127.0.0.1:3000/myprefix/api`.

When `URLPrefix` is empty, nothing changes and the URL is already correct.

cc @xjxyxgq 