### PR TITLE
MySQL Orchestrator does not support new semi-sync variables introduced in MySQL 8.0.26

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -75,6 +75,8 @@ var apiSynonyms = map[string]string{
 	"stop-slave-nice":            "stop-replica-nice",
 	"reset-slave":                "reset-replica",
 	"restart-slave-statements":   "restart-replica-statements",
+	"enable-semi-sync-master":    "enable-semi-sync-source",
+	"disable-semi-sync-master":   "disable-semi-sync-source",
 }
 
 var registeredPaths = []string{}

--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -95,6 +95,8 @@ type Instance struct {
 	ReplicationCredentialsAvailable   bool
 	SemiSyncAvailable                 bool // when both semi sync plugins (master & replica) are loaded
 	SemiSyncPriority                  uint // higher value means higher priority, zero means async replica
+	SemiSyncMasterPluginNewVersion    bool // true for the plugin introduced with MySql 8.0.26
+	SemiSyncReplicaPluginNewVersion   bool // true for the plugin introduced with MySql 8.0.26
 	SemiSyncMasterEnabled             bool
 	SemiSyncReplicaEnabled            bool
 	SemiSyncMasterTimeout             uint64

--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -223,7 +223,11 @@ func SetSemiSyncMaster(instanceKey *InstanceKey, enableMaster bool) (*Instance, 
 	if err != nil {
 		return instance, err
 	}
-	if _, err := ExecInstance(instanceKey, "set @@global.rpl_semi_sync_master_enabled=?", enableMaster); err != nil {
+	query := "set @@global.rpl_semi_sync_master_enabled=?"
+	if instance.SemiSyncMasterPluginNewVersion {
+		query = "set @@global.rpl_semi_sync_source_enabled=?"
+	}
+	if _, err := ExecInstance(instanceKey, query, enableMaster); err != nil {
 		return instance, log.Errore(err)
 	}
 	return ReadTopologyInstance(instanceKey)
@@ -237,7 +241,13 @@ func SetSemiSyncReplica(instanceKey *InstanceKey, enableReplica bool) (*Instance
 	if instance.SemiSyncReplicaEnabled == enableReplica {
 		return instance, nil
 	}
-	if _, err := ExecInstance(instanceKey, "set @@global.rpl_semi_sync_slave_enabled=?", enableReplica); err != nil {
+
+	query := "set @@global.rpl_semi_sync_slave_enabled=?"
+	if instance.SemiSyncReplicaPluginNewVersion {
+		query = "set @@global.rpl_semi_sync_replica_enabled=?"
+	}
+
+	if _, err := ExecInstance(instanceKey, query, enableReplica); err != nil {
 		return instance, log.Errore(err)
 	}
 	if instance.ReplicationIOThreadRuning {

--- a/tests/system/semi-sync/01-semi-sync-all/expect_output
+++ b/tests/system/semi-sync/01-semi-sync-all/expect_output
@@ -1,0 +1,4 @@
+127.0.0.1:10111   [0s,ok,VERSION,rw,ROW,>>,GTID,semi:master]
++ 127.0.0.1:10112 [0s,ok,VERSION,ro,ROW,>>,GTID,semi:replica]
++ 127.0.0.1:10113 [0s,ok,VERSION,ro,ROW,>>,GTID,semi:replica]
++ 127.0.0.1:10114 [0s,ok,VERSION,ro,ROW,>>,GTID,semi:replica]

--- a/tests/system/semi-sync/01-semi-sync-all/run
+++ b/tests/system/semi-sync/01-semi-sync-all/run
@@ -1,0 +1,2 @@
+# sed is to get rid of MySql version from the output
+orchestrator-client -c topology -i 127.0.0.1:10111 | sed -n "s/\(^.*0s,ok,\)\s*\S*\(,r.,.*$\)/\1VERSION\2/p"

--- a/tests/system/semi-sync/01-semi-sync-all/setup
+++ b/tests/system/semi-sync/01-semi-sync-all/setup
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+orchestrator-client -c enable-semi-sync-master -i 127.0.0.1:10111
+orchestrator-client -c enable-semi-sync-replica -i 127.0.0.1:10112
+orchestrator-client -c enable-semi-sync-replica -i 127.0.0.1:10113
+orchestrator-client -c enable-semi-sync-replica -i 127.0.0.1:10114
+sleep 10

--- a/tests/system/semi-sync/teardown
+++ b/tests/system/semi-sync/teardown
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+orchestrator-client -c all-instances | while read i ; do
+  orchestrator-client -c disable-semi-sync-master -i $i
+  orchestrator-client -c disable-semi-sync-replica -i $i
+done
+
+sleep 5


### PR DESCRIPTION
Problem:
MySql 8.0.26 introduced new semisync replication plugins
semisync_source.so and semisync_replica.so
in place of
semisync_master.so and semisync_slave.so
All semisync replication plugins' variables were renamed in the way
that 'master' was replaced with the term 'source' and 'slave' was
replaced by 'replica'.

As 8.0.26 contains also old plugins and when they are installed
everything works fine it is not enough to detect server version.
Moreover, it is possible to mix old source plugin with new replica
plugin and the opposite.

Solution:
Detect which plugins are installed and use proper variable names.

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
