### PR TITLE
ascii topology: indicate errant GTID

### DIFF
--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -512,7 +512,11 @@ func (this *Instance) descriptionTokens() (tokens []string) {
 			extraTokens = append(extraTokens, ">>")
 		}
 		if this.UsingGTID() || this.SupportsOracleGTID {
-			extraTokens = append(extraTokens, "GTID")
+			token := "GTID"
+			if this.GtidErrant != "" {
+				token = fmt.Sprintf("%s:errant", token)
+			}
+			extraTokens = append(extraTokens, token)
 		}
 		if this.UsingPseudoGTID {
 			extraTokens = append(extraTokens, "P-GTID")


### PR DESCRIPTION
In `orchestrator[-client] -c topology[-tabulated]`, and for GTID enabled servers, indicate if there's an errant GTID by appending `:errant`, as follows:

```shell
$ orchestrator-client -c topology-tabulated -alias ci
127.0.0.1:10111  |0s|ok|5.7.26-log|rw|ROW|>>,GTID
+ 127.0.0.1:10112|0s|ok|5.7.26-log|ro|ROW|>>,GTID
+ 127.0.0.1:10113|0s|ok|5.7.26-log|ro|ROW|>>,GTID
+ 127.0.0.1:10114|0s|ok|5.7.26-log|ro|ROW|>>,GTID:errant
```