### PR TITLE
system tests and ci-env: enable raft

### DIFF
--- a/conf/orchestrator-ci-env.conf.json
+++ b/conf/orchestrator-ci-env.conf.json
@@ -81,6 +81,13 @@
   "MasterFailoverDetachReplicaMasterHost": false,
   "MasterFailoverLostInstancesDowntimeMinutes": 0,
   "PostponeReplicaRecoveryOnLagMinutes": 0,
+  "RaftEnabled": true,
+  "RaftDataDir": "/tmp",
+  "RaftBind": "127.0.0.1",
+  "DefaultRaftPort": 10008,
+  "RaftNodes": [
+    "127.0.0.1"
+  ],
   "ConsulAddress": "127.0.0.1:8500",
   "ConsulAclToken": ""
 }

--- a/tests/system/orchestrator-ci-system.conf.json
+++ b/tests/system/orchestrator-ci-system.conf.json
@@ -81,6 +81,13 @@
   "MasterFailoverDetachReplicaMasterHost": false,
   "MasterFailoverLostInstancesDowntimeMinutes": 0,
   "PostponeReplicaRecoveryOnLagMinutes": 0,
+  "RaftEnabled": true,
+  "RaftDataDir": "/tmp",
+  "RaftBind": "127.0.0.1",
+  "DefaultRaftPort": 10008,
+  "RaftNodes": [
+    "127.0.0.1"
+  ],
   "ConsulAddress": "127.0.0.1:8500",
   "ConsulAclToken": ""
 }


### PR DESCRIPTION
configure `orchestrator` [to run raft](https://github.com/openark/orchestrator/blob/master/docs/configuration-raft.md) in CI-env and in system tests. While `orchestrator` operates as a single raft node in a single-node cluster, this still tests all raft functionality in terms of message passing.