### PR TITLE
Fixes #1279 

### DIFF
--- a/docs/ssl-and-tls.md
+++ b/docs/ssl-and-tls.md
@@ -3,7 +3,9 @@
 Orchestrator supports SSL/TLS for the web interface as HTTPS.  This can be standard server side certificates
 or you can configure Orchestrator to validate and filter client provided certificates with Mutual TLS.
 
-Orchestrator also allows for the use of certificates to authenticate with MySQL
+Orchestrator also allows for the use of certificates to authenticate with MySQL.
+
+If MySQL is using SSL encryption for replication, Orchestrator will attempt to configure replication with SSL during recovery.
 
 #### HTTPS for the Web/API interface
 You can set up SSL/TLS protection like so:
@@ -85,3 +87,8 @@ Similarly the connections to the topology databases can be encrypted with:
 
 In this case all of your topology servers must respond to the certificates provided.  There's no current
 method to have TLS enabled only for some servers.
+
+#### MySQL SSL Replication
+If Orchestrator is able to configure the failed Source to replicate to the newly promoted Source during recovery, it will attempt to configure `Master_SSL=1` if the newly promoted Source was configured that way.
+
+Orchestrator currently does not handle configuring Source SSL certificates for replication during recovery. 

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -2102,17 +2102,16 @@ func GracefulMasterTakeover(clusterName string, designatedKey *inst.InstanceKey,
 			err = credentialsErr
 		}
 	}
-	if auto {
-		_, startReplicationErr := inst.StartReplication(&clusterMaster.Key)
-		if err == nil {
-			err = startReplicationErr
-		}
-	}
-
 	if designatedInstance.AllowTLS {
 		_, enableSSLErr := inst.EnableMasterSSL(&clusterMaster.Key)
 		if err == nil {
 			err = enableSSLErr
+		}
+	}
+	if auto {
+		_, startReplicationErr := inst.StartReplication(&clusterMaster.Key)
+		if err == nil {
+			err = startReplicationErr
 		}
 	}
 	executeProcesses(config.Config.PostGracefulTakeoverProcesses, "PostGracefulTakeoverProcesses", topologyRecovery, false)


### PR DESCRIPTION
Related issue: https://github.com/openark/orchestrator/issues/1279

### Description

This moves the `EnableMasterSSL` function call prior to the starting of replication if `graceful-master-takeover-auto` is called.

Also, added some documentation on SSL replication.
