### PR TITLE
docs: Removed long running queries leftover

### DIFF
--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -7,11 +7,6 @@ places (once in the `cluster` page, once in the `problems` drop down) in two dif
 
 If you want to get the most up to date instance status, use the "Refresh" button on the instance's _settings dialog_.  
 
-* Similarly, on `Long Queries` page the queries presented are true to a point in time in the last minute (or otherwise the
-`InstancePollSeconds` settings). Thus, it is possible that by the time you look at this page, the queries listed will have been
-completed. If you choose to click the `Kill query` button, please be advised that you might actually be killing a *different*
-query, executing on same connection following up on the by-now-completed listed long running query.
-
 * It could take a couple of minutes for `orchestrator` to fully detect a cluster's topology. The time depends on the depth
 of the topology (if you have replicas-of-replicas the time increases). This is due to the fact that `orchestrator` polls the instances independently, and an insight on the topology must propagate from master to replica on the next polling occasion.
 

--- a/docs/using-the-web-interface.md
+++ b/docs/using-the-web-interface.md
@@ -101,6 +101,3 @@ The `Audit` page presents with all actions taken via `orchestrator`: replica mov
 (`START SLAVE` and `STOP SLAVE` are currently not audited).
 
 ![Orchestrator screenshot](images/orchestrator-audit-small.png)
-
-`Queries` -> `Long queries` page list last met long running queries over the entire topology. these would be
-queries running over `60` seconds, non-replication, non-event-scheduler.


### PR DESCRIPTION
Long running queries section was removed and cleaned up at #726, but
looks like there are still some references to it on the documentation.

Related issue: #1227

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
