### PR TITLE
GitHub Actions CI: manually start MySQL service

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,5 +18,8 @@ jobs:
     - name: Set up SQLite
       run:  sudo apt-get install sqlite3
 
+    - name: Start local MySQL
+      run: sudo /etc/init.d/mysql start
+
     - name: Build
       run:  script/cibuild


### PR DESCRIPTION
Adapt to breaking change: https://github.blog/changelog/2020-02-21-github-actions-breaking-change-ubuntu-virtual-environments-will-no-longer-start-the-mysql-service-automatically/

by manually starting the MySQL service.