### PR TITLE
Include port in DiscoveryIgnoreReplicaHostnameFilters regexp matching

### DIFF
--- a/conf/orchestrator-sample-sqlite.conf.json
+++ b/conf/orchestrator-sample-sqlite.conf.json
@@ -18,7 +18,8 @@
   "InstancePollSeconds": 5,
   "DiscoveryIgnoreReplicaHostnameFilters": [
     "a_host_i_want_to_ignore[.]example[.]com",
-    ".*[.]ignore_all_hosts_from_this_domain[.]example[.]com"
+    ".*[.]ignore_all_hosts_from_this_domain[.]example[.]com",
+    "a_host_with_extra_port_i_want_to_ignore[.]example[.]com:3307"
   ],
   "UnseenInstanceForgetHours": 240,
   "SnapshotTopologiesIntervalHours": 0,

--- a/conf/orchestrator-sample.conf.json
+++ b/conf/orchestrator-sample.conf.json
@@ -27,7 +27,8 @@
   "InstancePollSeconds": 5,
   "DiscoveryIgnoreReplicaHostnameFilters": [
     "a_host_i_want_to_ignore[.]example[.]com",
-    ".*[.]ignore_all_hosts_from_this_domain[.]example[.]com"
+    ".*[.]ignore_all_hosts_from_this_domain[.]example[.]com",
+    "a_host_with_extra_port_i_want_to_ignore[.]example[.]com:3307"
   ],
   "UnseenInstanceForgetHours": 240,
   "SnapshotTopologiesIntervalHours": 0,

--- a/conf/orchestrator-simple.conf.json
+++ b/conf/orchestrator-simple.conf.json
@@ -19,7 +19,8 @@
   "InstancePollSeconds": 5,
   "DiscoveryIgnoreReplicaHostnameFilters": [
     "a_host_i_want_to_ignore[.]example[.]com",
-    ".*[.]ignore_all_hosts_from_this_domain[.]example[.]com"
+    ".*[.]ignore_all_hosts_from_this_domain[.]example[.]com",
+    "a_host_with_extra_port_i_want_to_ignore[.]example[.]com:3307"
   ],
   "HostnameResolveMethod": "default",
   "MySQLHostnameResolveMethod": "@@hostname",

--- a/docs/configuration-sample.md
+++ b/docs/configuration-sample.md
@@ -31,7 +31,8 @@ The following is a production configuration file, with some details redacted.
   "InstancePollSeconds": 5,
   "DiscoveryIgnoreReplicaHostnameFilters": [
     "a_host_i_want_to_ignore[.]example[.]com",
-    ".*[.]ignore_all_hosts_from_this_domain[.]example[.]com"
+    ".*[.]ignore_all_hosts_from_this_domain[.]example[.]com",
+    "a_host_with_extra_port_i_want_to_ignore[.]example[.]com:3307"
   ],
   "ReadLongRunningQueries": false,
   "SkipMaxScaleCheck": true,

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -1330,7 +1330,7 @@ func ReadProblemInstances(clusterName string) ([](*Instance), error) {
 		if instance.IsDowntimed {
 			skip = true
 		}
-		if RegexpMatchPatterns(instance.Key.Hostname, config.Config.ProblemIgnoreHostnameFilters) {
+		if RegexpMatchPatterns(instance.Key.StringCode(), config.Config.ProblemIgnoreHostnameFilters) {
 			skip = true
 		}
 		if !skip {
@@ -1491,7 +1491,7 @@ func ReadClusterNeutralPromotionRuleInstances(clusterName string) (neutralInstan
 func filterOSCInstances(instances [](*Instance)) [](*Instance) {
 	result := [](*Instance){}
 	for _, instance := range instances {
-		if RegexpMatchPatterns(instance.Key.Hostname, config.Config.OSCIgnoreHostnameFilters) {
+		if RegexpMatchPatterns(instance.Key.StringCode(), config.Config.OSCIgnoreHostnameFilters) {
 			continue
 		}
 		if instance.IsBinlogServer() {

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -279,7 +279,7 @@ func DiscoverInstance(instanceKey inst.InstanceKey) {
 		replicaKey := replicaKey // not needed? no concurrency here?
 
 		// Avoid noticing some hosts we would otherwise discover
-		if inst.RegexpMatchPatterns(replicaKey.Hostname, config.Config.DiscoveryIgnoreReplicaHostnameFilters) {
+		if inst.RegexpMatchPatterns(replicaKey.StringCode(), config.Config.DiscoveryIgnoreReplicaHostnameFilters) {
 			continue
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/github/orchestrator/issues/923

This PR simply extends the hostname matching for the `DiscoveryIgnoreReplicaHostnameFilters` config setting to also include a server's port. By allowing the match on port number as well as hostname, you can prevent any replica instances (or transient gh-ost processes) which connect on [a secondary port](https://www.percona.com/doc/percona-server/LATEST/performance/threadpool.html#extra_port) from showing up in Orchestrator by using a config setting like this:

```
  "DiscoveryIgnoreReplicaHostnameFilters": [ ".*:3307" ]
```

Notes:
* See [the related issue](https://github.com/github/orchestrator/issues/923) for an explanation of how this affects us with our gh-ost usage.
* You will need to tell Orchestrator to *Forget* an already-discovered instance. This is not a change in functionality, just something I noticed during my testing.


- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`
