### PR TITLE
System tests: fail cross region graceful takeover

### DIFF
--- a/conf/orchestrator-ci-env.conf.json
+++ b/conf/orchestrator-ci-env.conf.json
@@ -25,7 +25,7 @@
   "DetectInstanceAliasQuery": "",
   "DetectPromotionRuleQuery": "",
   "DetectDataCenterQuery": "select IF(@@port <= 10112, 'dc-east', 'dc-west')",
-  "DetectRegionQuery": "select @@hostname",
+  "DetectRegionQuery": "select IF(@@port <= 10112, 'rgn-east', 'rgn-west')",
   "DetectPhysicalEnvironmentQuery": "select 'prod'",
   "DetectSemiSyncEnforcedQuery": "",
   "DiscoverySeeds": [
@@ -76,7 +76,7 @@
   "DetachLostSlavesAfterMasterFailover": true,
   "ApplyMySQLPromotionAfterMasterFailover": true,
   "PreventCrossDataCenterMasterFailover": false,
-  "PreventCrossRegionMasterFailover": false,
+  "PreventCrossRegionMasterFailover": true,
   "MasterFailoverDetachReplicaMasterHost": false,
   "MasterFailoverLostInstancesDowntimeMinutes": 0,
   "PostponeReplicaRecoveryOnLagMinutes": 0,

--- a/tests/system/graceful-master-takeover-fail-cross-region/expect_failure
+++ b/tests/system/graceful-master-takeover-fail-cross-region/expect_failure
@@ -1,0 +1,1 @@
+PreventCrossRegionMasterFailover

--- a/tests/system/graceful-master-takeover-fail-cross-region/run
+++ b/tests/system/graceful-master-takeover-fail-cross-region/run
@@ -1,0 +1,1 @@
+orchestrator-client -c graceful-master-takeover -i 127.0.0.1:10111 -d 127.0.0.1:10113

--- a/tests/system/graceful-master-takeover-fail-cross-region/teardown
+++ b/tests/system/graceful-master-takeover-fail-cross-region/teardown
@@ -1,0 +1,1 @@
+orchestrator-client -c relocate-replicas -i 127.0.0.1:10113 -d 127.0.0.1:10111

--- a/tests/system/orchestrator-ci-system.conf.json
+++ b/tests/system/orchestrator-ci-system.conf.json
@@ -80,7 +80,7 @@
   "DetachLostSlavesAfterMasterFailover": true,
   "ApplyMySQLPromotionAfterMasterFailover": true,
   "PreventCrossDataCenterMasterFailover": false,
-  "PreventCrossRegionMasterFailover": false,
+  "PreventCrossRegionMasterFailover": true,
   "MasterFailoverDetachReplicaMasterHost": false,
   "MasterFailoverLostInstancesDowntimeMinutes": 0,
   "PostponeReplicaRecoveryOnLagMinutes": 0,

--- a/tests/system/orchestrator-ci-system.conf.json
+++ b/tests/system/orchestrator-ci-system.conf.json
@@ -35,6 +35,8 @@
   "DetectClusterDomainQuery": "",
   "DetectInstanceAliasQuery": "",
   "DetectPromotionRuleQuery": "",
+  "DetectDataCenterQuery": "select IF(@@port <= 10112, 'dc-east', 'dc-west')",
+  "DetectRegionQuery": "select IF(@@port <= 10112, 'rgn-east', 'rgn-west')",
   "PromotionIgnoreHostnameFilters": [],
   "DetectSemiSyncEnforcedQuery": "",
   "ServeAgentsHttp": false,


### PR DESCRIPTION
`PreventCrossRegionMasterFailover` is set to `true`.

Attempt to promote a replica from a cross-region and expect `PreventCrossRegionMasterFailover` failure.