### PR TITLE
Fixed ReadUnambiguousSuggestedClusterAliases logic

### DIFF
--- a/go/inst/cluster_alias_dao.go
+++ b/go/inst/cluster_alias_dao.go
@@ -195,7 +195,7 @@ func ReplaceAliasClusterName(oldClusterName string, newClusterName string) (err 
 	return err
 }
 
-// ReadUnambiguousSuggestedClusterAliases reads hostname:port who have suggested cluster aliases,
+// ReadUnambiguousSuggestedClusterAliases reads potential master hostname:port who have suggested cluster aliases,
 // where no one else shares said suggested cluster alias. Such hostname:port are likely true owners
 // of the alias.
 func ReadUnambiguousSuggestedClusterAliases() (result map[string]InstanceKey, err error) {
@@ -210,6 +210,7 @@ func ReadUnambiguousSuggestedClusterAliases() (result map[string]InstanceKey, er
 			database_instance
 		where
 			suggested_cluster_alias != ''
+			and replication_depth=0
 		group by
 			suggested_cluster_alias
 		having

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1774,8 +1774,12 @@ func TakeMaster(instanceKey *InstanceKey, allowTakingCoMaster bool) (*Instance, 
 	// swap is done!
 
 Cleanup:
-	instance, _ = StartSlave(&instance.Key)
-	masterInstance, _ = StartSlave(&masterInstance.Key)
+	if instance != nil {
+		instance, _ = StartSlave(&instance.Key)
+	}
+	if masterInstance != nil {
+		masterInstance, _ = StartSlave(&masterInstance.Key)
+	}
 	if err != nil {
 		return instance, err
 	}


### PR DESCRIPTION
`ReadUnambiguousSuggestedClusterAliases` logic was broken ever since a change where `suggested_cluster_alias` value in `database_instance` got copied onto replicas.

`ReadUnambiguousSuggestedClusterAliases` was (only) used for ending downtime on a `lost-in-recovery` server found to be back in a `master` position. The broken version of `ReadUnambiguousSuggestedClusterAliases` could not identify said `master` as an unambiguous master, hence downtime was never ended.