### PR TITLE
Use RaftHttpTransport for reverse-proxy

### DIFF
--- a/go/http/raft_reverse_proxy.go
+++ b/go/http/raft_reverse_proxy.go
@@ -44,5 +44,10 @@ func raftReverseProxy(w http.ResponseWriter, r *http.Request, c martini.Context)
 		r.SetBasicAuth(config.Config.HTTPAuthUser, config.Config.HTTPAuthPassword)
 	}
 	proxy := httputil.NewSingleHostReverseProxy(url)
+	proxy.Transport, err = orcraft.GetRaftHttpTransport()
+	if err != nil {
+		log.Errore(err)
+		return
+	}
 	proxy.ServeHTTP(w, r)
 }


### PR DESCRIPTION
<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/1343


### Description

This PR introduces a `GetRaftHttpTransport` function in `orcraft` package that returns an `http.Transport` object that can be used for both raft Health Checks and raft reverse-proxy.
This function is used to set a correct HttpTransport for a raft reverse-proxy to make it SSL compatible.

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
