### PR TITLE
Skip Verify should be SSLSkipVerify Instead the mysql backend config.

### DIFF
--- a/go/raft/http_client.go
+++ b/go/raft/http_client.go
@@ -40,7 +40,7 @@ func setupHttpClient() error {
 	}
 
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: config.Config.MySQLOrchestratorSSLSkipVerify,
+		InsecureSkipVerify: config.Config.SSLSkipVerify,
 	}
 	if config.Config.UseSSL {
 		caPool, err := ssl.ReadCAFile(config.Config.SSLCAFile)


### PR DESCRIPTION
Hello.

Related issue: https://github.com/openark/orchestrator/issues/dev/null (couldn't create an issue :D)

### Description

This PR fixes the configuration in the Raft http_client setup. Currently to skip the validation for raft SSL setup is with the variable MySQLOrchestratorSSLSkipVerify which should be used only to skip the validation against the MySQL backend for orchestrator. Instead, I have changed the variable for SSLSkipVerify which I guess is the right one.
