### PR TITLE
system tests: enforce statement injection on failover

### DIFF
--- a/tests/system/master-failover-candidate-lag-cross-region/01-failover/setup
+++ b/tests/system/master-failover-candidate-lag-cross-region/01-failover/setup
@@ -1,6 +1,7 @@
 orchestrator-client -c stop-replica -i 127.0.0.1:10112
 orchestrator-client -c stop-replica -i 127.0.0.1:10113
 orchestrator-client -c register-candidate -i 127.0.0.1:10113 --promotion-rule prefer
+mysql -uci -pci -h 127.0.0.1 --port=10111 -e "delete from test.heartbeat where id<0"
 sleep 2
 mysqladmin -uci -pci -h 127.0.0.1 --port=10111 shutdown
 sleep 20

--- a/tests/system/master-failover-candidate-lag/01-failover/setup
+++ b/tests/system/master-failover-candidate-lag/01-failover/setup
@@ -1,5 +1,6 @@
 orchestrator-client -c stop-replica -i 127.0.0.1:10113
 orchestrator-client -c register-candidate -i 127.0.0.1:10113 --promotion-rule prefer
+mysql -uci -pci -h 127.0.0.1 --port=10111 -e "delete from test.heartbeat where id<0"
 sleep 2
 mysqladmin -uci -pci -h 127.0.0.1 --port=10111 shutdown
 sleep 20


### PR DESCRIPTION
on tests that depend on a replica lagging, enforce some statement injection; this is on top heartbeat injection that takes place every `0.5sec`.