### PR TITLE
ConsulTxnStore: handle failure in read/get transaction

### DIFF
--- a/go/kv/consul_txn.go
+++ b/go/kv/consul_txn.go
@@ -71,13 +71,12 @@ func NewConsulTxnStore() KVStore {
 func (this *consulTxnStore) doWriteTxn(txnOps consulapi.TxnOps, queryOptions *consulapi.QueryOptions) (err error) {
 	ok, resp, _, err := this.client.Txn().Txn(txnOps, queryOptions)
 	if err != nil {
+		log.Errorf("consulTxnStore.doWriteTxn(): failed %v", err)
 		return err
 	} else if !ok {
-		// return the first transaction error found
-		for _, txnErr := range resp.Errors {
-			if txnErr.What != "" {
-				return fmt.Errorf("consul txn error: %v", txnErr.What)
-			}
+		for _, terr := range resp.Errors {
+			log.Errorf("consulTxnStore.doWriteTxn(): transaction error %v", terr.What)
+			err = fmt.Errorf("%v", terr.What)
 		}
 	}
 	return err

--- a/go/kv/consul_txn.go
+++ b/go/kv/consul_txn.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 Shlomi Noach, GitHub Inc.
+   Copyright 2021 Shlomi Noach, GitHub Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ func (this *consulTxnStore) updateDatacenterKVPairs(wg *sync.WaitGroup, dc strin
 	if len(getTxnOps) > 0 {
 		_, getTxnResp, _, terr = this.client.Txn().Txn(getTxnOps, queryOptions)
 		if terr != nil {
-			log.Errorf("consulTxnStore.DistributePairs(): get transaction failed %v", terr)
+			log.Errorf("consulTxnStore.DistributePairs(): %v", terr)
 			err = terr
 		}
 	}
@@ -124,11 +124,6 @@ func (this *consulTxnStore) updateDatacenterKVPairs(wg *sync.WaitGroup, dc strin
 	for _, pair := range possibleSetKVPairs {
 		var kvExistsAndEqual bool
 		if getTxnResp != nil {
-			for _, terr := range getTxnResp.Errors {
-				if !strings.HasSuffix(terr.What, "doesn't exist") {
-					log.Errorf("consulTxnStore.DistributePairs(): get transaction error %v", terr.What)
-				}
-			}
 			for _, result := range getTxnResp.Results {
 				if pair.Key == result.KV.Key && string(pair.Value) == string(result.KV.Value) {
 					this.kvCache.SetDefault(getConsulKVCacheKey(dc, pair.Key), string(pair.Value))

--- a/go/kv/consul_txn.go
+++ b/go/kv/consul_txn.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"sync/atomic"
 

--- a/go/kv/consul_txn_test.go
+++ b/go/kv/consul_txn_test.go
@@ -85,8 +85,8 @@ func TestConsulTxnStorePutKVPairs(t *testing.T) {
 		if err := store.PutKVPairs([]*KVPair{
 			{Key: "fail1", Value: "test"},
 			{Key: "fail2", Value: "test2"},
-		}); err == nil || err.Error() != "consul txn error: test error" {
-			t.Fatalf("Expected %q error from .PutKVPairs(), got: %q", "consul txn error: test error", err.Error())
+		}); err == nil || err.Error() != "test error" {
+			t.Fatalf("Expected %q error from .PutKVPairs(), got: %q", "test error", err.Error())
 		}
 	})
 }

--- a/go/kv/consul_txn_test.go
+++ b/go/kv/consul_txn_test.go
@@ -107,10 +107,10 @@ func TestConsulTxnStoreUpdateDatacenterKVPairs(t *testing.T) {
 			Response: &consulapi.TxnResponse{
 				Results: consulapi.TxnResults{
 					{
-						KV: &consulapi.KVPair{Key: "test", Value: []byte("test"), ModifyIndex: 123},
+						KV: &consulapi.KVPair{Key: "test", Value: []byte("test")},
 					},
 					{
-						KV: &consulapi.KVPair{Key: "test2", Value: []byte("not-equal"), ModifyIndex: 123},
+						KV: &consulapi.KVPair{Key: "test2", Value: []byte("not-equal")},
 					},
 				},
 			},

--- a/go/kv/consul_txn_test.go
+++ b/go/kv/consul_txn_test.go
@@ -98,19 +98,43 @@ func TestConsulTxnStoreUpdateDatacenterKVPairs(t *testing.T) {
 			URL:    "/v1/txn?dc=dc1",
 			Request: consulapi.TxnOps{
 				{
-					KV: &consulapi.KVTxnOp{Verb: consulapi.KVGet, Key: "test"}, // exists
+					KV: &consulapi.KVTxnOp{Verb: consulapi.KVGet, Key: "test"},
 				},
 				{
-					KV: &consulapi.KVTxnOp{Verb: consulapi.KVGet, Key: "test2"}, // does not exist
+					KV: &consulapi.KVTxnOp{Verb: consulapi.KVGet, Key: "test2"},
 				},
 			},
 			Response: &consulapi.TxnResponse{
 				Results: consulapi.TxnResults{
 					{
-						KV: &consulapi.KVPair{Key: "test", Value: []byte("test")},
+						KV: &consulapi.KVPair{Key: "test", Value: []byte("test"), ModifyIndex: 123},
+					},
+					{
+						KV: &consulapi.KVPair{Key: "test2", Value: []byte("not-equal"), ModifyIndex: 123},
 					},
 				},
 			},
+		},
+		{
+			Method: "PUT",
+			URL:    "/v1/txn?dc=dc1",
+			Request: consulapi.TxnOps{
+				{
+					KV: &consulapi.KVTxnOp{Verb: consulapi.KVGet, Key: "test"},
+				},
+				{
+					KV: &consulapi.KVTxnOp{Verb: consulapi.KVGet, Key: "doesnt-exist"},
+				},
+			},
+			Response: &consulapi.TxnResponse{
+				Errors: consulapi.TxnErrors{
+					{
+						OpIndex: 1,
+						What:    `key "doesnt-exist" doesn't exist`,
+					},
+				},
+			},
+			ResponseCode: http.StatusConflict, // PUT /v1/txn returns a HTTP 409 code on txn failure
 		},
 		{
 			Method: "PUT",
@@ -128,35 +152,78 @@ func TestConsulTxnStoreUpdateDatacenterKVPairs(t *testing.T) {
 				},
 			},
 		},
+		{
+			Method: "PUT",
+			URL:    "/v1/txn?dc=dc1",
+			Request: consulapi.TxnOps{
+				{
+					KV: &consulapi.KVTxnOp{Verb: consulapi.KVSet, Key: "test", Value: []byte("test")},
+				},
+				{
+					KV: &consulapi.KVTxnOp{Verb: consulapi.KVSet, Key: "doesnt-exist", Value: []byte("test")},
+				},
+			},
+			Response: &consulapi.TxnResponse{
+				Results: consulapi.TxnResults{
+					{
+						KV: &consulapi.KVPair{Key: "test", Value: []byte("test")},
+					},
+					{
+						KV: &consulapi.KVPair{Key: "doesnt-exist", Value: []byte("test")},
+					},
+				},
+			},
+		},
 	})
 	defer server.Close()
-	config.Config.ConsulAddress = server.URL
-
-	store := NewConsulTxnStore().(*consulTxnStore)
-	cacheKey := getConsulKVCacheKey(consulTestDefaultDatacenter, "cached")
-	store.kvCache.SetDefault(cacheKey, "cached") // pre-cache the 'cached' key-value
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	kvPairs := []*consulapi.KVPair{
-		{Key: "cached", Value: []byte("cached")}, // already cached key-value
-		{Key: "test", Value: []byte("test")},     // already correct on consul server
-		{Key: "test2", Value: []byte("test")},    // does not exist on consul server
-	}
-	skipped, existing, written, failed, err := store.updateDatacenterKVPairs(&wg, consulTestDefaultDatacenter, kvPairs)
-	if err != nil {
-		t.Fatalf(".updateDatacenterKVPairs() should not return an error, got: %v", err)
-	}
-	if skipped != 1 || existing != 1 || written != 1 || failed != 0 {
-		t.Fatalf("expected: existing/skipped/written=1 and failed=0, got: skipped=%d, existing=%d, written=%d, failed=%d",
-			skipped, existing, written, failed,
-		)
-	}
+	config.Config.ConsulAddress = server.URL
+	store := NewConsulTxnStore().(*consulTxnStore)
 
-	for _, pair := range kvPairs {
-		cacheKey := getConsulKVCacheKey(consulTestDefaultDatacenter, pair.Key)
-		if cached, found := store.kvCache.Get(cacheKey); !found || cached != string(pair.Value) {
-			t.Fatalf("expected cache key %q to equal %q, got %v", cacheKey, string(pair.Value), cached)
+	t.Run("success-cached", func(t *testing.T) {
+		wg.Add(1)
+		cacheKey := getConsulKVCacheKey(consulTestDefaultDatacenter, "cached")
+		store.kvCache.SetDefault(cacheKey, "cached") // pre-cache the 'cached' key-value
+		defer store.kvCache.Flush()
+
+		kvPairs := []*consulapi.KVPair{
+			{Key: "cached", Value: []byte("cached")}, // already cached key-value
+			{Key: "test", Value: []byte("test")},     // already correct on consul server
+			{Key: "test2", Value: []byte("test")},    // not equal on consul server
 		}
-	}
+		skipped, existing, written, failed, err := store.updateDatacenterKVPairs(&wg, consulTestDefaultDatacenter, kvPairs)
+		if err != nil {
+			t.Fatalf(".updateDatacenterKVPairs() should not return an error, got: %v", err)
+		}
+		if skipped != 1 || existing != 1 || written != 1 || failed != 0 {
+			t.Fatalf("expected: existing/skipped/written=1 and failed=0, got: skipped=%d, existing=%d, written=%d, failed=%d",
+				skipped, existing, written, failed,
+			)
+		}
+
+		for _, pair := range kvPairs {
+			cacheKey := getConsulKVCacheKey(consulTestDefaultDatacenter, pair.Key)
+			if cached, found := store.kvCache.Get(cacheKey); !found || cached != string(pair.Value) {
+				t.Fatalf("expected cache key %q to equal %q, got %v", cacheKey, string(pair.Value), cached)
+			}
+		}
+	})
+
+	t.Run("success-missing-kv", func(t *testing.T) {
+		wg.Add(1)
+		kvPairs := []*consulapi.KVPair{
+			{Key: "test", Value: []byte("test")},         // already correct on consul server
+			{Key: "doesnt-exist", Value: []byte("test")}, // does not exist on consul server
+		}
+		skipped, existing, written, failed, err := store.updateDatacenterKVPairs(&wg, consulTestDefaultDatacenter, kvPairs)
+		if err != nil {
+			t.Fatalf(".updateDatacenterKVPairs() should not return an error, got: %v", err)
+		}
+		if skipped != 0 || existing != 0 || written != 2 || failed != 0 { // confirm all KVs are updated if one does not exist
+			t.Fatalf("expected: existing/skipped/failed=0 and written=2, got: skipped=%d, existing=%d, written=%d, failed=%d",
+				skipped, existing, written, failed,
+			)
+		}
+	})
 }


### PR DESCRIPTION
<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/1300


### Description

This PR resolves a panic when the `ConsulTxnStore` returns a nil transaction response due to an error in the transaction

Following this PR errors in the read transaction (to check existing values) will be logged and will cause the store to perform an update of the keys in the read transaction, as we can't be sure they're consistent if there is a read transaction error

Lastly, this PR adds better unit testing for this issue. Fixes https://github.com/openark/orchestrator/issues/1300

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
