### PR TITLE
Discovery timeouts, emergency read operations throttled by discovery timeouts

### DIFF
--- a/go/db/db.go
+++ b/go/db/db.go
@@ -17,6 +17,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -365,7 +366,7 @@ func execInternal(db *sql.DB, query string, args ...interface{}) (sql.Result, er
 	if err != nil {
 		return nil, err
 	}
-	res, err := sqlutils.ExecNoPrepare(db, query, args...)
+	res, err := sqlutils.ExecNoPrepare(context.Background(), db, query, args...)
 	return res, err
 }
 
@@ -380,7 +381,9 @@ func ExecOrchestrator(query string, args ...interface{}) (sql.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	res, err := sqlutils.ExecNoPrepare(db, query, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(config.Config.MySQLOrchestratorReadTimeoutSeconds)*time.Second)
+	defer cancel()
+	res, err := sqlutils.ExecNoPrepare(ctx, db, query, args...)
 	return res, err
 }
 

--- a/go/db/db.go
+++ b/go/db/db.go
@@ -382,8 +382,7 @@ func ExecOrchestrator(query string, args ...interface{}) (sql.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(config.Config.MySQLOrchestratorReadTimeoutSeconds)*time.Second)
-	defer cancel()
+	ctx := context.Background()
 	res, err := sqlutils.ExecNoPrepare(ctx, db, query, args...)
 	return res, err
 }

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -208,6 +208,7 @@ func (this *HttpAPI) Instance(params martini.Params, r render.Render, req *http.
 // AsyncDiscover issues an asynchronous read on an instance. This is
 // useful for bulk loads of a new set of instances and will not block
 // if the instance is slow to respond or not reachable.
+// It will also not block the raft queue in the event ocmmunication to discover instance hangs.
 func (this *HttpAPI) AsyncDiscover(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
@@ -218,7 +219,12 @@ func (this *HttpAPI) AsyncDiscover(params martini.Params, r render.Render, req *
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	go this.Discover(params, r, req, user)
+
+	if orcraft.IsRaftEnabled() {
+		orcraft.PublishCommand("async-discover", instanceKey)
+	} else {
+		go logic.DiscoverInstance(instanceKey)
+	}
 
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Asynchronous discovery initiated for Instance: %+v", instanceKey)})
 }

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -208,7 +208,7 @@ func (this *HttpAPI) Instance(params martini.Params, r render.Render, req *http.
 // AsyncDiscover issues an asynchronous read on an instance. This is
 // useful for bulk loads of a new set of instances and will not block
 // if the instance is slow to respond or not reachable.
-// It will also not block the raft queue in the event ocmmunication to discover instance hangs.
+// It will also not block the raft queue in the event communication to discover instance hangs.
 func (this *HttpAPI) AsyncDiscover(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -350,6 +350,10 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 	if err != nil {
 		goto Cleanup
 	}
+	if db.Stats().InUse >= config.MySQLTopologyMaxPoolConnections {
+		err = fmt.Errorf("Database connections exhausted for %v", *instanceKey)
+		goto Cleanup
+	}
 
 	instance.Key = *instanceKey
 

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -63,7 +63,9 @@ func ExecInstance(instanceKey *InstanceKey, query string, args ...interface{}) (
 	if err != nil {
 		return nil, err
 	}
-	return sqlutils.ExecNoPrepare(db, query, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(config.Config.MySQLTopologyReadTimeoutSeconds)*time.Second)
+	defer cancel()
+	return sqlutils.ExecNoPrepare(ctx, db, query, args...)
 }
 
 // ExecuteOnTopology will execute given function while maintaining concurrency limit

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -227,7 +227,7 @@ func getCountPendingRecoveries() int64 {
 func initializeTopologyRecoveryPostConfiguration() {
 	config.WaitForConfigurationToBeLoaded()
 
-	emergencyReadTopologyInstanceMap = cache.New(time.Second, time.Millisecond*250)
+	emergencyReadTopologyInstanceMap = cache.New(time.Duration(config.Config.MySQLDiscoveryReadTimeoutSeconds)*time.Second, time.Millisecond*500)
 	emergencyRestartReplicaTopologyInstanceMap = cache.New(time.Second*30, time.Second)
 	emergencyOperationGracefulPeriodMap = cache.New(time.Second*5, time.Millisecond*500)
 }

--- a/script/test-integration
+++ b/script/test-integration
@@ -7,7 +7,7 @@ setup_mysql() {
   if [ ! -f "dbdeployer" ] ; then
     return
   fi
-  ./dbdeployer deploy single "5.7.21" --sandbox-binary $PWD/sandbox/binary --sandbox-home $PWD/sandboxes --sandbox-directory orc-sandbox --port=3306
+  ./dbdeployer deploy single "5.7.26" --sandbox-binary $PWD/sandbox/binary --sandbox-home $PWD/sandboxes --sandbox-directory orc-sandbox --port=3306
   mkdir -p bin
   ln -s /go/src/github.com/openark/orchestrator/sandboxes/orc-sandbox/use bin/mysql
   chmod +x bin/mysql

--- a/tests/integration/orchestrator.conf.json
+++ b/tests/integration/orchestrator.conf.json
@@ -15,7 +15,7 @@
   "BackendDB": "backend-db-placeholder",
   "SQLite3DataFile": "sqlite-data-file-placeholder",
   "MySQLOrchestratorHost": "127.0.0.1",
-  "MySQLOrchestratorPort": 3306,
+  "MySQLOrchestratorPort": mysql-orchestrator-port-placeholder,
   "MySQLOrchestratorDatabase": "test",
   "MySQLOrchestratorCredentialsConfigFile": "/tmp/orchestrator-test-my.cnf",
   "MySQLOrchestratorSSLPrivateKeyFile": "",

--- a/vendor/github.com/openark/golib/sqlutils/sqlutils.go
+++ b/vendor/github.com/openark/golib/sqlutils/sqlutils.go
@@ -211,7 +211,7 @@ func GetSQLiteDB(dbFile string) (*sql.DB, bool, error) {
 func RowToArray(rows *sql.Rows, columns []string) []CellData {
 	buff := make([]interface{}, len(columns))
 	data := make([]CellData, len(columns))
-	for i, _ := range buff {
+	for i := range buff {
 		buff[i] = data[i].NullString()
 	}
 	rows.Scan(buff...)


### PR DESCRIPTION
Followup to an issue reported outside this repo.

Scenario:

- Instance becomes unavailable, and causing connections to hang
- `ReadTopologyInstanceBufferable` (the main discovery function) runs again and again, totaling 3 concurrent executions, exhausting the connection pool limit for this instance.
- any further queries, such as `api/discover/the-instance/3306` are blocked on this instance
- In a `orchestrator/raft` setup, someone calls `api/discover/the-instance/3306`
- Now the raft protocol is blocked 
- All further rat communications are blocked
- No failovers possible


### Description

Timeouts already configured at DSN level. We add: 

- Explicit `context.WithTimeout()` in `ReadTopologyInstanceBufferable`, now using `db.QueryRowContext()` and `sqlutils.QueryRowsMapContext()`
- in `topology_recovery.go`, `emergentlyReadTopologyInstance()` only runs at most 1 read (for a given instance) per `MySQLDiscoveryReadTimeoutSeconds`, to avoid further spamming the instance.

Expected result: worst case scenario an operation will hang up to `MySQLDiscoveryReadTimeoutSeconds` (configurable, default: `10`)
