### PR TITLE
Allow semi-sync even if a replica's promotion rule is "must_not"

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -192,6 +192,7 @@ type Configuration struct {
 	DetectRegionQuery                          string            // Optional query (executed on topology instance) that returns the region of an instance. If provided, must return one row, one column. Overrides RegionPattern and useful for installments where Region cannot be inferred by hostname
 	DetectPhysicalEnvironmentQuery             string            // Optional query (executed on topology instance) that returns the physical environment of an instance. If provided, must return one row, one column. Overrides PhysicalEnvironmentPattern and useful for installments where env cannot be inferred by hostname
 	DetectSemiSyncEnforcedQuery                string            // Optional query (executed on topology instance) to determine whether semi-sync is fully enforced for master writes (async fallback is not allowed under any circumstance). If provided, must return one row, one column, value 0 or 1.
+	AllowSemiSyncForUnpromotableHosts          bool              // If true, enable semi-sync even if a replica's promotion rule is "must_not" (assuming that DetectSemiSyncEnforcedQuery returns 1 for the host)
 	SupportFuzzyPoolHostnames                  bool              // Should "submit-pool-instances" command be able to pass list of fuzzy instances (fuzzy means non-fqdn, but unique enough to recognize). Defaults 'true', implies more queries on backend db
 	InstancePoolExpiryMinutes                  uint              // Time after which entries in database_instance_pool are expired (resubmit via `submit-pool-instances`)
 	PromotionIgnoreHostnameFilters             []string          // Orchestrator will not promote replicas with hostname matching pattern (via -c recovery; for example, avoid promoting dev-dedicated machines)
@@ -370,6 +371,7 @@ func newConfiguration() *Configuration {
 		DetectDataCenterQuery:                      "",
 		DetectPhysicalEnvironmentQuery:             "",
 		DetectSemiSyncEnforcedQuery:                "",
+		AllowSemiSyncForUnpromotableHosts:          false,
 		SupportFuzzyPoolHostnames:                  true,
 		InstancePoolExpiryMinutes:                  60,
 		PromotionIgnoreHostnameFilters:             []string{},

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -457,8 +457,8 @@ func StartReplication(instanceKey *InstanceKey) (*Instance, error) {
 	// Note: We assume that replicas use 'skip-slave-start' so they won't
 	//       START SLAVE on their own upon restart.
 	if instance.SemiSyncEnforced {
-		// Send ACK only from promotable instances.
-		sendACK := instance.PromotionRule != MustNotPromoteRule
+		// Send ACK only from promotable instances (unless explicitly allowed)
+		sendACK := config.Config.AllowSemiSyncForUnpromotableHosts || instance.PromotionRule != MustNotPromoteRule
 		// Always disable master setting, in case we're converting a former master.
 		if err := EnableSemiSync(instanceKey, false, sendACK); err != nil {
 			return instance, log.Errore(err)
@@ -1091,8 +1091,8 @@ func SetReadOnly(instanceKey *InstanceKey, readOnly bool) (*Instance, error) {
 	// If async fallback is disallowed, we're responsible for flipping the master
 	// semi-sync switch ON before accepting writes. The setting is off by default.
 	if instance.SemiSyncEnforced && !readOnly {
-		// Send ACK only from promotable instances.
-		sendACK := instance.PromotionRule != MustNotPromoteRule
+		// Send ACK only from promotable instances (unless explicitly allowed)
+		sendACK := config.Config.AllowSemiSyncForUnpromotableHosts || instance.PromotionRule != MustNotPromoteRule
 		if err := EnableSemiSync(instanceKey, true, sendACK); err != nil {
 			return instance, log.Errore(err)
 		}
@@ -1115,8 +1115,8 @@ func SetReadOnly(instanceKey *InstanceKey, readOnly bool) (*Instance, error) {
 	// If we just went read-only, it's safe to flip the master semi-sync switch
 	// OFF, which is the default value so that replicas can make progress.
 	if instance.SemiSyncEnforced && readOnly {
-		// Send ACK only from promotable instances.
-		sendACK := instance.PromotionRule != MustNotPromoteRule
+		// Send ACK only from promotable instances (unless explicitly allowed)
+		sendACK := config.Config.AllowSemiSyncForUnpromotableHosts || instance.PromotionRule != MustNotPromoteRule
 		if err := EnableSemiSync(instanceKey, false, sendACK); err != nil {
 			return instance, log.Errore(err)
 		}


### PR DESCRIPTION
This PR resolves https://github.com/openark/orchestrator/issues/1369 by introducing a flag that allows enabling semi-sync on an unpromotable host.