### PR TITLE
Improve logging of problems during db connection

### DIFF
--- a/go/raft/rel_store.go
+++ b/go/raft/rel_store.go
@@ -75,7 +75,7 @@ func (relStore *RelationalStore) openDB() (*sql.DB, error) {
 
 	if relStore.backend == nil {
 		relStoreFile := filepath.Join(relStore.dataDir, raftStoreFile)
-		sqliteDB, _, err := sqlutils.GetSQLiteDB(relStoreFile)
+		sqliteDB, _, err := sqlutils.GetSQLiteDB(relStoreFile, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Problem:
Some error logs indicate only the error returned by the server without the information about the server identity itself.
On the other hand there are also logs which display the server identity together with the returned error.

Cause:
There is an utility layer implemented by golib/sqlutils which intercepts database queries. Some queries done by orchestrator go through this layer and some don't.
sqlutils layer in case of query error prints out the query to the stdout

Solution:
golib/sqlutils layer is not aware of the server identity it operates on. It proxies creation of sql.DB object and then uses this object for queries execution.

Logger interface has been introduced. golib/sqlutils client can register its own logger which will be used instead of internal logging when the error occurs during usage of the related sql.DB object.

# I am taking time off from maintaining this repo. I will not be reviewing pull requests.
# Details in https://code.openark.org/blog/mysql/reducing-my-oss-involvement-and-how-it-affects-orchestrator-gh-ost

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
