### PR TITLE
explicitly load db drivers, before removing drivers from vendor package

### DIFF
--- a/go/cmd/orchestrator/main.go
+++ b/go/cmd/orchestrator/main.go
@@ -25,6 +25,9 @@ import (
 	"github.com/openark/orchestrator/go/app"
 	"github.com/openark/orchestrator/go/config"
 	"github.com/openark/orchestrator/go/inst"
+
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 var AppVersion, GitCommit string


### PR DESCRIPTION
`openark/golib` is to drop imports for `github.com/mattn/go-sqlite3` and `github.com/go-sql-driver/mysql` ; they are not directly used by `openark/golib` and they create overhead when importing `openark/golib`.

We therefore now explicitly load these two packages in `orchestrator`.