### PR TITLE
Compatible with single primary replication group slave node query

### DIFF
--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -192,7 +192,12 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		) AS is_cluster_master,
 		MIN(master_instance.gtid_mode) AS gtid_mode,
 		-- Consider GR group members as replicas
-		GREATEST(COUNT( replica_instance.server_id ), COUNT( member_instance.server_id ) ) AS count_replicas,
+		CASE 
+			WHEN COUNT( replica_instance.server_id ) > COUNT( member_instance.server_id ) THEN
+				COUNT( replica_instance.server_id ) 
+			ELSE 
+				COUNT( member_instance.server_id )
+			END AS count_replicas,
 		-- Consider GR group members as valid replicas
 		IFNULL(
 			SUM( replica_instance.last_checked <= replica_instance.last_seen ), 

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -197,7 +197,7 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		IFNULL(
 			SUM( replica_instance.last_checked <= replica_instance.last_seen ), 
 			SUM( member_instance.last_checked <= member_instance.last_seen 
-				AND member_instance.replication_group_member_state = 'ONLINE')
+			AND member_instance.replication_group_member_state = 'ONLINE')
 		) AS count_valid_replicas,
 		IFNULL(
 			SUM(

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -205,7 +205,10 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 				AND replica_instance.slave_io_running != 0
 				AND replica_instance.slave_sql_running != 0
 			),
-			0
+			SUM( 
+				member_instance.last_checked <= member_instance.last_seen 
+				AND member_instance.replication_group_member_state = 'ONLINE'
+			)
 		) AS count_valid_replicating_replicas,
 		IFNULL(
 			SUM(

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -227,8 +227,8 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 				), 
 				GROUP_CONCAT( 
 					concat( member_instance.Hostname, 
-					':', 
-					member_instance.PORT ) 
+							':', 
+							member_instance.PORT ) 
 				) 
 		) AS slave_hosts,
 		MIN(


### PR DESCRIPTION

### Description

This PR [briefly explain what is does]

When the bank-end architecture is single Primary Replication Group mode, the values of the count_replicas and count_valid_replicas and count_valid_replicating_replicas and slave_hosts variables obtained by the function GetReplicationAnalysis are always 0 or null.

After modification, it is compatible with single primary Replication Group mode, and normal members of the replication group are treated as counter_replicas and count_valid_replicas and count_valid_replicating_replicas and slave_hosts.

Please check again, thanks!
 