### PR TITLE
Dockerfile: upgrade to go 1.12.10 and reduce layer churn around packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,11 @@
 # ORC_USER (default: orc_server_user): username used to login to orchestrator backend MySQL server
 # ORC_PASSWORD (default: orc_server_password): password used to login to orchestrator backend MySQL server
 
-FROM golang:1.12.6-alpine3.9
+FROM golang:1.12.10-alpine3.10 as build
 
 ENV GOPATH=/tmp/go
 
-RUN apk update
-RUN apk upgrade
-RUN apk add --update libcurl
-RUN apk add --update rsync
-RUN apk add --update gcc
-RUN apk add --update g++
-RUN apk add --update build-base
-RUN apk add --update bash
-RUN apk add --update git
+RUN apk --no-cache add libcurl rsync gcc g++ build-base bash git
 
 RUN mkdir -p $GOPATH/src/github.com/github/orchestrator
 WORKDIR $GOPATH/src/github.com/github/orchestrator
@@ -38,15 +30,13 @@ RUN cp conf/orchestrator-sample-sqlite.conf.json /etc/orchestrator.conf.json
 
 FROM alpine:3.8
 
-RUN apk add --no-cache bash
-RUN apk add --no-cache curl
-RUN apk add --no-cache jq
+RUN apk --no-cache add bash curl jq
 
 EXPOSE 3000
 
-COPY --from=0 /usr/local/orchestrator /usr/local/orchestrator
-COPY --from=0 /usr/bin/orchestrator-client /usr/bin/orchestrator-client
-COPY --from=0 /etc/orchestrator.conf.json /etc/orchestrator.conf.json
+COPY --from=build /usr/local/orchestrator /usr/local/orchestrator
+COPY --from=build /usr/bin/orchestrator-client /usr/bin/orchestrator-client
+COPY --from=build /etc/orchestrator.conf.json /etc/orchestrator.conf.json
 
 WORKDIR /usr/local/orchestrator
 ADD docker/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
### Description

This PR offers some improvements to the bundled Dockerfile for `orchestrator`, namely:

- Bumps to go 1.12.10, which includes a security update around HTTP parsing: https://groups.google.com/forum/m/#!topic/golang-announce/cszieYyuL9Q
- Slims down the usage of `apk` to avoid superflous calls to their registry, as well as the creation of extra layers
- Names build containers to make the process slightly more legible. 

I did not create an issue as this is a proactive PR - I am happy to do any needed work, but I opted to move to a PR due to security constrains around the bump of Go versioning. 

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`

