### PR TITLE
Do not restart SQL thread in RestartReplicationQuick

### DIFF
--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -250,7 +250,7 @@ func SetSemiSyncReplica(instanceKey *InstanceKey, enableReplica bool) (*Instance
 }
 
 func RestartReplicationQuick(instanceKey *InstanceKey) error {
-	for _, cmd := range []string{`stop slave sql_thread`, `stop slave io_thread`, `start slave io_thread`, `start slave sql_thread`} {
+	for _, cmd := range []string{`stop slave io_thread`, `start slave io_thread`} {
 		if _, err := ExecInstance(instanceKey, cmd); err != nil {
 			return log.Errorf("%+v: RestartReplicationQuick: '%q' failed: %+v", *instanceKey, cmd, err)
 		} else {


### PR DESCRIPTION
<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/1308


### Description

This PR  removes stop and start of SQL thread from RestartReplicationQuick function. 
This is done to fix the replication lag that could occur because of restart of SQL thread on the replicas as explained in the issue #1308. 

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
