### PR TITLE
Fix to forget-instance db arguments

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -1879,7 +1879,7 @@ func ForgetUnseenInstancesDifferentlyResolved() error {
 				database_instance
 			where
 		    hostname = ? and port = ?
-			`, sqlutils.Args(key.Hostname, key.Port),
+			`, key.Hostname, key.Port,
 		)
 		if err != nil {
 			return log.Errore(err)


### PR DESCRIPTION
SQL query arguments fix

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`
