### PR TITLE
Support for 'X-Forwarded-Group' (customizable) header

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -173,6 +173,7 @@ type Configuration struct {
 	HTTPAuthUser                               string            // Username for HTTP Basic authentication (blank disables authentication)
 	HTTPAuthPassword                           string            // Password for HTTP Basic authentication
 	AuthUserHeader                             string            // HTTP header indicating auth user, when AuthenticationMethod is "proxy"
+	AuthGroupHeader                            string            // HTTP header indicating auth group, when AuthenticationMethod is "proxy"
 	PowerAuthUsers                             []string          // On AuthenticationMethod == "proxy", list of users that can make changes. All others are read-only.
 	PowerAuthGroups                            []string          // list of unix groups the authenticated user must be a member of to make changes.
 	AccessTokenUseExpirySeconds                uint              // Time by which an issued token must be used
@@ -349,6 +350,7 @@ func newConfiguration() *Configuration {
 		HTTPAuthUser:                               "",
 		HTTPAuthPassword:                           "",
 		AuthUserHeader:                             "X-Forwarded-User",
+		AuthGroupHeader:                            "X-Forwarded-Group",
 		PowerAuthUsers:                             []string{"*"},
 		PowerAuthGroups:                            []string{},
 		AccessTokenUseExpirySeconds:                60,


### PR DESCRIPTION
in `"AuthenticationMethod": "proxy"`, the proxy may pass a header called 'X-Forwarded-Group' (configurable via `AuthGroupHeader`). The value should be a comma delimited list of groups the authenticated user belongs to.

`orchestrator` will compare that list with `PowerAuthGroups`. If one of the groups in the list matches one of the groups in `PowerAuthGroups`, then the user is considered to be a power user
