### PR TITLE
Issue #1259 Fix topology-related API endpoints for group replication setups

### DIFF
--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -59,10 +59,14 @@ func getASCIITopologyEntry(depth int, instance *Instance, replicationMap map[*In
 	prefix := ""
 	if depth > 0 {
 		prefix = strings.Repeat(fillerCharacter, (depth-1)*2)
-		if instance.ReplicaRunning() && instance.IsLastCheckValid && instance.IsRecentlyChecked {
-			prefix += "+" + fillerCharacter
+		if instance.IsReplicationGroupSecondary() {
+			prefix += "‡" + fillerCharacter
 		} else {
-			prefix += "-" + fillerCharacter
+			if instance.ReplicaRunning() && instance.IsLastCheckValid && instance.IsRecentlyChecked {
+				prefix += "+" + fillerCharacter
+			} else {
+				prefix += "-" + fillerCharacter
+			}
 		}
 	}
 	entryAlias := ""
@@ -116,12 +120,22 @@ func ASCIITopology(clusterName string, historyTimestampPattern string, tabulated
 	var masterInstance *Instance
 	// Investigate replicas:
 	for _, instance := range instances {
-		master, ok := instancesMap[instance.MasterKey]
+		var masterOrGroupPrimary *Instance
+		var ok bool
+		// If the current instance is a a group member, get the group's primary instead of the classical replication
+		// source.
+		if instance.IsReplicationGroupMember() && instance.IsReplicationGroupSecondary() {
+			masterOrGroupPrimary, ok = instancesMap[instance.ReplicationGroupPrimaryInstanceKey]
+		} else {
+			masterOrGroupPrimary, ok = instancesMap[instance.MasterKey]
+		}
 		if ok {
-			if _, ok := replicationMap[master]; !ok {
-				replicationMap[master] = [](*Instance){}
+			if _, ok := replicationMap[masterOrGroupPrimary]; !ok {
+				replicationMap[masterOrGroupPrimary] = [](*Instance){}
 			}
-			replicationMap[master] = append(replicationMap[master], instance)
+			if !instance.IsReplicationGroupPrimary() || (instance.IsReplicationGroupPrimary() && instance.IsReplica()) {
+				replicationMap[masterOrGroupPrimary] = append(replicationMap[masterOrGroupPrimary], instance)
+			}
 		} else {
 			masterInstance = instance
 		}


### PR DESCRIPTION


<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/1259


### Description

This PR improves methods associated with serving the `/topology.*` endpoints so that replication groups are properly represented. For example, for a topology such as the one shown below:

![image](https://user-images.githubusercontent.com/5791035/98442012-66022580-2102-11eb-8f07-c2d1856b9c13.png)

the topology representation is now such that `orchestrator-client` shows this:

```
[ 10430 ] user@sabre ~/go/src/github.com/openark/orchestrator (master) % ➜  ./resources/bin/orchestrator-client -c topology -i sabre:5000
sabre:5020       [0s,ok,8.0.22,rw,ROW,>>,GTID]
+ sabre:5000     [0s,ok,8.0.22,rw,ROW,>>,GTID]
  ‡ sabre:5001 [0s,ok,8.0.22,ro,ROW,>>,GTID]
  ‡ sabre:5002 [0s,ok,8.0.22,ro,ROW,>>,GTID]
    + sabre:5010 [0s,ok,8.0.22,rw,ROW,>>,GTID]
+ sabre:5022     [0s,ok,8.0.22,rw,ROW,>>,GTID]
  + sabre:5021   [0s,ok,8.0.22,rw,ROW,>>,GTID]
```
Notice that we use the double dagger  character `‡` to distinguish group replication from classical replication. 

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
