### PR TITLE
Expire cluster_alias entries

### DIFF
--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -551,6 +551,7 @@ func ContinuousDiscovery() {
 					go inst.InjectUnseenMasters()
 
 					go inst.ForgetLongUnseenInstances()
+					go inst.ForgetLongUnseenClusterAliases()
 					go inst.ForgetUnseenInstancesDifferentlyResolved()
 					go inst.ForgetExpiredHostnameResolves()
 					go inst.DeleteInvalidHostnameResolves()


### PR DESCRIPTION
Fixes https://github.com/openark/orchestrator/issues/1245

This PR expires `cluster_alias` entries, based on `UnseenInstanceForgetHours`, same as `database_instance` entries are expired.

The effect is that `orchestrator` properly forgets aliases for clusters that have no instances (ie. created long ago, but which have probably been decomissioned, seeing that there's no instances that associate themselves with said alias).

cc @tomkrouper 