### PR TITLE
Add log.Errorf in moveReplicasViaGTID

### DIFF
--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -692,6 +692,7 @@ func moveReplicasViaGTID(replicas [](*Instance), other *Instance, postponedFunct
 				movedReplica, replicaErr := moveInstanceBelowViaGTID(replica, other)
 				if replicaErr != nil && movedReplica != nil {
 					replica = movedReplica
+					log.Errorf("moveReplicasViaGTID(): error on moveInstanceBelowViaGTID(). replica: %v; error: %v", replica.Key, replicaErr)
 				}
 
 				// After having moved replicas, update local shared variables:


### PR DESCRIPTION
issue: #1063 