### PR TITLE
Adjust the discovery uri logging to show the full dsn used (less pass…

### DIFF
--- a/go/db/db.go
+++ b/go/db/db.go
@@ -18,7 +18,9 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -28,8 +30,11 @@ import (
 	"github.com/openark/orchestrator/go/config"
 )
 
+const dsnRegexp = `^([^:]+)(:.*)?(@(socket|tcp)\(.+\)/.*)$`
+
 var (
-	EmptyArgs []interface{}
+	EmptyArgs  []interface{}
+	ErrNoMatch = errors.New("no match")
 )
 
 var mysqlURI string
@@ -129,6 +134,42 @@ func isInMemorySQLite() bool {
 	return config.Config.IsSQLite() && strings.Contains(config.Config.SQLite3DataFile, ":memory:")
 }
 
+// matchDSN tries to match the DSN or returns an error
+func matchDSN(dsn string) (string, error) {
+	re := regexp.MustCompile(dsnRegexp)
+
+	matches := re.FindStringSubmatch(dsn)
+	if matches == nil {
+		return "", ErrNoMatch
+	}
+
+	// matching dsn so printout excluding the password
+	// - if no password is provided the lack of a password will be visible!
+	maskedPass := ""
+	if len(matches[2]) > 0 {
+		maskedPass = `:?`
+	}
+
+	return matches[1] + maskedPass + matches[3], nil
+}
+
+// safeMySQLURI returns a version of the dsn without showing the password so it can be logged safely.
+// - if we are unable to correctly match the provided dsn we build an incomplete one based on some of the settings.
+func safeMySQLURI(dsn string) string {
+	if safeDSN, err := matchDSN(dsn); err == nil {
+		return safeDSN
+	}
+
+	// Fallback to use an incomplete dsn which may be good enough.
+	// Do not show the password but do show what we connect to.
+	return fmt.Sprintf("%s:?@tcp(%s:%d)/%s?timeout=%ds (incomplete dsn!)",
+		config.Config.MySQLOrchestratorUser,
+		config.Config.MySQLOrchestratorHost,
+		config.Config.MySQLOrchestratorPort,
+		config.Config.MySQLOrchestratorDatabase,
+		config.Config.MySQLConnectTimeoutSeconds)
+}
+
 // OpenTopology returns the DB instance for the orchestrator backed database
 func OpenOrchestrator() (db *sql.DB, err error) {
 	var fromCache bool
@@ -149,12 +190,11 @@ func OpenOrchestrator() (db *sql.DB, err error) {
 				return db, log.Errore(err)
 			}
 		}
-		db, fromCache, err = sqlutils.GetDB(getMySQLURI())
+		dsn := getMySQLURI()
+		db, fromCache, err = sqlutils.GetDB(dsn)
 		if err == nil && !fromCache {
-			// do not show the password but do show what we connect to.
-			safeMySQLURI := fmt.Sprintf("%s:?@tcp(%s:%d)/%s?timeout=%ds", config.Config.MySQLOrchestratorUser,
-				config.Config.MySQLOrchestratorHost, config.Config.MySQLOrchestratorPort, config.Config.MySQLOrchestratorDatabase, config.Config.MySQLConnectTimeoutSeconds)
-			log.Debugf("Connected to orchestrator backend: %v", safeMySQLURI)
+			log.Debugf("Connected to orchestrator backend: %v", safeMySQLURI(dsn))
+
 			if config.Config.MySQLOrchestratorMaxPoolConnections > 0 {
 				log.Debugf("Orchestrator pool SetMaxOpenConns: %d", config.Config.MySQLOrchestratorMaxPoolConnections)
 				db.SetMaxOpenConns(config.Config.MySQLOrchestratorMaxPoolConnections)

--- a/go/db/db_test.go
+++ b/go/db/db_test.go
@@ -1,0 +1,32 @@
+package db
+
+import (
+	"testing"
+)
+
+// TestMatchDSN tests that the dsns we match don't expose the password
+func TestMatchDSN(t *testing.T) {
+	var tests = []struct {
+		dsn    string
+		output string
+		err    error
+	}{
+		{"user@tcp(host:3306)/", "user@tcp(host:3306)/", nil},
+		{"user:pass@tcp(host:3306)/", "user:?@tcp(host:3306)/", nil},
+		{"user@tcp(host:3306)/db", "user@tcp(host:3306)/db", nil},
+		{"user:pass@tcp(host:3306)/db", "user:?@tcp(host:3306)/db", nil},
+		{"user:pass@tcp(host:3306)/db?param1=true", "user:?@tcp(host:3306)/db?param1=true", nil},
+		{"user:pass@tcp(host:3306)/db?param1=true&param2=10", "user:?@tcp(host:3306)/db?param1=true&param2=10", nil},
+		// tricky ones
+		{"user:user:pass@tcp(host:3306)/db?param1=true&param2=10", "user:?@tcp(host:3306)/db?param1=true&param2=10", nil},
+		{"user:pass@pass@tcp(host:3306)/db?param1=true&param2=10", "user:?@tcp(host:3306)/db?param1=true&param2=10", nil},
+	}
+
+	for i := range tests {
+		match, err := matchDSN(tests[i].dsn)
+		if match != tests[i].output || err != tests[i].err {
+			t.Errorf("Failed to match %q: expected(%q,%v), got(%q,%v)",
+				tests[i].dsn, tests[i].output, tests[i].err, match, err)
+		}
+	}
+}


### PR DESCRIPTION
### Description

A few changes to show the full dsn used to talk to the MySQL driver. This helps debugging and what gets logged doesn't actually match what is passed to the driver which can be confusing.

Try to ensure that no passwords are logged, and if for some reason we can't match the dsn properly provide a _synthetic_ dsn to provide information about the values we are using instead.

There are some tests to see that in various cases the process works correctly.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code passes compilation
