### PR TITLE
Fix minor typo: isGeneralyValid... -> isGenerallyValid...

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -950,8 +950,8 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 	return true, topologyRecovery, err
 }
 
-// isGeneralyValidAsCandidateSiblingOfIntermediateMaster sees that basic server configuration and state are valid
-func isGeneralyValidAsCandidateSiblingOfIntermediateMaster(sibling *inst.Instance) bool {
+// isGenerallyValidAsCandidateSiblingOfIntermediateMaster sees that basic server configuration and state are valid
+func isGenerallyValidAsCandidateSiblingOfIntermediateMaster(sibling *inst.Instance) bool {
 	if !sibling.LogBinEnabled {
 		return false
 	}
@@ -973,7 +973,7 @@ func isValidAsCandidateSiblingOfIntermediateMaster(intermediateMasterInstance *i
 		// same instance
 		return false
 	}
-	if !isGeneralyValidAsCandidateSiblingOfIntermediateMaster(sibling) {
+	if !isGenerallyValidAsCandidateSiblingOfIntermediateMaster(sibling) {
 		return false
 	}
 	if inst.IsBannedFromBeingCandidateReplica(sibling) {


### PR DESCRIPTION
Fix typo in function name `isGeneralyValidAsCandidateSiblingOfIntermediateMaster` ==> `isGenerallyValidAsCandidateSiblingOfIntermediateMaster`.
* no functional code changes
* just makes things easier to read.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `go test ./go/...`
