### PR TITLE
fix out of range in semi_sync_master_timeout

### DIFF
--- a/go/db/generate_patches.go
+++ b/go/db/generate_patches.go
@@ -577,7 +577,7 @@ var generateSQLPatches = []string{
 			ADD COLUMN semi_sync_available TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER semi_sync_enforced
 	`,
 	`
-		ALTER TABLE
+		ALTER TABLE /* sqlite3-skip */
 			database_instance
 			MODIFY COLUMN semi_sync_master_timeout BIGINT UNSIGNED NOT NULL DEFAULT 0
 	`,

--- a/go/db/generate_patches.go
+++ b/go/db/generate_patches.go
@@ -579,6 +579,6 @@ var generateSQLPatches = []string{
 	`
 		ALTER TABLE /* sqlite3-skip */
 			database_instance
-			MODIFY COLUMN semi_sync_master_timeout BIGINT UNSIGNED NOT NULL DEFAULT 0
+			MODIFY semi_sync_master_timeout BIGINT UNSIGNED NOT NULL DEFAULT 0
 	`,
 }

--- a/go/db/generate_patches.go
+++ b/go/db/generate_patches.go
@@ -576,4 +576,9 @@ var generateSQLPatches = []string{
 			database_instance
 			ADD COLUMN semi_sync_available TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER semi_sync_enforced
 	`,
+	`
+		ALTER TABLE
+			database_instance
+			MODIFY COLUMN semi_sync_master_timeout BIGINT UNSIGNED NOT NULL DEFAULT 0
+	`,
 }

--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -97,7 +97,7 @@ type Instance struct {
 	SemiSyncEnforced                  bool
 	SemiSyncMasterEnabled             bool
 	SemiSyncReplicaEnabled            bool
-	SemiSyncMasterTimeout             uint
+	SemiSyncMasterTimeout             int64
 	SemiSyncMasterWaitForReplicaCount uint
 	SemiSyncMasterStatus              bool
 	SemiSyncMasterClients             uint

--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -97,7 +97,7 @@ type Instance struct {
 	SemiSyncEnforced                  bool
 	SemiSyncMasterEnabled             bool
 	SemiSyncReplicaEnabled            bool
-	SemiSyncMasterTimeout             int64
+	SemiSyncMasterTimeout             uint64
 	SemiSyncMasterWaitForReplicaCount uint
 	SemiSyncMasterStatus              bool
 	SemiSyncMasterClients             uint

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -429,7 +429,7 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 						instance.SemiSyncMasterEnabled = (m.GetString("Value") == "ON")
 						semiSyncMasterPluginLoaded = true
 					} else if m.GetString("Variable_name") == "rpl_semi_sync_master_timeout" {
-						instance.SemiSyncMasterTimeout = m.GetInt64("Value")
+						instance.SemiSyncMasterTimeout = m.GetUint64("Value")
 					} else if m.GetString("Variable_name") == "rpl_semi_sync_master_wait_for_slave_count" {
 						instance.SemiSyncMasterWaitForReplicaCount = m.GetUint("Value")
 					} else if m.GetString("Variable_name") == "rpl_semi_sync_slave_enabled" {
@@ -1139,7 +1139,7 @@ func readInstanceRow(m sqlutils.RowMap) *Instance {
 	instance.SemiSyncEnforced = m.GetBool("semi_sync_enforced")
 	instance.SemiSyncAvailable = m.GetBool("semi_sync_available")
 	instance.SemiSyncMasterEnabled = m.GetBool("semi_sync_master_enabled")
-	instance.SemiSyncMasterTimeout = m.GetInt64("semi_sync_master_timeout")
+	instance.SemiSyncMasterTimeout = m.GetUint64("semi_sync_master_timeout")
 	instance.SemiSyncMasterWaitForReplicaCount = m.GetUint("semi_sync_master_wait_for_slave_count")
 	instance.SemiSyncReplicaEnabled = m.GetBool("semi_sync_replica_enabled")
 	instance.SemiSyncMasterStatus = m.GetBool("semi_sync_master_status")

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -429,7 +429,7 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 						instance.SemiSyncMasterEnabled = (m.GetString("Value") == "ON")
 						semiSyncMasterPluginLoaded = true
 					} else if m.GetString("Variable_name") == "rpl_semi_sync_master_timeout" {
-						instance.SemiSyncMasterTimeout = m.GetUint("Value")
+						instance.SemiSyncMasterTimeout = m.GetInt64("Value")
 					} else if m.GetString("Variable_name") == "rpl_semi_sync_master_wait_for_slave_count" {
 						instance.SemiSyncMasterWaitForReplicaCount = m.GetUint("Value")
 					} else if m.GetString("Variable_name") == "rpl_semi_sync_slave_enabled" {
@@ -1139,7 +1139,7 @@ func readInstanceRow(m sqlutils.RowMap) *Instance {
 	instance.SemiSyncEnforced = m.GetBool("semi_sync_enforced")
 	instance.SemiSyncAvailable = m.GetBool("semi_sync_available")
 	instance.SemiSyncMasterEnabled = m.GetBool("semi_sync_master_enabled")
-	instance.SemiSyncMasterTimeout = m.GetUint("semi_sync_master_timeout")
+	instance.SemiSyncMasterTimeout = m.GetInt64("semi_sync_master_timeout")
 	instance.SemiSyncMasterWaitForReplicaCount = m.GetUint("semi_sync_master_wait_for_slave_count")
 	instance.SemiSyncReplicaEnabled = m.GetBool("semi_sync_replica_enabled")
 	instance.SemiSyncMasterStatus = m.GetBool("semi_sync_master_status")


### PR DESCRIPTION


Solves issue: https://github.com/openark/orchestrator/issues/1205


### Description

This PR  sets `semi_sync_master_timeout` as `bigint` to avoid out of range (overflow) errors.