### PR TITLE
DiscoverySeeds: hard coded instances to be discovered upon startup

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -147,6 +147,7 @@ type Configuration struct {
 	DiscoveryQueueCapacity                     uint     // Buffer size of the discovery queue. Should be greater than the number of DB instances being discovered
 	DiscoveryQueueMaxStatisticsSize            int      // The maximum number of individual secondly statistics taken of the discovery queue
 	DiscoveryCollectionRetentionSeconds        uint     // Number of seconds to retain the discovery collection information
+	DiscoverySeeds                             []string // Hard coded array of hostname:port, ensuring orchestrator discovers these hosts upon startup, assuming not already known to orchestrator
 	InstanceBulkOperationsWaitTimeoutSeconds   uint     // Time to wait on a single instance when doing bulk (many instances) operation
 	HostnameResolveMethod                      string   // Method by which to "normalize" hostname ("none"/"default"/"cname")
 	MySQLHostnameResolveMethod                 string   // Method by which to "normalize" hostname via MySQL server. ("none"/"@@hostname"/"@@report_host"; default "@@hostname")
@@ -320,6 +321,7 @@ func newConfiguration() *Configuration {
 		DiscoveryQueueCapacity:                     100000,
 		DiscoveryQueueMaxStatisticsSize:            120,
 		DiscoveryCollectionRetentionSeconds:        120,
+		DiscoverySeeds:                             []string{},
 		InstanceBulkOperationsWaitTimeoutSeconds:   10,
 		HostnameResolveMethod:                      "default",
 		MySQLHostnameResolveMethod:                 "@@hostname",

--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -113,6 +113,8 @@ type Instance struct {
 	Problems []string
 
 	LastDiscoveryLatency time.Duration
+
+	seed bool // Means we force this instance to be written to backend, even if it's invalid, empty or forgotten
 }
 
 // NewInstance creates a new, empty instance
@@ -219,6 +221,13 @@ func (this *Instance) IsOracleMySQL() bool {
 		return false
 	}
 	return true
+}
+
+func (this *Instance) SetSeed() {
+	this.seed = true
+}
+func (this *Instance) IsSeed() bool {
+	return this.seed
 }
 
 // applyFlavorName


### PR DESCRIPTION
Introducing a new configuration variable, `DiscoverySeeds`, an array of instances, as follows:

```json
  "DiscoverySeeds": [
    "host1:3306",
    "host2",
    "host3:3307"
  ],
```

This config allows for a hard-coded seeding of a list of hosts. This is useful for bootstrapping a new setup of orchestrator where the identity of MySQL hosts is known up front. This removes the initial need for hosts to present themselves to `orchestrator` and/or for automation to ask `orchestrator` to discover said hosts.

Seeded hosts are discovered even if instructed to be forgotten.