### PR TITLE
orchestrator-client: return raw JSON for api call on error

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -3081,11 +3081,10 @@ func (this *HttpAPI) gracefulMasterTakeover(params martini.Params, r render.Rend
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error(), Details: topologyRecovery})
 		return
 	}
-	if topologyRecovery.SuccessorKey == nil {
+	if topologyRecovery == nil || topologyRecovery.SuccessorKey == nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: "graceful-master-takeover: no successor promoted", Details: topologyRecovery})
 		return
 	}
-
 	Respond(r, &APIResponse{Code: OK, Message: "graceful-master-takeover: successor promoted", Details: topologyRecovery})
 }
 

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -777,7 +777,7 @@ func Repoint(instanceKey *InstanceKey, masterKey *InstanceKey, gtidHint Operatio
 	masterIsAccessible := (err == nil)
 	if !masterIsAccessible {
 		master, _, err = ReadInstance(masterKey)
-		if err != nil {
+		if master == nil || err != nil {
 			return instance, err
 		}
 	}

--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -250,6 +250,7 @@ function api {
   local curl_auth_params="$(get_curl_auth_params)"
 
   path="$1"
+  raw_output="${2:-}"
 
   uri="$leader_api/$path"
   # echo $uri
@@ -281,8 +282,12 @@ function api {
   fi
   api_details=$(echo $api_response | jq '.Details')
   if echo $api_response | jq -r '.Code' | grep -q "ERROR" ; then
-    echo $api_response | jq -r '.Message' | tr -d "'" | xargs >&2 echo
-    [ "$api_details" != "null" ] && echo $api_details
+    if [ -n "$raw_output" ] ; then
+      echo $api_response
+    else
+      echo $api_response | jq -r '.Message' | tr -d "'" | xargs >&2 echo
+      [ "$api_details" != "null" ] && echo $api_details
+    fi
     exit 1
   fi
 }
@@ -329,7 +334,7 @@ function which_api {
 
 function api_call {
   assert_nonempty "path" "$api_path"
-  api "$api_path"
+  api "$api_path" "true"
   print_response
 }
 


### PR DESCRIPTION
Fixes #949 

when running `orchestrator-client -c api -path ...` and operation returns with error, return complete JSON as opposed to parsing the error text. 

Parsing the error text remains on all "normal" commands. For example, consider these two calls:

```shell
$ orchestrator-client -c stop-replica -i 127.0.0.1:10119
dial tcp 127.0.0.1:10119: connect: connection refused
```

```shell
$ orchestrator-client -c api -path stop-replica/127.0.0.1/10119
{ "Code": "ERROR", "Message": "dial tcp 127.0.0.1:10119: connect: connection refused", "Details": null }
```