### PR TITLE
ReasonableInstanceCheckSeconds

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -140,6 +140,7 @@ type Configuration struct {
 	DiscoverByShowSlaveHosts                   bool     // Attempt SHOW SLAVE HOSTS before PROCESSLIST
 	UseSuperReadOnly                           bool     // Should orchestrator super_read_only any time it sets read_only
 	InstancePollSeconds                        uint     // Number of seconds between instance reads
+	ReasonableInstanceCheckSeconds             uint     // Number of seconds an instance read is allowed to take before it is considered invalid, i.e. before LastCheckValid will be false
 	InstanceWriteBufferSize                    int      // Instance write buffer size (max number of instances to flush in one INSERT ODKU)
 	BufferInstanceWrites                       bool     // Set to 'true' for write-optimization on backend table (compromise: writes can be stale and overwrite non stale data)
 	InstanceFlushIntervalMilliseconds          int      // Max interval between instance write buffer flushes
@@ -320,6 +321,7 @@ func newConfiguration() *Configuration {
 		DefaultInstancePort:                        3306,
 		TLSCacheTTLFactor:                          100,
 		InstancePollSeconds:                        5,
+		ReasonableInstanceCheckSeconds:             1,
 		InstanceWriteBufferSize:                    100,
 		BufferInstanceWrites:                       false,
 		InstanceFlushIntervalMilliseconds:          100,

--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -228,5 +228,5 @@ func (this *ReplicationAnalysis) GetAnalysisInstanceType() AnalysisInstanceType 
 // ValidSecondsFromSeenToLastAttemptedCheck returns the maximum allowed elapsed time
 // between last_attempted_check to last_checked before we consider the instance as invalid.
 func ValidSecondsFromSeenToLastAttemptedCheck() uint {
-	return config.Config.InstancePollSeconds + 1
+	return config.Config.InstancePollSeconds + config.Config.ReasonableInstanceCheckSeconds
 }


### PR DESCRIPTION
Related issue: https://github.com/openark/orchestrator/issues/1367

This PR introduces a config option `ReasonableInstanceCheckSeconds` that allows configuring the time that Orchestrator allows for a check to take before considering an instanced failed (`LastCheckValid: false`). Currently this value is hardcoded as 1s.

More details in the issue.

