### PR TITLE
adding script/dock: utility to wrap docker build

### DIFF
--- a/script/dock
+++ b/script/dock
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Usage:
+# dock <test|alpine|packages> [arg]
+#   dock test:                build orchestrator & run unit and integration tests
+#   docker alpine:            build and run orchestrator on alpine linux
+#   docker pkg [target-path]: build orchestrator release packages and copy to target path (default path: /tmp/orchestrator-release)
+
+command="$1"
+
+case "$command" in
+  "test")
+    docker_target="orchestrator-test"
+    docker build . -f Dockerfile.test -t "${docker_target}" && docker run --rm -it "${docker_target}:latest"
+    ;;
+  "alpine")
+    docker_target="orchestrator-alpine"
+    docker build . -f Dockerfile -t "${docker_target}" && docker run --rm -it -p 3000:3000 "${docker_target}:latest"
+    ;;
+  "pkg")
+    packages_path="${2:-/tmp/orchestrator-release}"
+    docker_target="orchestrator-packaging"
+    docker build . -f Dockerfile.packaging -t "${docker_target}" && docker run --rm -it -v "${packages_path}:/tmp/pkg" "${docker_target}:latest" bash -c 'find /tmp/orchestrator-release/ -maxdepth 1 -type f | xargs cp -t /tmp/pkg'
+    echo "packages generated on ${packages_path}:"
+    ls -l "${packages_path}"
+    ;;
+  *)
+    >&2 echo "Usage: dock dock <test|alpine|packages> [arg]"
+    exit 1
+esac


### PR DESCRIPTION
`script/dock` is a shell script that wraps docker builds/runs:
```
# Usage:
# dock <test|alpine|packages> [arg]
#   dock test:              build orchestrator & run unit and integration tests
#   dock alpine:            build and run orchestrator on alpine linux
#   dock pkg [target-path]: build orchestrator release packages and copy to target path (default path: /tmp/orchestrator-release)
```

e.g. to build `orchestrator` packages you will:

```
script/dock pkg /tmp/orchestrator-release
```


