### PR TITLE
Update README to explicitly state MariaDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![Orchestrator logo](https://github.com/openark/orchestrator/raw/master/docs/images/orchestrator-logo-wide.png)
 
-`orchestrator` is a MySQL high availability and replication management tool, runs as a service and provides command line access, HTTP API and Web interface. `orchestrator` supports:
+`orchestrator` is a MySQL and MariaDB high availability and replication management tool, runs as a service and provides command line access, HTTP API and Web interface. `orchestrator` supports:
 
 #### Discovery
 


### PR DESCRIPTION

### Description

While Orchestrator supports both MySQL and MariaDB for high availability and replication management, the main README file did not clearly mention MariaDB support. As a first-time user trying to explore Orchestrator, it was unclear whether MariaDB was supported or not.  It would be great to list the supported database engines in the main README file.

This pull request makes a small change to the README to explicitly state that Orchestrator is compatible with both MySQL and MariaDB databases.

Reference: The MariaDB documentation for using Orchestrator with MariaDB (https://mariadb.com/kb/en/orchestrator-overview/).