### PR TITLE
Add .PutKVPairs() method to KVStore interface

### DIFF
--- a/go/kv/consul.go
+++ b/go/kv/consul.go
@@ -86,6 +86,18 @@ func (this *consulStore) GetKeyValue(key string) (value string, found bool, err 
 	return string(pair.Value), (pair != nil), nil
 }
 
+func (this *consulStore) PutKVPairs(kvPairs []*KVPair) (err error) {
+	if this.client == nil {
+		return nil
+	}
+	for _, pair := range kvPairs {
+		if err := this.PutKeyValue(pair.Key, pair.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (this *consulStore) DistributePairs(kvPairs [](*KVPair)) (err error) {
 	// This function is non re-entrant (it can only be running once at any point in time)
 	if atomic.CompareAndSwapInt64(&this.distributionReentry, 0, 1) {

--- a/go/kv/internal.go
+++ b/go/kv/internal.go
@@ -62,6 +62,15 @@ func (this *internalKVStore) GetKeyValue(key string) (value string, found bool, 
 	return value, found, log.Errore(err)
 }
 
+func (this *internalKVStore) PutKVPairs(kvPairs []*KVPair) (err error) {
+	for _, pair := range kvPairs {
+		if err := this.PutKeyValue(pair.Key, pair.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (this *internalKVStore) DistributePairs(kvPairs [](*KVPair)) (err error) {
 	return nil
 }

--- a/go/kv/kv.go
+++ b/go/kv/kv.go
@@ -36,6 +36,7 @@ func (this *KVPair) String() string {
 
 type KVStore interface {
 	PutKeyValue(key string, value string) (err error)
+	PutKVPairs(kvPairs []*KVPair) (err error)
 	GetKeyValue(key string) (value string, found bool, err error)
 	DistributePairs(kvPairs [](*KVPair)) (err error)
 }
@@ -89,6 +90,18 @@ func PutKVPair(kvPair *KVPair) (err error) {
 		return nil
 	}
 	return PutValue(kvPair.Key, kvPair.Value)
+}
+
+func PutKVPairs(kvPairs []*KVPair) (err error) {
+	if len(kvPairs) < 1 {
+		return nil
+	}
+	for _, store := range getKVStores() {
+		if err := store.PutKVPairs(kvPairs); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func DistributePairs(kvPairs [](*KVPair)) (err error) {

--- a/go/kv/kv.go
+++ b/go/kv/kv.go
@@ -85,13 +85,6 @@ func PutValue(key string, value string) (err error) {
 	return nil
 }
 
-func PutKVPair(kvPair *KVPair) (err error) {
-	if kvPair == nil {
-		return nil
-	}
-	return PutValue(kvPair.Key, kvPair.Value)
-}
-
 func PutKVPairs(kvPairs []*KVPair) (err error) {
 	if len(kvPairs) < 1 {
 		return nil

--- a/go/kv/zk.go
+++ b/go/kv/zk.go
@@ -75,6 +75,18 @@ func (this *zkStore) GetKeyValue(key string) (value string, found bool, err erro
 	return string(result), true, nil
 }
 
+func (this *zkStore) PutKVPairs(kvPairs []*KVPair) (err error) {
+	if this.zook == nil {
+		return nil
+	}
+	for _, pair := range kvPairs {
+		if err := this.PutKeyValue(pair.Key, pair.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (this *zkStore) DistributePairs(kvPairs [](*KVPair)) (err error) {
 	return nil
 }

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -256,11 +256,11 @@ func (applier *CommandApplier) enableGlobalRecoveries(value []byte) interface{} 
 }
 
 func (applier *CommandApplier) putKeyValue(value []byte) interface{} {
-	kvPair := kv.KVPair{}
-	if err := json.Unmarshal(value, &kvPair); err != nil {
+	kvPair := &kv.KVPair{}
+	if err := json.Unmarshal(value, kvPair); err != nil {
 		return log.Errore(err)
 	}
-	err := kv.PutKVPair(&kvPair)
+	err := kv.PutKVPairs([]*kv.KVPair{kvPair})
 	return err
 }
 

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -444,7 +444,7 @@ func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVP
 	log.Debugf("kv.SubmitMastersToKvStores: submitKvPairs: %+v", len(submitKvPairs))
 	if orcraft.IsRaftEnabled() {
 		for _, kvPair := range submitKvPairs {
-			_, err = orcraft.PublishCommand("put-key-value", kvPair)
+			_, err := orcraft.PublishCommand("put-key-value", kvPair)
 			if err == nil {
 				submittedCount++
 			} else {

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -442,23 +442,19 @@ func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVP
 		submitKvPairs = append(submitKvPairs, kvPair)
 	}
 	log.Debugf("kv.SubmitMastersToKvStores: submitKvPairs: %+v", len(submitKvPairs))
-	var kvPutKVPairs [](*kv.KVPair)
-	for _, kvPair := range submitKvPairs {
-		if orcraft.IsRaftEnabled() {
+	if orcraft.IsRaftEnabled() {
+		for _, kvPair := range submitKvPairs {
 			_, err = orcraft.PublishCommand("put-key-value", kvPair)
 			if err == nil {
 				submittedCount++
 			} else {
 				selectedError = err
 			}
-		} else {
-			kvPutKVPairs = append(kvPutKVPairs, kvPair)
 		}
-	}
-	if len(kvPutKVPairs) > 0 {
-		err := kv.PutKVPairs(kvPutKVPairs)
+	} else {
+		err := kv.PutKVPairs(submitKvPairs)
 		if err == nil {
-			submittedCount = submittedCount + len(kvPutKVPairs)
+			submittedCount += len(submitKvPairs)
 		} else {
 			selectedError = err
 		}

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -922,10 +922,8 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 			// of the put-key-value event upon startup. We _recommend_ a snapshot in the near future.
 			go orcraft.PublishCommand("async-snapshot", "")
 		} else {
-			for _, kvPair := range kvPairs {
-				err := kv.PutKVPair(kvPair)
-				log.Errore(err)
-			}
+			err := kv.PutKVPairs(kvPairs)
+			log.Errore(err)
 		}
 		{
 			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("Distributing KV %+v", kvPairs))


### PR DESCRIPTION
Related issue: https://github.com/openark/orchestrator/issues/1273


### Description

This PR adds the `.PutKVPairs()` function to the `KVStore` interface _(from `go/kv/kv.go`)_ to allow decisions around updating multiple KVs to be pushed down to the various KV store implementations. This new method replaces the single-KVPair method `.PutKVPair()` from `go/kv/kv.go`

The following files were updated to use `.PutKVPairs()` vs single-KVPair updates:
1. `go/logic/command_applier.go`
2. `go/logic/orchestrator.go`
3. `go/logic/topology_recovery.go`

For now the `.PutKVPairs()` function in each `KVStore` is just doing a plain-loop over `.PutKeyValue()`. In the near-future this method will be used to implement atomic multi-KVPair updates for the Consul KV store (https://github.com/openark/orchestrator/issues/1273) and potentially the Internal/ZooKeeper store, too

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->

cc @shlomi-noach 