### PR TITLE
instance problems dropdown menu: use fixed max-height and overflow

### DIFF
--- a/resources/public/css/orchestrator.css
+++ b/resources/public/css/orchestrator.css
@@ -320,6 +320,12 @@ body {
     color: #ffffff;
 }
 
+#instance_problems ul.dropdown-menu {
+    height: auto;
+    max-height: 600px;
+    overflow: auto;
+}
+
 .instance.instance-problem {
     font: 10px sans-serif;
     display: block;


### PR DESCRIPTION
Fixes: https://github.com/github/orchestrator/issues/1055

### Description

Add fixed `max-height` and `overflow` into instance problems dropdown menu, so we can scroll in case of multiple problems.
