### PR TITLE
Expanded ReplicationAnalysis struct to support GR members info

### DIFF
--- a/go/inst/analysis.go
+++ b/go/inst/analysis.go
@@ -136,6 +136,9 @@ type ReplicationAnalysis struct {
 	ReplicationDepth                          uint
 	Replicas                                  InstanceKeyMap
 	SlaveHosts                                InstanceKeyMap // for backwards compatibility. Equals `Replicas`
+	CountReplicationGroupMembers              uint           // GR
+	CountValidReplicationGroupMembers         uint
+	ReplicationGroupMemberHosts               InstanceKeyMap
 	IsFailingToConnectToMaster                bool
 	Analysis                                  AnalysisCode
 	Description                               string


### PR DESCRIPTION
### Description

Obtain the Replication Group member information from the entry GetReplicationAnalysis, so that it is convenient to use this information to implement some logical judgments.

like this:
```go
// Group member is not reachable, has replicas, and none of its reachable replicas can replicate from it
if !a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
	a.Analysis = DeadReplicationGroupMemberWithReplicas
	a.Description = "Group member is unreachable and all its reachable replicas are not replicating"
}
```
