### PR TITLE
Uploading orchestrator binary artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,5 +39,5 @@ jobs:
     - name: Upload orchestrator binary artifact
       uses: actions/upload-artifact@v1
       with:
-        name: orchestrator-build-binary-linux-amd64
+        name: orchestrator
         path: bin/orchestrator

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,9 @@ jobs:
 
     - name: Test documentation
       run:  script/test-docs
+
+    - name: Upload orchestrator binary artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: orchestrator-build-binary-linux-amd64
+        path: bin/orchestrator


### PR DESCRIPTION
The CI build now uploads the binary artifact: the `orchestrator` binary, for Linux amd64 environments.