### PR TITLE
If access to ORCHESTRATOR_API fails do not expose the password(s)

### DIFF
--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -212,10 +212,12 @@ function detect_leader_api {
   # - in which case we just normalize the URL
   # or it may be a space delimited list, such as "http://host1:3000/api http://host2:3000/api http://host3:3000/api "
   # - in which case we figure out which of the URLs is the leader
+  # Prevent leaking passwords if the URL has credentials like: http://<user>:<password>@host:3000/api
   local curl_auth_params="$(get_curl_auth_params)"
 
   if [ "${curl_auth_params}" == "$unauthorized_401" ] ; then
-    fail "Cannot access orchestrator at ${orchestrator_api}.  Check ORCHESTRATOR_API is configured correctly and orchestrator is running"
+    santised_api=$(echo "${orchestrator_api}" | sed -e 's|:[^:^@^ ]*@|:<REMOVED>@|g')
+    fail "Cannot access orchestrator at ${santised_api}.  Check ORCHESTRATOR_API is configured correctly and orchestrator is running"
   fi
 
   leader_api=


### PR DESCRIPTION
### Description

Recently seen:

```
orchestrator-client[10450]: Cannot access orchestrator at http://user:password@host.com/api.  Check ORCHESTRATOR_API is configured correctly and orchestrator is running
```

This exposes the password.

Change to:

```
orchestrator-client[10450]: Cannot access orchestrator at http://user:<REMOVED>@host.com/api.  Check ORCHESTRATOR_API is configured correctly and orchestrator is running
```
Also works if `ORCHESTRATOR_API` contains multiple hostnames.

- [x] contributed code is using same conventions as original code
