### PR TITLE
support for routed-leader-check

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -3754,6 +3754,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequestNoProxy(m, "hostname-resolve-cache", this.HostnameResolveCache)
 	this.registerAPIRequestNoProxy(m, "reset-hostname-resolve-cache", this.ResetHostnameResolveCache)
 	// Meta
+	this.registerAPIRequest(m, "routed-leader-check", this.LeaderCheck)
 	this.registerAPIRequest(m, "reelect", this.Reelect)
 	this.registerAPIRequest(m, "reload-cluster-alias", this.ReloadClusterAlias)
 	this.registerAPIRequest(m, "deregister-hostname-unresolve/:host/:port", this.DeregisterHostnameUnresolve)

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -222,6 +222,15 @@ function detect_leader_api {
       return
     fi
   done
+  # Cannot find leader directly. Maybe our config is wrong. But, perhaps one of the nodes can route us?
+  for api in ${apis[@]} ; do
+    api=$(normalize_orchestrator_api $api)
+    leader_check=$(curl ${curl_auth_params} -m 1 -s -o /dev/null -w "%{http_code}" "${api}/routed-leader-check")
+    if [ "$leader_check" == "200" ] ; then
+      leader_api="$api"
+      return
+    fi
+  done
   fail "Cannot determine leader from $orchestrator_api"
 }
 


### PR DESCRIPTION
Recall that in a raft setup nodes relay (reverse proxy) API calls to the leader.

A `api/leader-check` call never routes through reverse proxy.

A new endpoint, `api/routed-leader-check` _does_. And this is useful for `orchestrator-client`. A misconfiguration in `ORCHESTRATOR_API` may not include the current leader (perhaps changes are pending, `puppet` to be deployed, whatever). But another node, which _is_ listed in `ORCHESTRATOR_API` can relay traffic to the leader. In which case `orchestrator-client` is happy to work with said node.
