### PR TITLE
Towards system tests dependencies

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -845,10 +845,6 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 		if satisfied, reason := MasterFailoverGeographicConstraintSatisfied(&analysisEntry, promotedReplica); !satisfied {
 			return nil, fmt.Errorf("RecoverDeadMaster: failed %+v promotion; %s", promotedReplica.Key, reason)
 		}
-		log.Debugf("===================")
-		log.Debugf("++ FailMasterPromotionOnLagMinutes: %+v", config.Config.FailMasterPromotionOnLagMinutes)
-		log.Debugf("++ promotedReplica.SlaveLagSeconds.Int64: %+v", promotedReplica.SlaveLagSeconds.Int64)
-		log.Debugf("++ lag > config?: %+v", (time.Duration(promotedReplica.SlaveLagSeconds.Int64)*time.Second >= time.Duration(config.Config.FailMasterPromotionOnLagMinutes)*time.Minute))
 		if config.Config.FailMasterPromotionOnLagMinutes > 0 &&
 			time.Duration(promotedReplica.SlaveLagSeconds.Int64)*time.Second >= time.Duration(config.Config.FailMasterPromotionOnLagMinutes)*time.Minute {
 			// candidate replica lags too much

--- a/tests/system/graceful-master-takeover-fail-cross-region/depends-on
+++ b/tests/system/graceful-master-takeover-fail-cross-region/depends-on
@@ -1,0 +1,1 @@
+graceful-master-takeover

--- a/tests/system/graceful-master-takeover/depends-on
+++ b/tests/system/graceful-master-takeover/depends-on
@@ -1,0 +1,2 @@
+relocate-multiple
+relocate-replicas

--- a/tests/system/master-failover-candidate-lag-cross-datacenter/depends-on
+++ b/tests/system/master-failover-candidate-lag-cross-datacenter/depends-on
@@ -1,0 +1,1 @@
+master-failover-candidate

--- a/tests/system/master-failover-candidate-lag-cross-region/depends-on
+++ b/tests/system/master-failover-candidate-lag-cross-region/depends-on
@@ -1,0 +1,1 @@
+master-failover-candidate

--- a/tests/system/master-failover-candidate-lag/depends-on
+++ b/tests/system/master-failover-candidate-lag/depends-on
@@ -1,0 +1,1 @@
+master-failover-candidate

--- a/tests/system/master-failover-candidate/depends-on
+++ b/tests/system/master-failover-candidate/depends-on
@@ -1,0 +1,1 @@
+master-failover

--- a/tests/system/master-failover-fail-promotion-lag-minutes-failure/depends-on
+++ b/tests/system/master-failover-fail-promotion-lag-minutes-failure/depends-on
@@ -1,0 +1,1 @@
+master-failover

--- a/tests/system/master-failover-fail-promotion-lag-minutes-success/depends-on
+++ b/tests/system/master-failover-fail-promotion-lag-minutes-success/depends-on
@@ -1,0 +1,1 @@
+master-failover

--- a/tests/system/master-failover-lost-replicas/depends-on
+++ b/tests/system/master-failover-lost-replicas/depends-on
@@ -1,0 +1,1 @@
+master-failover

--- a/tests/system/master-failover/depends-on
+++ b/tests/system/master-failover/depends-on
@@ -1,0 +1,2 @@
+relocate-multiple
+relocate-replicas

--- a/tests/system/relocate-multiple/depends-on
+++ b/tests/system/relocate-multiple/depends-on
@@ -1,0 +1,1 @@
+relocate-single

--- a/tests/system/relocate-replicas/depends-on
+++ b/tests/system/relocate-replicas/depends-on
@@ -1,0 +1,1 @@
+relocate-multiple

--- a/tests/system/relocate-single/depends-on
+++ b/tests/system/relocate-single/depends-on
@@ -1,0 +1,1 @@
+all-instances

--- a/tests/system/test.sh
+++ b/tests/system/test.sh
@@ -293,7 +293,6 @@ test_all() {
 
     find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | xargs ls -td1 | cut -d "/" -f 4 | egrep "$test_pattern" | while read test_name ; do
       if ! test_listed_as_attempted "$test_name" ; then
-        echo "# test $test_name hasn't been executed before"
         echo "$test_name" >> $tests_todo_file
       fi
       if should_attempt_test "$test_name" "$test_pattern" ; then
@@ -305,10 +304,9 @@ test_all() {
           exit 1
         fi
       else
-        echo "# should not attempt $test_name"
+        : # echo "# should not attempt $test_name"
       fi
     done || return 1
-    echo "# Iterated: $(cat $tests_todo_file)"
   done
 }
 

--- a/tests/system/test.sh
+++ b/tests/system/test.sh
@@ -267,6 +267,17 @@ should_attempt_test() {
   if [ "$force_test_pattern" != "." ] ; then
     return 0
   fi
+  # validate dependencies
+  (cat ${tests_path}/${check_test_name}/depends-on 2> /dev/null || echo -n "") | while read dependency ; do
+    if [ "$dependency" == "$check_test_name" ] ; then
+      echo "# ERROR: test $check_test_name depends on itself"
+      exit 1
+    fi
+    if [ ! -d ${tests_path}/$dependency ] ; then
+      echo "# ERROR: test $check_test_name depends on $dependency, but $dependency does not exist"
+      exit 1
+    fi
+  done || exit 1 # completely bail out
   # iterate dependencies
   (cat ${tests_path}/${check_test_name}/depends-on 2> /dev/null || echo -n "") | while read dependency ; do
     if test_listed_as_failed $dependency ; then

--- a/tests/system/test.sh
+++ b/tests/system/test.sh
@@ -318,6 +318,12 @@ test_all() {
       fi
     done || return 1
   done
+  find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | xargs ls -td1 | cut -d "/" -f 4 | egrep "$test_pattern" | while read test_name ; do
+    if ! test_listed_as_attempted "$test_name" ; then
+      echo "# ERROR: tests completed by $test_name seems to have been skipped"
+      exit 1
+    fi
+  done || exit 1
 }
 
 main() {

--- a/tests/system/test.sh
+++ b/tests/system/test.sh
@@ -225,7 +225,6 @@ test_single() {
     echo "---"
     return 1
   fi
-  echo "# marking test as successful"
 }
 
 test_listed_as_successful() {

--- a/tests/system/test.sh
+++ b/tests/system/test.sh
@@ -226,7 +226,6 @@ test_single() {
     return 1
   fi
   echo "# marking test as successful"
-  echo "$test_name" >> $tests_successful_file
 }
 
 test_listed_as_successful() {
@@ -298,7 +297,13 @@ test_all() {
         echo "$test_name" >> $tests_todo_file
       fi
       if should_attempt_test "$test_name" "$test_pattern" ; then
-        test_single "$test_name" || exit 1
+        test_single "$test_name"
+        if [ $? -eq 0 ] ; then
+          echo "$test_name" >> $tests_successful_file
+        else
+          echo "$test_name" >> $tests_failed_file
+          exit 1
+        fi
       else
         echo "# should not attempt $test_name"
       fi

--- a/tests/system/test.sh
+++ b/tests/system/test.sh
@@ -16,6 +16,9 @@ test_query_file=/tmp/orchestrator-test.sql
 test_restore_outfile=/tmp/orchestrator-test-restore.out
 test_restore_diff_file=/tmp/orchestrator-test-restore.diff
 export deploy_replication_file=/tmp/deploy_replication.log
+tests_todo_file=/tmp/system-tests-todo.txt
+tests_successful_file=/tmp/system-tests-todo.txt
+tests_failed_file=/tmp/system-tests-todo.txt
 
 exec_cmd() {
   echo "$@"
@@ -28,6 +31,18 @@ echo_dot() {
 }
 
 check_environment() {
+  if ! echo "" > $tests_todo_file ; then
+    echo "ERROR: unable to write to $tests_todo_file"
+    exit 1
+  fi
+  if ! echo "" > $tests_successful_file ; then
+    echo "ERROR: unable to write to $tests_successful_file"
+    exit 1
+  fi
+  if ! echo "" > $tests_failed_file ; then
+    echo "ERROR: unable to write to $tests_failed_file"
+    exit 1
+  fi
   echo "checking orchestrator-client"
   if ! which orchestrator-client ; then
     echo "+ not found in PATH"
@@ -161,57 +176,97 @@ test_step() {
   return 0
 }
 
+test_single() {
+  local test_name="$1"
 
-test_all() {
-  test_pattern="${1:-.}"
-  find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | xargs ls -td1 | cut -d "/" -f 4 | egrep "$test_pattern" | while read test_name ; do
+  bash $tests_path/setup 1> $setup_teardown_logfile 2>&1
+  if [ $? -ne 0 ] ; then
+    echo "ERROR global setup failed"
+    cat $setup_teardown_logfile
+    return 1
+  fi
 
-    bash $tests_path/setup 1> $setup_teardown_logfile 2>&1
-    if [ $? -ne 0 ] ; then
-      echo "ERROR global setup failed"
-      cat $setup_teardown_logfile
-      return 1
-    fi
-
-    # test steps:
-    find "$tests_path/$test_name" ! -path . -type d -mindepth 1 -maxdepth 1 | sort | cut -d "/" -f 5 | while read test_step_name ; do
-      [ "$test_step_name" == "." ] && continue
-      test_step "$tests_path/$test_name/$test_step_name" "$test_name" "$test_step_name"
-      if [ $? -ne 0 ] ; then
-        echo "+ FAIL"
-        bash $tests_path/debug_dump
-        return 1
-      fi
-      echo "+ pass"
-    done || return 1
-
-    # test main step:
-    test_step "$tests_path/$test_name" "$test_name" "main"
+  # test steps:
+  find "$tests_path/$test_name" ! -path . -type d -mindepth 1 -maxdepth 1 | sort | cut -d "/" -f 5 | while read test_step_name ; do
+    [ "$test_step_name" == "." ] && continue
+    test_step "$tests_path/$test_name/$test_step_name" "$test_name" "$test_step_name"
     if [ $? -ne 0 ] ; then
       echo "+ FAIL"
       bash $tests_path/debug_dump
       return 1
     fi
     echo "+ pass"
+  done || return 1
 
-    bash $tests_path/teardown 1> $setup_teardown_logfile 2>&1
-    if [ $? -ne 0 ] ; then
-      echo "ERROR global teardown failed"
-      cat $setup_teardown_logfile
+  # test main step:
+  test_step "$tests_path/$test_name" "$test_name" "main"
+  if [ $? -ne 0 ] ; then
+    echo "+ FAIL"
+    bash $tests_path/debug_dump
+    return 1
+  fi
+  echo "+ pass"
+
+  bash $tests_path/teardown 1> $setup_teardown_logfile 2>&1
+  if [ $? -ne 0 ] ; then
+    echo "ERROR global teardown failed"
+    cat $setup_teardown_logfile
+    return 1
+  fi
+
+  bash $tests_path/check_restore > $test_restore_outfile
+  diff -b $tests_path/expect_restore $test_restore_outfile > $test_restore_diff_file
+  diff_result=$?
+  if [ $diff_result -ne 0 ] ; then
+    echo
+    echo "ERROR $test_name restore failure. cat $test_restore_diff_file"
+    echo "---"
+    cat $test_restore_diff_file
+    echo "---"
+    return 1
+  fi
+  echo "$check_test_name" >> $tests_successful_file  
+}
+
+test_listed_as_successful() {
+  local check_test_name="$1"
+  cat $tests_successful_file | egrep -q "^$check_test_name\$"
+}
+
+test_listed_as_failed() {
+  local check_test_name="$1"
+  cat $tests_failed_file | egrep -q "^$check_test_name\$"
+}
+
+should_attempt_test() {
+  local check_test_name="$1"
+  if test_listed_as_successful $check_test_name ; then
+    return 1
+  fi
+  if test_listed_as_failed $check_test_name ; then
+    return 1
+  fi
+  # iterate dependencies
+  (cat ${tests_path}/${check_test_name}/depends-on 2> /dev/null || echo -n "") | while read dependency ; do
+    if test_listed_as_failed $dependency ; then
+      # dependency has failed; fail this test, too
+      echo "$check_test_name" >> $tests_failed_file
       return 1
     fi
-
-    bash $tests_path/check_restore > $test_restore_outfile
-    diff -b $tests_path/expect_restore $test_restore_outfile > $test_restore_diff_file
-    diff_result=$?
-    if [ $diff_result -ne 0 ] ; then
-      echo
-      echo "ERROR $test_name restore failure. cat $test_restore_diff_file"
-      echo "---"
-      cat $test_restore_diff_file
-      echo "---"
+  done
+  (cat ${tests_path}/${check_test_name}/depends-on 2> /dev/null || echo -n "") | while read dependency ; do
+    if ! test_listed_as_successful $dependency ; then
+      # dependency hasn't been successful (yet?)
       return 1
     fi
+  done
+  return 0
+}
+
+test_all() {
+  test_pattern="${1:-.}"
+  find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | xargs ls -td1 | cut -d "/" -f 4 | egrep "$test_pattern" | while read test_name ; do
+    test_single "$test_name" || exit 1
   done || return 1
 }
 

--- a/tests/system/test.sh
+++ b/tests/system/test.sh
@@ -272,15 +272,15 @@ should_attempt_test() {
     if test_listed_as_failed $dependency ; then
       # dependency has failed; fail this test, too
       echo "$check_test_name" >> $tests_failed_file
-      return 1
+      exit 1
     fi
-  done
+  done || return 1
   (cat ${tests_path}/${check_test_name}/depends-on 2> /dev/null || echo -n "") | while read dependency ; do
     if ! test_listed_as_successful $dependency ; then
       # dependency hasn't been successful (yet?)
-      return 1
+      exit 1
     fi
-  done
+  done || return 1
   return 0
 }
 


### PR DESCRIPTION
Each test will be able to specify a list of dependency tests via `depends-on` file, listing one test per line.

A test will only run iff all of its dependencies have run successfully.
A test will be automatically marked as failed if one of its dependency has failed.

This implies ordering of system tests.
