### PR TITLE
Update orchestrator-client to append headers_auth

### DIFF
--- a/resources/bin/orchestrator-client
+++ b/resources/bin/orchestrator-client
@@ -158,7 +158,7 @@ function get_curl_auth_params {
   fi
 
   if [[ -n "${headers_auth}" ]]; then
-    requires_auth="-H "${headers_auth}""
+    requires_auth+=" -H "${headers_auth}""
   fi
 
   # Test API access


### PR DESCRIPTION
Related issue: https://github.com/openark/orchestrator/issues/1412

### Description

Currently if `$headers_auth` is set, it will replace any previous settings in `$requires_auth`. This change updates the script to append `$headers_auth` to `$requires_auth` instead of replace.
