### PR TITLE
Orchestrator analysis-locked-hypothesis test is unstable

### DIFF
--- a/tests/system/analysis-locked-semi-sync-master/01-analysis-locked-hypothesis/setup
+++ b/tests/system/analysis-locked-semi-sync-master/01-analysis-locked-hypothesis/setup
@@ -10,4 +10,4 @@ orchestrator-client -c enable-semi-sync-replica -i 127.0.0.1:10112
 sleep 2
 
 orchestrator-client -c disable-semi-sync-replica -i 127.0.0.1:10112
-sleep 2
+sleep 7


### PR DESCRIPTION
https://github.com/openark/orchestrator/issues/1464

Problem:
analysis-locked-hypothesis test is unstable

Cause:
By default instance is polled every 5 seconds, but we wait only for 2 seconds, so it may happen that instance is not polled before we get the analysis result.

Solution:
Wait for 7 seconds after disabling instance. It is 7 because it has to be > 5 but LockedSemiSyncMasterHypothesis is reported only within 6 secs window (InstancePollSeconds + ReasonableInstanceCheckSeconds), then it switches to LockedSemiSyncMaster status.

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
