### PR TITLE
Rudimentary version of "KVWipeValuesPreFailover" option

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -265,8 +265,9 @@ type Configuration struct {
 	ConsulScheme                               string            // Scheme (http or https) for Consul
 	ConsulAclToken                             string            // ACL token used to write to Consul KV
 	ConsulCrossDataCenterDistribution          bool              // should orchestrator automatically auto-deduce all consul DCs and write KVs in all DCs
-	ZkAddress                                  string            // UNSUPPERTED YET. Address where (single or multiple) ZooKeeper servers are found, in `srv1[:port1][,srv2[:port2]...]` format. Default port is 2181. Example: srv-a,srv-b:12181,srv-c
+	ZkAddress                                  string            // UNSUPPORTED YET. Address where (single or multiple) ZooKeeper servers are found, in `srv1[:port1][,srv2[:port2]...]` format. Default port is 2181. Example: srv-a,srv-b:12181,srv-c
 	KVClusterMasterPrefix                      string            // Prefix to use for clusters' masters entries in KV stores (internal, consul, ZK), default: "mysql/master"
+	KVWipeValuesPreFailover                    bool              // Wipe the master hostname/address at the beginning of a recovery (fencing)
 	WebMessage                                 string            // If provided, will be shown on all web pages below the title bar
 	MaxConcurrentReplicaOperations             int               // Maximum number of concurrent operations on replicas
 }
@@ -434,6 +435,7 @@ func newConfiguration() *Configuration {
 		ConsulCrossDataCenterDistribution:          false,
 		ZkAddress:                                  "",
 		KVClusterMasterPrefix:                      "mysql/master",
+		KVWipeValuesPreFailover:                    false,
 		WebMessage:                                 "",
 		MaxConcurrentReplicaOperations:             5,
 	}

--- a/go/inst/cluster.go
+++ b/go/inst/cluster.go
@@ -34,7 +34,7 @@ func getClusterMasterKVPair(clusterAlias string, masterKey *InstanceKey) *kv.KVP
 		return nil
 	}
 	if masterKey == nil {
-		return nil
+		return kv.NewKVPair(GetClusterMasterKVKey(clusterAlias), "")
 	}
 	return kv.NewKVPair(GetClusterMasterKVKey(clusterAlias), masterKey.StringCode())
 }
@@ -53,12 +53,20 @@ func GetClusterMasterKVPairs(clusterAlias string, masterKey *InstanceKey) (kvPai
 		kvPairs = append(kvPairs, kv.NewKVPair(key, value))
 	}
 
-	addPair("hostname", masterKey.Hostname)
-	addPair("port", fmt.Sprintf("%d", masterKey.Port))
-	if ipv4, ipv6, err := readHostnameIPs(masterKey.Hostname); err == nil {
-		addPair("ipv4", ipv4)
-		addPair("ipv6", ipv6)
+	if masterKey == nil {
+		addPair("hostname", "")
+		addPair("port", "")
+		addPair("ipv4", "")
+		addPair("ipv6", "")
+	} else {
+		addPair("hostname", masterKey.Hostname)
+		addPair("port", fmt.Sprintf("%d", masterKey.Port))
+		if ipv4, ipv6, err := readHostnameIPs(masterKey.Hostname); err == nil {
+			addPair("ipv4", ipv4)
+			addPair("ipv6", ipv6)
+		}
 	}
+
 	return kvPairs
 }
 


### PR DESCRIPTION
Related issue: https://github.com/openark/orchestrator/issues/1275

### Description

This is an entirely untested proposal to introduce an option called `KVWipeValuesPreFailover`. If enabled, the values in the KV store will be zeroed out at the beginning of the failover process, i.e. `mysql/master/$cluster/{hostname,port,ipv4,ipv6}` will all be set to `""` (empty string). The purpose of this is to allow immediate fencing of the mysql host that has failed, e.g. by reacting to it in consul-template ("if empty then remove from writer hostgroup" or "if empty then repoint to dead end").

The same can currently be achieved by running `consul kv put ...` in the `PreFailover...` hooks, but having it in Orchestrator seemed like a pretty good idea to me.

If this proposal is well-received, I'm happy to make any adjustments to the code that are necessary to make this a real thing.