### PR TITLE
Remove resetting Auth credentials in reverse-proxy

### DIFF
--- a/go/http/raft_reverse_proxy.go
+++ b/go/http/raft_reverse_proxy.go
@@ -4,12 +4,10 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strings"
 
 	"github.com/openark/golib/log"
 
 	"github.com/go-martini/martini"
-	"github.com/openark/orchestrator/go/config"
 	"github.com/openark/orchestrator/go/raft"
 )
 
@@ -39,10 +37,6 @@ func raftReverseProxy(w http.ResponseWriter, r *http.Request, c martini.Context)
 		return
 	}
 	r.Header.Del("Accept-Encoding")
-	switch strings.ToLower(config.Config.AuthenticationMethod) {
-	case "basic", "multi":
-		r.SetBasicAuth(config.Config.HTTPAuthUser, config.Config.HTTPAuthPassword)
-	}
 	proxy := httputil.NewSingleHostReverseProxy(url)
 	proxy.Transport, err = orcraft.GetRaftHttpTransport()
 	if err != nil {


### PR DESCRIPTION
<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/979

### Description

This PR removes setting Auth credentials in reverse-proxy.
@andrein was right about the fact that lines
https://github.com/openark/orchestrator/blob/d536bc655f1dcff0a196b438709958e75bc292cf/go/http/raft_reverse_proxy.go#L42-L45
reset auth credentials for every request going through `reverse-proxy` and therefore provide this request read/write permissions even for a `readonly` user.

These lines are unnecessary, because there are 3 basic scenarios:
1. Username and password are incorrect, so an attempt to sent a request receives `401 Unauthorized`. In this case we shouldn't care about proxying, because it never reaches the proxy.
2. Leader and follower have different configuration. For example, a follower has `"AuthenticationMethod": "multi"` and a leader has `"AuthenticationMethod": "basic"`. But that isn't a proxy problem.
3. Leader and follower are configured correctly, so if Authorization in a request is good for a follower, it should be good for a leader when request is proxied to it. So it means there is no need to modify authorisation for a request.

### Testing
During the whole testing both servers had the following configuration:
```json
{
  "AuthenticationMethod": "multi",
  "HTTPAuthUser":         "dba_team",
  "HTTPAuthPassword":     "time_for_dinner"
}
```

**Before fix behaviour** (Orchestrator version built from the latest `master` state):
```bash
bash-4.2$ curl https://orch-leader:3000/api/forget-cluster/mysql-cluster -k -u readonly:123
{"Code":"ERROR","Message":"Unauthorized","Details":null}
bash-4.2$ curl https://orch-follower:3000/api/forget-cluster/mysql-cluster -k -u readonly:123
{"Code":"OK","Message":"Cluster forgotten: mysql-server-1:3306","Details":null}
```
Request to the leader is rejected, because it's executed as `readonly`, but the same request sent to the follower is accepted, because its user is implicitly changed to `dba_team` by reverse-proxy.

**After fix behaviour:**
```bash
bash-4.2$ curl -k https://orch-leader:3000/api/forget-cluster/mysql-cluster -u readonly:123
{"Code":"ERROR","Message":"Unauthorized","Details":null}
bash-4.2$ curl -k https://orch-follower:3000/api/forget-cluster/mysql-cluster -u readonly:123
{"Code":"ERROR","Message":"Unauthorized","Details":null}
```
Since credentials are not rewritten by reverse-proxy, both requests produce expected results.

To ensure that we didn't break actual functionality, let's execute a valid request through a follower:
```bash
bash-4.2$ curl -k https://orch-follower:3000/api/forget-cluster/mysql-cluster -u dba_team:time_for_dinner
{"Code":"OK","Message":"Cluster forgotten: mysql-server-1:3306","Details":null}
```
It shows that the request was relayed and executed successfully.

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
