### PR TITLE
emergentlyRestartReplicationOnTopologyInstance fixes

### DIFF
--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -242,10 +242,12 @@ func SetSemiSyncReplica(instanceKey *InstanceKey, enableReplica bool) (*Instance
 
 }
 
-func RestartIOThread(instanceKey *InstanceKey) error {
-	for _, cmd := range []string{`stop slave io_thread`, `start slave io_thread`} {
+func RestartReplicationQuick(instanceKey *InstanceKey) error {
+	for _, cmd := range []string{`stop slave sql_thread`, `stop slave io_thread`, `start slave io_thread`, `start slave sql_thread`} {
 		if _, err := ExecInstance(instanceKey, cmd); err != nil {
-			return log.Errorf("%+v: RestartIOThread: '%q' failed: %+v", *instanceKey, cmd, err)
+			return log.Errorf("%+v: RestartReplicationQuick: '%q' failed: %+v", *instanceKey, cmd, err)
+		} else {
+			log.Infof("%s on %+v as part of RestartReplicationQuick", cmd, *instanceKey)
 		}
 	}
 	return nil
@@ -400,7 +402,6 @@ func StopSlave(instanceKey *InstanceKey) (*Instance, error) {
 		}
 	}
 	if err != nil {
-
 		return instance, log.Errore(err)
 	}
 	instance, err = ReadTopologyInstance(instanceKey)

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1412,7 +1412,7 @@ func emergentlyRestartReplicationOnTopologyInstance(instanceKey *inst.InstanceKe
 		return
 	}
 	go inst.ExecuteOnTopology(func() {
-		inst.RestartIOThread(instanceKey)
+		inst.RestartReplicationQuick(instanceKey)
 		inst.AuditOperation("emergently-restart-replication-topology-instance", instanceKey, string(analysisCode))
 	})
 }
@@ -1444,7 +1444,8 @@ func emergentlyRestartReplicationOnTopologyInstanceReplicas(instanceKey *inst.In
 		return
 	}
 	for _, replica := range replicas {
-		go emergentlyRestartReplicationOnTopologyInstance(&replica.Key, analysisCode)
+		replicaKey := &replica.Key
+		go emergentlyRestartReplicationOnTopologyInstance(replicaKey, analysisCode)
 	}
 }
 


### PR DESCRIPTION
 - restart replication fully (both SQL and IO threads)
 - fix concurrency/itration bug
 - slightly more logging

Yesterday we observed a situation where `stop slave io_thread; start slave io_thread;` was not enough to make a replica identify that it's master is broken. By stopping replication completely I hope this mitigates such behavior.

cc @timvaillancourt 