### PR TITLE
Turn seconds into a more meaningful Wd Xh Ym Zs output

### DIFF
--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -119,6 +119,24 @@ function toHumanFormat(bytes) {
   return (bytes / Math.pow(1024, e)).toFixed(2) + " " + s[e];
 }
 
+function secondsToString(time_s) {
+  let seconds = Math.floor(time_s) % 60;
+  let minutes = Math.floor(time_s / 60) % 60;
+  let hours   = Math.floor(time_s / 3600) % 24;
+  let days    = Math.floor(time_s / 86400);
+  let message = '';
+  if (days > 0)
+    message = days + 'd ' + hours + 'h ' + minutes + 'm ' + seconds + 's';
+  else if (hours > 0)
+    message = hours + 'h ' + minutes + 'm ' + seconds + 's';
+  else if (minutes > 0)
+    message = minutes + 'm ' + seconds + 's';
+  else
+    message = seconds + 's';
+
+  return message;
+}
+
 function getInstanceId(host, port) {
   return "instance__" + host.replace(/[.]/g, "_") + "__" + port
 }
@@ -826,9 +844,9 @@ function renderInstanceElement(popoverElement, instance, renderType) {
     if (instance.renderHint != "") {
       popoverElement.find("h3").addClass("label-" + instance.renderHint);
     }
-    var statusMessage = instance.SlaveLagSeconds.Int64 + ' seconds lag';
+    var statusMessage = secondsToString(instance.SlaveLagSeconds.Int64) + ' lag';
     if (indicateLastSeenInStatus) {
-      statusMessage = 'seen ' + instance.SecondsSinceLastSeen.Int64 + ' seconds ago';
+      statusMessage = 'seen ' + secondsToString(instance.SecondsSinceLastSeen.Int64) + ' ago';
     }
     var identityHtml = '' + instance.Version;
     if (instance.LogBinEnabled) {


### PR DESCRIPTION
# Description

Displaying of replication delay or time since seeing a host in seconds is fine except when you may have some boxes that have a very high value. Then it's better to show the value in terms of days/hours/minutes/seconds as that's easier to read and avoids the need for mental conversion.

This tiny patch presents the delays in the web interface in for form `1d 2h 3m 4s lag` or `1d 2h 3m 4s ago` which makes these delays easier to read.

- [x] contributed code is using same conventions as original code
- [x] code is tested
