### PR TITLE
Skip RestartReplicationQuick() on MariaDB with GTID

### DIFF
--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1526,22 +1526,22 @@ func emergentlyRestartReplicationOnTopologyInstance(instanceKey *inst.InstanceKe
 		return
 	}
 
-	instance, _, err := inst.ReadInstance(instanceKey)
-	if err != nil {
-		return
-	}
-	if instance.UsingMariaDBGTID {
-		// In MariaDB GTID, stopping and starting IO thread actually deletes relay logs.
-		// This is counter productive to our objective.
-		// Specifically, in a situation where the primary is unreachable and where replicas are lagging,
-		// we want to restart IO thread to see if lag is actually caused by locked primary. If this results
-		// with losing relay logs, then we've lost data.
-		// So, unfortunately we avoid this step in MariaDB GTID.
-		// See https://github.com/openark/orchestrator/issues/1260
-		return
-	}
-
 	go inst.ExecuteOnTopology(func() {
+		instance, _, err := inst.ReadInstance(instanceKey)
+		if err != nil {
+			return
+		}
+		if instance.UsingMariaDBGTID {
+			// In MariaDB GTID, stopping and starting IO thread actually deletes relay logs.
+			// This is counter productive to our objective.
+			// Specifically, in a situation where the primary is unreachable and where replicas are lagging,
+			// we want to restart IO thread to see if lag is actually caused by locked primary. If this results
+			// with losing relay logs, then we've lost data.
+			// So, unfortunately we avoid this step in MariaDB GTID.
+			// See https://github.com/openark/orchestrator/issues/1260
+			return
+		}
+
 		inst.RestartReplicationQuick(instanceKey)
 		inst.AuditOperation("emergently-restart-replication-topology-instance", instanceKey, string(analysisCode))
 	})


### PR DESCRIPTION
Fixes https://github.com/openark/orchestrator/issues/1260

In MariaDB GTID, stopping and starting IO thread actually deletes relay logs. This is counter productive to our objective.

Specifically, in a situation where the primary is unreachable and where replicas are lagging, we want to restart IO thread to see if lag is actually caused by locked primary. If this results with losing relay logs, then we've lost data.

So, unfortunately we avoid this step in MariaDB GTID.

cc @pedroalb 