### PR TITLE
Compatible with single primary replication group slave node query

### DIFF
--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -191,12 +191,12 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			) = master_instance.cluster_name
 		) AS is_cluster_master,
 		MIN(master_instance.gtid_mode) AS gtid_mode,
-		COUNT(replica_instance.server_id) AS count_replicas,
+		-- Consider GR group members as replicas
+		GREATEST(COUNT( replica_instance.server_id ), COUNT( member_instance.server_id ) ) AS count_replicas,
+		-- Consider GR group members as valid replicas
 		IFNULL(
-			SUM(
-				replica_instance.last_checked <= replica_instance.last_seen
-			),
-			0
+			SUM( replica_instance.last_checked <= replica_instance.last_seen ), 
+			SUM( member_instance.last_checked <= member_instance.last_seen )
 		) AS count_valid_replicas,
 		IFNULL(
 			SUM(
@@ -370,6 +370,14 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 				master_instance.hostname
 			) = replica_instance.master_host
 			AND master_instance.port = replica_instance.master_port
+			AND replica_instance.replication_group_name = ''
+		)
+		LEFT JOIN database_instance member_instance ON (
+			master_instance.replication_group_name = member_instance.replication_group_name 
+			AND master_instance.PORT = member_instance.PORT 
+			AND member_instance.replication_group_member_state = 'ONLINE' 
+			AND member_instance.last_seen >= member_instance.last_checked 
+			AND member_instance.replication_group_name != ''
 		)
 		LEFT JOIN database_instance_maintenance ON (
 			master_instance.hostname = database_instance_maintenance.hostname


### PR DESCRIPTION

### Description

This PR [briefly explain what is does]

When the bank-end architecture is in Replication Group mode, the values of the count_replicas and count_valid_replicas variables obtained by the function GetReplicationAnalysis are always 0. 
After modification, it is compatible with Replication Group mode, and normal members of the replication group are treated as counter_replicas and count_valid_replicas.


