### PR TITLE
Fix misspelled word "woth" to "with"

### DIFF
--- a/resources/templates/layout.tmpl
+++ b/resources/templates/layout.tmpl
@@ -200,7 +200,7 @@
 						<button type="button" class="btn btn-danger" data-btn="skip-query" title="Skip a single query and resume replication">Skip query</button>
 						<button type="button" class="btn btn-warning" data-btn="set-read-only"><span class="glyphicon glyphicon-eye-open"></span> Set read-only</button>
 						<button type="button" class="btn btn-warning" data-btn="set-writeable"><span class="glyphicon glyphicon-pencil"></span> Set writeable</button>
-						<button type="button" class="btn btn-warning" data-btn="reattach-replica-master-host" title="Reattach woth detached master">
+						<button type="button" class="btn btn-warning" data-btn="reattach-replica-master-host" title="Reattach with detached master">
 							</span> Reattach</button>
 						<button type="button" class="btn btn-danger" data-btn="reset-replica" title="Make this replica forget its master and stop replicating">Reset replica</button>
 						<button type="button" class="btn btn-info" data-btn="take-siblings" title="Take siblings of this replica">Take siblings</button>


### PR DESCRIPTION
Hello!

While working on some replicas today I noticed this:
![image](https://user-images.githubusercontent.com/6295044/110859303-77a63600-8278-11eb-98b2-709b6efc5b2b.png)

This change fixes the "woth" to be "with"