### PR TITLE
Ensure to start SQL thread on recovery emergency operation

### DIFF
--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -249,8 +249,17 @@ func SetSemiSyncReplica(instanceKey *InstanceKey, enableReplica bool) (*Instance
 	return ReadTopologyInstance(instanceKey)
 }
 
+func StartSQLThreadQuick(instanceKey *InstanceKey) error {
+	cmd := `start slave sql_thread`
+	if _, err := ExecInstance(instanceKey, cmd); err != nil {
+		return log.Errorf("%+v: StartSQLThreadQuickly: '%q' failed: %+v", *instanceKey, cmd, err)
+	}
+	log.Infof("%s on %+v as part of StartSQLThreadQuickly", cmd, *instanceKey)
+	return nil
+}
+
 func RestartReplicationQuick(instanceKey *InstanceKey) error {
-	for _, cmd := range []string{`stop slave io_thread`, `start slave io_thread`} {
+	for _, cmd := range []string{`stop slave io_thread`, `start slave io_thread`, `start slave sql_thread`} {
 		if _, err := ExecInstance(instanceKey, cmd); err != nil {
 			return log.Errorf("%+v: RestartReplicationQuick: '%q' failed: %+v", *instanceKey, cmd, err)
 		} else {

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1578,10 +1578,14 @@ func emergentlyRestartReplicationOnTopologyInstance(instanceKey *inst.InstanceKe
 			// with losing relay logs, then we've lost data.
 			// So, unfortunately we avoid this step in MariaDB GTID.
 			// See https://github.com/openark/orchestrator/issues/1260
+
+			// We will only start SQL thread
+			inst.StartSQLThreadQuick(instanceKey)
 			return
 		}
 
 		inst.RestartReplicationQuick(instanceKey)
+		inst.StartSQLThreadQuick(instanceKey)
 		inst.AuditOperation("emergently-restart-replication-topology-instance", instanceKey, string(analysisCode))
 	})
 }


### PR DESCRIPTION
### Description

In #1309 (see issue #1308) we removed `stop slave sql_thread` & `start slave sql_thread` , because the replica might be committing a large transaction, and that sequence of command could take long due to rollback and roll forward.

However, it still makes sense to run `start slave sql_thread` (and, regardless, even on MariaDB)
