### PR TITLE
Better analysis of UnreachableMaster

### DIFF
--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -503,10 +503,12 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			a.Description = "Master cannot be reached by orchestrator and all of its replicas are lagging"
 			//
 		} else if a.IsMaster && !a.LastCheckValid && !a.LastCheckPartialSuccess && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
+			// partial success is here to redice noise
 			a.Analysis = UnreachableMaster
 			a.Description = "Master cannot be reached by orchestrator but it has replicating replicas; possibly a network/host issue"
 			//
 		} else if a.IsMaster && !a.LastCheckValid && a.LastCheckPartialSuccess && a.CountReplicasFailingToConnectToMaster > 0 && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
+			// there's partial success, but also at least one replica is failing to connect to master
 			a.Analysis = UnreachableMaster
 			a.Description = "Master cannot be reached by orchestrator but it has replicating replicas; possibly a network/host issue"
 			//

--- a/tests/integration/analysis-unreachable-master-partial-success-broken-replica/create.sql
+++ b/tests/integration/analysis-unreachable-master-partial-success-broken-replica/create.sql
@@ -1,0 +1,3 @@
+UPDATE database_instance SET last_seen=last_checked - interval 1 minute where port=22293;
+-- UPDATE database_instance SET last_check_partial_success = 1 where port=22293;
+UPDATE database_instance SET slave_io_running=0, last_io_error='error connecting to master' where port=22294;

--- a/tests/integration/analysis-unreachable-master-partial-success-broken-replica/create.sql
+++ b/tests/integration/analysis-unreachable-master-partial-success-broken-replica/create.sql
@@ -1,3 +1,3 @@
 UPDATE database_instance SET last_seen=last_checked - interval 1 minute where port=22293;
--- UPDATE database_instance SET last_check_partial_success = 1 where port=22293;
+UPDATE database_instance SET last_check_partial_success = 1 where port=22293;
 UPDATE database_instance SET slave_io_running=0, last_io_error='error connecting to master' where port=22294;

--- a/tests/integration/analysis-unreachable-master-partial-success-broken-replica/expect_output
+++ b/tests/integration/analysis-unreachable-master-partial-success-broken-replica/expect_output
@@ -1,0 +1,2 @@
+testhost:22293 (cluster testhost:22293): UnreachableMaster
+testhost:22294 (cluster testhost:22293): FirstTierReplicaFailingToConnectToMaster

--- a/tests/integration/analysis-unreachable-master-partial-success-broken-replica/extra_args
+++ b/tests/integration/analysis-unreachable-master-partial-success-broken-replica/extra_args
@@ -1,0 +1,1 @@
+-c replication-analysis

--- a/tests/integration/test.sh
+++ b/tests/integration/test.sh
@@ -190,6 +190,7 @@ generate_config_file() {
   cp ${tests_path}/orchestrator.conf.json ${test_config_file}
   sed -i -e "s/backend-db-placeholder/${db_type}/g" ${test_config_file}
   sed -i -e "s^sqlite-data-file-placeholder^${sqlite_file}^g" ${test_config_file}
+  touch "$test_mysql_defaults_file" # required even for sqlite because config file references the my.cnf cgf file
   echo "- generate_config_file OK"
 }
 
@@ -202,7 +203,7 @@ test_all() {
   echo "- deploy_internal_db OK"
 
   test_pattern="${1:-.}"
-  find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | xargs ls -td1 | cut -d "/" -f 4 | egrep "$test_pattern" | while read test_name ; do
+  find $tests_path -mindepth 1 -maxdepth 1 ! -path . -type d | xargs ls -td1 | cut -d "/" -f 4 | egrep "$test_pattern" | while read test_name ; do
     test_single "$test_name"
     if [ $? -ne 0 ] ; then
       echo "+ FAIL"


### PR DESCRIPTION
Improvement to `UnreachableMaster` analysis. Previously, when there was partial success probing a dead master, and at least some replicas were claiming to be replicating, `orchestrator` would not issue an analysis.
Now, however, if `orchestrator` cannot see the master, even if there's partial success, and at least one replica is failing to connect to the master (while other replicas claim to be connected to the master), an `UnreachableMaster` analysis is issued. That, in turn, will spawn emergent probing of 1st tier replicas to potentially identify a `DeadMaster` incident more quickly. 