### PR TITLE
graceful-takeover-auto switchover failed. when i set true for PreventCrossDataCenterMasterFailover.

### DIFF
--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -2241,18 +2241,32 @@ func chooseCandidateReplica(replicas [](*Instance)) (candidateReplica *Instance,
 	priorityDataCenter, _ :=  getPriorityDataCenterForCandidate(replicas)
 
 
-	for _, replica := range replicas {
-		replica := replica
-		if isGenerallyValidAsCandidateReplica(replica) &&
-			!IsBannedFromBeingCandidateReplica(replica) &&
-			!IsSmallerMajorVersion(priorityMajorVersion, replica.MajorVersionString()) &&
-			!IsSmallerBinlogFormat(priorityBinlogFormat, replica.Binlog_format) &&
-			IsDataCenterCandiadateReplica(priorityDataCenter, replica) {
-			// this is the one
-			candidateReplica = replica
-			break
-		}
-	}
+	if config.Config.PreventCrossDataCenterMasterFailover {
+                for _, replica := range replicas {
+                        replica := replica
+                        if isGenerallyValidAsCandidateReplica(replica) &&
+                                !IsBannedFromBeingCandidateReplica(replica) &&
+                                !IsSmallerMajorVersion(priorityMajorVersion, replica.MajorVersionString()) &&
+                                !IsSmallerBinlogFormat(priorityBinlogFormat, replica.Binlog_format) &&
+                                IsDataCenterCandiadateReplica(priorityDataCenter, replica) {
+                                // this is the one
+                                candidateReplica = replica
+                                break
+                        }
+                }
+        } else {
+                for _, replica := range replicas {
+                        replica := replica
+                        if isGenerallyValidAsCandidateReplica(replica) &&
+                                !IsBannedFromBeingCandidateReplica(replica) &&
+                                !IsSmallerMajorVersion(priorityMajorVersion, replica.MajorVersionString()) &&
+                                !IsSmallerBinlogFormat(priorityBinlogFormat, replica.Binlog_format) {
+                                // this is the one
+                                candidateReplica = replica
+                                break
+                        }
+                }
+        }
 	if candidateReplica == nil {
 		// Unable to find a candidate that will master others.
 		// Instead, pick a (single) replica which is not banned.

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -2202,6 +2202,8 @@ func getPriorityBinlogFormatForCandidate(replicas [](*Instance)) (priorityBinlog
 	return sorted.First(), nil
 }
 
+// getPriorityDataCenterForCandidate returns the replica datacenter found
+// among given instances. This will be used for choosing best candidate for promotion.
 func getPriorityDataCenterForCandidate(replicas [](*Instance)) (priorityDataCenter string, err error) {
 	if len(replicas) == 0 {
                 return "", log.Errorf("empty replicas list in getPriorityBinlogFormatForCandidate")
@@ -2214,7 +2216,8 @@ func getPriorityDataCenterForCandidate(replicas [](*Instance)) (priorityDataCent
 	return "", nil
 }
 
-
+// IsDataCenterCandiadateReplica compare master's datacenter and replica datacenter.
+// if master's datacenter eq replica datacenter return true
 func IsDataCenterCandiadateReplica(priorityDataCenter string, replica *Instance) bool {
 	masterOfDesignatedInstance, _ := GetInstanceMaster(replica)
 	if masterOfDesignatedInstance.DataCenter == priorityDataCenter {
@@ -2234,7 +2237,10 @@ func chooseCandidateReplica(replicas [](*Instance)) (candidateReplica *Instance,
 	}
 	priorityMajorVersion, _ := getPriorityMajorVersionForCandidate(replicas)
 	priorityBinlogFormat, _ := getPriorityBinlogFormatForCandidate(replicas)
+	// priorityDataCenter return boll for candidate
 	priorityDataCenter, _ :=  getPriorityDataCenterForCandidate(replicas)
+
+
 	for _, replica := range replicas {
 		replica := replica
 		if isGenerallyValidAsCandidateReplica(replica) &&

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -2202,12 +2202,12 @@ func getPriorityBinlogFormatForCandidate(replicas [](*Instance)) (priorityBinlog
 	return sorted.First(), nil
 }
 
-func getPriorityDataCenterForCandidate(replica [](*Instance)) (priorityDataCenter string, err error) {
+func getPriorityDataCenterForCandidate(replicas [](*Instance)) (priorityDataCenter string, err error) {
 	if len(replicas) == 0 {
                 return "", log.Errorf("empty replicas list in getPriorityBinlogFormatForCandidate")
 	}
 	candidate := ""
-	for _, replica := range {
+	for _, replica := range replicas {
 		candidate = replica.DataCenter
 		return candidate, nil
 	}


### PR DESCRIPTION
I don't know if this is a bug. When I use one master and two slave architecture and set true for PreventCrossDataCenterMasterFailover, the instance selected for automatic switching is always the instance of another machine room, resulting in the failure of the whole switching

from orchestrator base version: 3.2.4

my architecture:
```bash
db.045.stg
+db.046.stg
+db.047.stg
```
When I use PreventCrossDataCenterMasterFailover set true, and DetectDataCenterQuery is :
```sql
select dc_vaild from meta.cluster where id = 1
```
Main configuration:
```bash
PreventCrossDataCenterMasterFailover: true
DataCenterPattern: ""
```
I issue this command:
```bash
orchestrator-client -c graceful-master-takeover-auto -alias test
```
return error:
```bash
PreventCrossRegionMasterFailover: will not promote server in Y when failed server in N
```
Status after switching:
```bash
db.045.stg
  +db.046.stg
    +db.047.stg
```
I Debug code, find this code and i fell this logic unreasonable:
function calls:
```bash
getGracefulMasterTakeoverDesignatedInstance->GetCandidateReplica->chooseCandidateReplica.
```
This result is caused by the error of the promotion instance returned here:
```
func chooseCandidateReplica(...) {
...golang
for _, replica := range replicas {
		replica := replica
		if isGenerallyValidAsCandidateReplica(replica) &&
			!IsBannedFromBeingCandidateReplica(replica) &&
			!IsSmallerMajorVersion(priorityMajorVersion, replica.MajorVersionString()) &&
			!IsSmallerBinlogFormat(priorityBinlogFormat, replica.Binlog_format) {
                        #######################################################
                        // Here should be added to the judgment of the data center
			// this is the one
			candidateReplica = replica
			break
		}
	}
...
}
```
And I have added judgment on the data center, so that I can switch in the test environment.

I think the automatic selection of instances should follow the configuration of the configuration file, otherwise the configuration will be meaningless.

Thanks!