### PR TITLE
dock: build odcker hub image

### DIFF
--- a/script/dock
+++ b/script/dock
@@ -3,8 +3,9 @@
 # Usage:
 # dock <test|alpine|packages> [arg]
 #   dock test:                build orchestrator & run unit and integration tests
-#   docker alpine:            build and run orchestrator on alpine linux
-#   docker pkg [target-path]: build orchestrator release packages and copy to target path (default path: /tmp/orchestrator-release)
+#   dock alpine:              build and run orchestrator on alpine linux
+#   dock hub:                 build hub.docker.com image with latest tag
+#   dock pkg [target-path]:   build orchestrator release packages and copy to target path (default path: /tmp/orchestrator-release)
 
 command="$1"
 
@@ -16,6 +17,14 @@ case "$command" in
   "alpine")
     docker_target="orchestrator-alpine"
     docker build . -f Dockerfile -t "${docker_target}" && docker run --rm -it -p 3000:3000 "${docker_target}:latest"
+    ;;
+  "hub")
+    tag="$(git describe --tags --abbrev=0)"
+    if [ -z "$tag" ] ; then
+      echo "Cannot find latest tag"
+      exit 1
+    fi
+    docker build . -f Dockerfile -t "openarkcode/orchestrator:${tag}"
     ;;
   "pkg")
     packages_path="${2:-/tmp/orchestrator-release}"


### PR DESCRIPTION
This PR adds a docker build in favor of docker-hub images on https://hub.docker.com/r/openarkcode/orchestrator.

Related: #1087 