### PR TITLE
Adding systemd open file limit

### DIFF
--- a/etc/systemd/orchestrator.service
+++ b/etc/systemd/orchestrator.service
@@ -9,6 +9,7 @@ WorkingDirectory=/usr/local/orchestrator
 ExecStart=/usr/local/orchestrator/orchestrator http
 EnvironmentFile=-/etc/sysconfig/orchestrator
 ExecReload=/bin/kill -HUP $MAINPID
+LimitNOFILE=16384
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Related issue: https://github.com/openark/orchestrator/issues/1236


### Description

To make the systemd unit file to be inline with [init.d ](https://github.com/openark/orchestrator/blob/master/etc/init.d/orchestrator.bash#L37) ulimit configuration. To avoid following error.

> socket: too many open files