### PR TITLE
Return the correct discovery queue length and adjust documentation.

### DIFF
--- a/go/discovery/queue.go
+++ b/go/discovery/queue.go
@@ -124,12 +124,14 @@ func (q *Queue) collectStatistics() {
 	}
 }
 
-// QueueLen returns the length of the queue (channel size + queued size)
+// QueueLen returns the length of the 2 queue maps, those keys which
+// are queued, queuedKeys (not being processed yet) and consumedKeys
+// (those where discovery is actively taking place)
 func (q *Queue) QueueLen() int {
 	q.Lock()
 	defer q.Unlock()
 
-	return len(q.queue) + len(q.queuedKeys)
+	return len(q.queuedKeys) + len(q.consumedKeys)
 }
 
 // Push enqueues a key if it is not on a queue and is not being


### PR DESCRIPTION
See: https://github.com/openark/orchestrator/issues/909


### Description

The discovery queue length being returned was incorrect.

This patch resolves that and adjusts documentation for `queue.QueueLen()` to correctly explain what is being returned.

- [X] contributed code is using same conventions as original code
