### PR TITLE
Compatible with single primary replication group slave node query

### DIFF
--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -197,7 +197,7 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		IFNULL(
 			SUM( replica_instance.last_checked <= replica_instance.last_seen ), 
 			SUM( member_instance.last_checked <= member_instance.last_seen 
-				AND member_instance.replication_group_member_state = 'ONLINE')
+			AND member_instance.replication_group_member_state = 'ONLINE')
 		) AS count_valid_replicas,
 		IFNULL(
 			SUM(

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -205,7 +205,10 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 				AND replica_instance.slave_io_running != 0
 				AND replica_instance.slave_sql_running != 0
 			),
-			0
+			SUM( 
+				member_instance.last_checked <= member_instance.last_seen 
+				AND member_instance.replication_group_member_state = 'ONLINE'
+			)
 		) AS count_valid_replicating_replicas,
 		IFNULL(
 			SUM(


### PR DESCRIPTION

### Description

This PR [briefly explain what is does]

When the bank-end architecture is in Replication Group mode, the values of the count_replicas and count_valid_replicas and count_valid_replicating_replicas] variables obtained by the function GetReplicationAnalysis are always 0.
After modification, it is compatible with Replication Group mode, and normal members of the replication group are treated as counter_replicas and count_valid_replicas and count_valid_replicating_replicas
 