### PR TITLE
Recovery: relaxed promotion rule check searching for ideal replica

### DIFF
--- a/go/inst/instance_utils.go
+++ b/go/inst/instance_utils.go
@@ -146,7 +146,7 @@ func (this *InstancesSorterByExec) Less(i, j int) bool {
 			return true
 		}
 		// Prefer candidates:
-		if this.instances[j].PromotionRule.SmallerThan(this.instances[i].PromotionRule) {
+		if this.instances[j].PromotionRule.BetterThan(this.instances[i].PromotionRule) {
 			return true
 		}
 	}

--- a/go/inst/promotion_rule.go
+++ b/go/inst/promotion_rule.go
@@ -26,10 +26,10 @@ type CandidatePromotionRule string
 
 const (
 	MustPromoteRule      CandidatePromotionRule = "must"
-	PreferPromoteRule                           = "prefer"
-	NeutralPromoteRule                          = "neutral"
-	PreferNotPromoteRule                        = "prefer_not"
-	MustNotPromoteRule                          = "must_not"
+	PreferPromoteRule    CandidatePromotionRule = "prefer"
+	NeutralPromoteRule   CandidatePromotionRule = "neutral"
+	PreferNotPromoteRule CandidatePromotionRule = "prefer_not"
+	MustNotPromoteRule   CandidatePromotionRule = "must_not"
 )
 
 var promotionRuleOrderMap = map[CandidatePromotionRule]int{
@@ -40,8 +40,12 @@ var promotionRuleOrderMap = map[CandidatePromotionRule]int{
 	MustNotPromoteRule:   4,
 }
 
-func (this *CandidatePromotionRule) SmallerThan(other CandidatePromotionRule) bool {
-	return promotionRuleOrderMap[*this] < promotionRuleOrderMap[other]
+func (this *CandidatePromotionRule) BetterThan(other CandidatePromotionRule) bool {
+	otherOrder, ok := promotionRuleOrderMap[other]
+	if !ok {
+		return false
+	}
+	return promotionRuleOrderMap[*this] < otherOrder
 }
 
 // ParseCandidatePromotionRule returns a CandidatePromotionRule by name.

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -514,18 +514,16 @@ func recoverDeadMaster(topologyRecovery *TopologyRecovery, candidateInstanceKey 
 			return false
 		}
 		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: promotedReplicaIsIdeal(%+v)", promoted.Key))
-		if promoted.Key.Equals(candidateInstanceKey) {
-			return true
+		if candidateInstanceKey != nil { //explicit request to promote a specific server
+			return promoted.Key.Equals(candidateInstanceKey)
 		}
-		if candidateInstanceKey == nil { // No explicit request to promote a specific server
-			if promoted.DataCenter == topologyRecovery.AnalysisEntry.AnalyzedInstanceDataCenter &&
-				promoted.PhysicalEnvironment == topologyRecovery.AnalysisEntry.AnalyzedInstancePhysicalEnvironment {
-				if promoted.PromotionRule == inst.MustPromoteRule || promoted.PromotionRule == inst.PreferPromoteRule ||
-					(hasBestPromotionRule && promoted.PromotionRule != inst.MustNotPromoteRule) {
-					AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: found %+v to be ideal candidate; will optimize recovery", promoted.Key))
-					postponedAll = true
-					return true
-				}
+		if promoted.DataCenter == topologyRecovery.AnalysisEntry.AnalyzedInstanceDataCenter &&
+			promoted.PhysicalEnvironment == topologyRecovery.AnalysisEntry.AnalyzedInstancePhysicalEnvironment {
+			if promoted.PromotionRule == inst.MustPromoteRule || promoted.PromotionRule == inst.PreferPromoteRule ||
+				(hasBestPromotionRule && promoted.PromotionRule != inst.MustNotPromoteRule) {
+				AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: found %+v to be ideal candidate; will optimize recovery", promoted.Key))
+				postponedAll = true
+				return true
 			}
 		}
 		return false


### PR DESCRIPTION
The _current_ recovery logic has a mechanism to optimize recovery time on a dead master scenario:

1. If replicas are probed
2. And one is picked as candidate to be promoted (based on binlogs, version, configuraiton)
3. And it's in the same DC and environment as the dead master
4. And it has `prefer` (or `must`, which is yet unsupported) promotion rule

then, we we consider the replica as "ideal", immediately promote it as master, and asynchronously point the rest of replicas below it.

While analyzing a recent production use case, I noticed a setup where all servers were either marked as `neutral` or `must_not`. None was marked with `prefer`. In that scenario, the recovery was not optimized.

In this PR:

- as long as the server is not marked with `must_not` promotion rule
- if it has the best promotion rule from among the replicas it would own after promotion, then it's an "ideal" replica.