### PR TITLE
Fix healthcheck, support mTLS on client

### DIFF
--- a/go/ssl/ssl.go
+++ b/go/ssl/ssl.go
@@ -54,19 +54,30 @@ func NewTLSConfig(caFile string, verifyCert bool) (*tls.Config, error) {
 		log.Info("verifyCert requested, client certificates will be verified")
 		c.ClientAuth = tls.VerifyClientCertIfGiven
 	}
+	caPool, err := ReadCAFile(caFile)
+	if err != nil {
+		return &c, err
+	}
+	c.ClientCAs = caPool
+	c.BuildNameToCertificate()
+	return &c, nil
+}
+
+// Returns CA certificate. If caFile is non-empty, it will be loaded.
+func ReadCAFile(caFile string) (*x509.CertPool, error) {
+	var caCertPool *x509.CertPool
 	if caFile != "" {
 		data, err := ioutil.ReadFile(caFile)
 		if err != nil {
-			return &c, err
+			return nil, err
 		}
-		c.ClientCAs = x509.NewCertPool()
-		if !c.ClientCAs.AppendCertsFromPEM(data) {
-			return &c, errors.New("No certificates parsed")
+		caCertPool = x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(data) {
+			return nil, errors.New("No certificates parsed")
 		}
 		log.Info("Read in CA file:", caFile)
 	}
-	c.BuildNameToCertificate()
-	return &c, nil
+	return caCertPool, nil
 }
 
 // Verify that the OU of the presented client certificate matches the list


### PR DESCRIPTION
Related issue: #873 

### Description

If API uses SSL and mTLS is enabled, healthcheck requests to leader are unsuccessful.
In logs you can see something like:
`remote error: tls: bad certificate`

So, `setupHttpClient` is loading TLS configuration now - root certs and mTLS certs.
