### PR TITLE
Fixing SQLite3 issue on CI action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,14 @@ jobs:
     - name: Test unit
       run:  script/test-unit
 
+    - name: Update packages
+      run:  sudo apt-get update
+
     - name: Set up SQLite
-      run:  sudo apt-get update && sudo apt-get install sqlite3
+      run:  sudo apt-get install sqlite3
 
     - name: Start local MySQL
-      run: sudo /etc/init.d/mysql start
+      run:  sudo /etc/init.d/mysql start
 
     - name: Test integration
       run:  script/test-integration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       run:  script/test-unit
 
     - name: Set up SQLite
-      run:  cat /etc/*release && uname -a && sudo apt-get install sqlite3
+      run:  sudo apt-get update && sudo apt-get install sqlite3
 
     - name: Start local MySQL
       run: sudo /etc/init.d/mysql start

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       run:  script/test-unit
 
     - name: Set up SQLite
-      run:  sudo apt-get install sqlite3
+      run:  cat /etc/*release && uname -a && sudo apt-get install sqlite3
 
     - name: Start local MySQL
       run: sudo /etc/init.d/mysql start


### PR DESCRIPTION
CI (`main.yml`) job started consistently failing due to:

```
Run sudo apt-get install sqlite3
  sudo apt-get install sqlite3
  shell: /bin/bash -e {0}
  env:
    GOROOT: /opt/hostedtoolcache/go/1.14.4/x64
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  sqlite3-doc
The following NEW packages will be installed:
  sqlite3
0 upgraded, 1 newly installed, 0 to remove and 11 not upgraded.
Need to get 752 kB of archives.
After this operation, 2482 kB of additional disk space will be used.
Ign:1 http://azure.archive.ubuntu.com/ubuntu bionic-updates/main amd64 sqlite3 amd64 3.22.0-1ubuntu0.3
Err:1 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 sqlite3 amd64 3.22.0-1ubuntu0.3
  404  Not Found [IP: 52.168.50.79 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/s/sqlite3/sqlite3_3.22.0-1ubuntu0.3_amd64.deb  404  Not Found [IP: 52.168.50.79 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

(example: https://github.com/openark/orchestrator/pull/1191/checks?check_run_id=769374544)

Checking why this happened (did GitHub's Action image change?) and fixing it