### PR TITLE
Using TopologyRecovery as pointer to avoid go vet lock-copy issues

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -3277,7 +3277,7 @@ func (this *HttpAPI) AutomatedRecoveryFilters(params martini.Params, r render.Re
 // AuditFailureDetection provides list of topology_failure_detection entries
 func (this *HttpAPI) AuditFailureDetection(params martini.Params, r render.Render, req *http.Request) {
 
-	var audits []logic.TopologyRecovery
+	var audits []*logic.TopologyRecovery
 	var err error
 
 	if detectionId, derr := strconv.ParseInt(params["id"], 10, 0); derr == nil && detectionId > 0 {
@@ -3325,7 +3325,7 @@ func (this *HttpAPI) ReadReplicationAnalysisChangelog(params martini.Params, r r
 
 // AuditRecovery provides list of topology-recovery entries
 func (this *HttpAPI) AuditRecovery(params martini.Params, r render.Render, req *http.Request) {
-	var audits []logic.TopologyRecovery
+	var audits []*logic.TopologyRecovery
 	var err error
 
 	if recoveryUID := params["uid"]; recoveryUID != "" {

--- a/go/logic/topology_recovery_dao.go
+++ b/go/logic/topology_recovery_dao.go
@@ -268,7 +268,7 @@ func ClearActiveRecoveries() error {
 
 // RegisterBlockedRecoveries writes down currently blocked recoveries, and indicates what recovery they are blocked on.
 // Recoveries are blocked thru the in_active_period flag, which comes to avoid flapping.
-func RegisterBlockedRecoveries(analysisEntry *inst.ReplicationAnalysis, blockingRecoveries []TopologyRecovery) error {
+func RegisterBlockedRecoveries(analysisEntry *inst.ReplicationAnalysis, blockingRecoveries []*TopologyRecovery) error {
 	for _, recovery := range blockingRecoveries {
 		_, err := db.ExecOrchestrator(`
 			insert
@@ -502,8 +502,8 @@ func writeResolveRecovery(topologyRecovery *TopologyRecovery) error {
 }
 
 // readRecoveries reads recovery entry/audit entries from topology_recovery
-func readRecoveries(whereCondition string, limit string, args []interface{}) ([]TopologyRecovery, error) {
-	res := []TopologyRecovery{}
+func readRecoveries(whereCondition string, limit string, args []interface{}) ([]*TopologyRecovery, error) {
+	res := []*TopologyRecovery{}
 	query := fmt.Sprintf(`
 		select
       recovery_id,
@@ -578,7 +578,7 @@ func readRecoveries(whereCondition string, limit string, args []interface{}) ([]
 
 		topologyRecovery.LastDetectionId = m.GetInt64("last_detection_id")
 
-		res = append(res, topologyRecovery)
+		res = append(res, &topologyRecovery)
 		return nil
 	})
 
@@ -586,7 +586,7 @@ func readRecoveries(whereCondition string, limit string, args []interface{}) ([]
 }
 
 // ReadActiveRecoveries reads active recovery entry/audit entries from topology_recovery
-func ReadActiveClusterRecovery(clusterName string) ([]TopologyRecovery, error) {
+func ReadActiveClusterRecovery(clusterName string) ([]*TopologyRecovery, error) {
 	whereClause := `
 		where
 			in_active_period=1
@@ -597,7 +597,7 @@ func ReadActiveClusterRecovery(clusterName string) ([]TopologyRecovery, error) {
 
 // ReadInActivePeriodClusterRecovery reads recoveries (possibly complete!) that are in active period.
 // (may be used to block further recoveries on this cluster)
-func ReadInActivePeriodClusterRecovery(clusterName string) ([]TopologyRecovery, error) {
+func ReadInActivePeriodClusterRecovery(clusterName string) ([]*TopologyRecovery, error) {
 	whereClause := `
 		where
 			in_active_period=1
@@ -606,7 +606,7 @@ func ReadInActivePeriodClusterRecovery(clusterName string) ([]TopologyRecovery, 
 }
 
 // ReadRecentlyActiveClusterRecovery reads recently completed entries for a given cluster
-func ReadRecentlyActiveClusterRecovery(clusterName string) ([]TopologyRecovery, error) {
+func ReadRecentlyActiveClusterRecovery(clusterName string) ([]*TopologyRecovery, error) {
 	whereClause := `
 		where
 			end_recovery > now() - interval 5 minute
@@ -616,7 +616,7 @@ func ReadRecentlyActiveClusterRecovery(clusterName string) ([]TopologyRecovery, 
 
 // ReadInActivePeriodSuccessorInstanceRecovery reads completed recoveries for a given instance, where said instance
 // was promoted as result, still in active period (may be used to block further recoveries should this instance die)
-func ReadInActivePeriodSuccessorInstanceRecovery(instanceKey *inst.InstanceKey) ([]TopologyRecovery, error) {
+func ReadInActivePeriodSuccessorInstanceRecovery(instanceKey *inst.InstanceKey) ([]*TopologyRecovery, error) {
 	whereClause := `
 		where
 			in_active_period=1
@@ -626,7 +626,7 @@ func ReadInActivePeriodSuccessorInstanceRecovery(instanceKey *inst.InstanceKey) 
 }
 
 // ReadRecentlyActiveInstanceRecovery reads recently completed entries for a given instance
-func ReadRecentlyActiveInstanceRecovery(instanceKey *inst.InstanceKey) ([]TopologyRecovery, error) {
+func ReadRecentlyActiveInstanceRecovery(instanceKey *inst.InstanceKey) ([]*TopologyRecovery, error) {
 	whereClause := `
 		where
 			end_recovery > now() - interval 5 minute
@@ -636,7 +636,7 @@ func ReadRecentlyActiveInstanceRecovery(instanceKey *inst.InstanceKey) ([]Topolo
 }
 
 // ReadActiveRecoveries reads active recovery entry/audit entries from topology_recovery
-func ReadActiveRecoveries() ([]TopologyRecovery, error) {
+func ReadActiveRecoveries() ([]*TopologyRecovery, error) {
 	return readRecoveries(`
 		where
 			in_active_period=1
@@ -645,7 +645,7 @@ func ReadActiveRecoveries() ([]TopologyRecovery, error) {
 }
 
 // ReadCompletedRecoveries reads completed recovery entry/audit entries from topology_recovery
-func ReadCompletedRecoveries(page int) ([]TopologyRecovery, error) {
+func ReadCompletedRecoveries(page int) ([]*TopologyRecovery, error) {
 	limit := `
 		limit ?
 		offset ?`
@@ -653,19 +653,19 @@ func ReadCompletedRecoveries(page int) ([]TopologyRecovery, error) {
 }
 
 // ReadRecovery reads completed recovery entry/audit entries from topology_recovery
-func ReadRecovery(recoveryId int64) ([]TopologyRecovery, error) {
+func ReadRecovery(recoveryId int64) ([]*TopologyRecovery, error) {
 	whereClause := `where recovery_id = ?`
 	return readRecoveries(whereClause, ``, sqlutils.Args(recoveryId))
 }
 
 // ReadRecoveryByUID reads completed recovery entry/audit entries from topology_recovery
-func ReadRecoveryByUID(recoveryUID string) ([]TopologyRecovery, error) {
+func ReadRecoveryByUID(recoveryUID string) ([]*TopologyRecovery, error) {
 	whereClause := `where uid = ?`
 	return readRecoveries(whereClause, ``, sqlutils.Args(recoveryUID))
 }
 
 // ReadCRecoveries reads latest recovery entries from topology_recovery
-func ReadRecentRecoveries(clusterName string, clusterAlias string, unacknowledgedOnly bool, page int) ([]TopologyRecovery, error) {
+func ReadRecentRecoveries(clusterName string, clusterAlias string, unacknowledgedOnly bool, page int) ([]*TopologyRecovery, error) {
 	whereConditions := []string{}
 	whereClause := ""
 	args := sqlutils.Args()
@@ -690,8 +690,8 @@ func ReadRecentRecoveries(clusterName string, clusterAlias string, unacknowledge
 }
 
 // readRecoveries reads recovery entry/audit entries from topology_recovery
-func readFailureDetections(whereCondition string, limit string, args []interface{}) ([]TopologyRecovery, error) {
-	res := []TopologyRecovery{}
+func readFailureDetections(whereCondition string, limit string, args []interface{}) ([]*TopologyRecovery, error) {
+	res := []*TopologyRecovery{}
 	query := fmt.Sprintf(`
 		select
       detection_id,
@@ -737,7 +737,7 @@ func readFailureDetections(whereCondition string, limit string, args []interface
 
 		failureDetection.AnalysisEntry.ClusterDetails.ReadRecoveryInfo()
 
-		res = append(res, failureDetection)
+		res = append(res, &failureDetection)
 		return nil
 	})
 
@@ -745,7 +745,7 @@ func readFailureDetections(whereCondition string, limit string, args []interface
 }
 
 // ReadRecentFailureDetections
-func ReadRecentFailureDetections(clusterAlias string, page int) ([]TopologyRecovery, error) {
+func ReadRecentFailureDetections(clusterAlias string, page int) ([]*TopologyRecovery, error) {
 	whereClause := ""
 	args := sqlutils.Args()
 	if clusterAlias != "" {
@@ -760,7 +760,7 @@ func ReadRecentFailureDetections(clusterAlias string, page int) ([]TopologyRecov
 }
 
 // ReadFailureDetection
-func ReadFailureDetection(detectionId int64) ([]TopologyRecovery, error) {
+func ReadFailureDetection(detectionId int64) ([]*TopologyRecovery, error) {
 	whereClause := `where detection_id = ?`
 	return readFailureDetections(whereClause, ``, sqlutils.Args(detectionId))
 }


### PR DESCRIPTION
While this repo doesn't use (yet) `go vet` in CI, it has been noted elsewhere that `go vet` complains about copying a `WaitGroup` as part of `TopologyRecovery` struct.

This PR changes relevant references to pointers.