### PR TITLE
remove NoValidSemiSyncReplicasStructureWarning

### DIFF
--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -68,7 +68,6 @@ const (
 	ErrantGTIDStructureWarning                                               = "ErrantGTIDStructureWarning"
 	NoFailoverSupportStructureWarning                                        = "NoFailoverSupportStructureWarning"
 	NoWriteableMasterStructureWarning                                        = "NoWriteableMasterStructureWarning"
-	NoValidSemiSyncReplicasStructureWarning                                  = "NoValidSemiSyncReplicasStructureWarning"
 	NotEnoughValidSemiSyncReplicasStructureWarning                           = "NotEnoughValidSemiSyncReplicasStructureWarning"
 )
 

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -555,13 +555,9 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 				a.StructureAnalysis = append(a.StructureAnalysis, NoWriteableMasterStructureWarning)
 			}
 
-			if a.IsMaster && a.SemiSyncMasterEnabled && !a.SemiSyncMasterStatus && a.SemiSyncMasterWaitForReplicaCount > 0 && a.SemiSyncMasterClients == 0 {
-				a.StructureAnalysis = append(a.StructureAnalysis, NoValidSemiSyncReplicasStructureWarning)
-			}
-			if a.IsMaster && a.SemiSyncMasterEnabled && !a.SemiSyncMasterStatus && a.SemiSyncMasterWaitForReplicaCount > 0 && a.SemiSyncMasterClients > 0 && a.SemiSyncMasterClients < a.SemiSyncMasterWaitForReplicaCount {
+			if a.IsMaster && a.SemiSyncMasterEnabled && !a.SemiSyncMasterStatus && a.SemiSyncMasterWaitForReplicaCount > 0 && a.SemiSyncMasterClients < a.SemiSyncMasterWaitForReplicaCount {
 				a.StructureAnalysis = append(a.StructureAnalysis, NotEnoughValidSemiSyncReplicasStructureWarning)
 			}
-
 		}
 		appendAnalysis(&a)
 

--- a/tests/integration/analysis-semi-sync-no-valid-replicas/expect_output
+++ b/tests/integration/analysis-semi-sync-no-valid-replicas/expect_output
@@ -1,1 +1,1 @@
-testhost:22293 (cluster testhost:22293): NoValidSemiSyncReplicasStructureWarning
+testhost:22293 (cluster testhost:22293): NotEnoughValidSemiSyncReplicasStructureWarning


### PR DESCRIPTION
`NotEnoughValidSemiSyncReplicasStructureWarning` covers the case that used to be called `NoValidSemiSyncReplicasStructureWarning`